### PR TITLE
fix(security): Port 9091 GuildScout Alerts auf 0.0.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 | Discord Bot | — | — | Gateway-Connection (DEV + ZERODOX Server) |
 | Health Check + Changelog API | 8766 | 0.0.0.0 | Health, REST API, RSS Feed, Sitemap (UFW: nur Docker 172.16.0.0/12) |
 | GitHub Webhook | 9090 | 0.0.0.0 | Push/PR Events (Traefik) |
-| GuildScout Alerts | 9091 | 127.0.0.1 | Alert Forwarding |
+| GuildScout Alerts | 9091 | 0.0.0.0 | Alert Forwarding (UFW: nur Docker 172.16.0.0/12) |
 
 ## Befehle
 | Aktion | Befehl |

--- a/src/integrations/guildscout_alerts.py
+++ b/src/integrations/guildscout_alerts.py
@@ -81,8 +81,10 @@ class GuildScoutAlertsHandler:
 
         self.runner = web.AppRunner(self.app)
         await self.runner.setup()
+        # WICHTIG: 0.0.0.0 weil Docker-Container den Host über 172.17.0.1 erreichen
+        # Absicherung über UFW (nur 172.16.0.0/12) + HMAC-Signaturen
         self.site = web.TCPSite(
-            self.runner, '127.0.0.1', self.webhook_port,
+            self.runner, '0.0.0.0', self.webhook_port,
             reuse_address=True, reuse_port=True
         )
         await self.site.start()


### PR DESCRIPTION
## Summary
- **Finding #159** [MEDIUM]: GuildScout Alerts Webhook-Server bindet auf `127.0.0.1:9091` statt `0.0.0.0:9091`. Docker-Container (GuildScout API) erreichen den Host über `172.17.0.1` (Docker-Bridge) — bei `127.0.0.1`-Binding kommt "connection refused".

## Kontext
- Ports 8766 und 9090 binden korrekt auf `0.0.0.0`
- Nur Port 9091 wurde versehentlich auf `127.0.0.1` geändert
- **Vorfall 2026-03-17:** Identischer Fehler verursachte 11h Bot-Ausfall
- Absicherung: UFW (nur `172.16.0.0/12` erlaubt) + HMAC-Signaturen

## Änderungen
- `src/integrations/guildscout_alerts.py`: Bind-Adresse `127.0.0.1` → `0.0.0.0`
- `CLAUDE.md`: Port-Dokumentation aktualisiert

## Test plan
- [ ] Bot neustarten nach Merge
- [ ] `ss -tlnp | grep 9091` → sollte `0.0.0.0:9091` zeigen
- [ ] GuildScout Alert-Delivery testen (POST auf 172.17.0.1:9091/guildscout-alerts)

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)