### PR TITLE
fix: Bind-Address-Angaben in AI-Prompts korrigiert

### DIFF
--- a/src/integrations/analyst/prompts.py
+++ b/src/integrations/analyst/prompts.py
@@ -62,10 +62,10 @@ Untersuche den Server systematisch. Nutze Shell-Befehle:
 
 Port-Bindings bei ShadowOps-Servern:
 - Port 8766 (Health) auf 0.0.0.0 — KORREKT (UFW: nur Docker 172.16.0.0/12). Vorfall 2026-03-17: Aenderung auf 127.0.0.1 verursachte 11h Ausfall.
-- Port 9091 (GuildScout Alerts) auf 127.0.0.1 — KORREKT, nur intern.
+- Port 9091 (GuildScout Alerts) auf 0.0.0.0 — KORREKT (UFW: nur Docker 172.16.0.0/12, wie 8766). Docker-Container erreichen Host ueber 172.17.0.1.
 - Port 9090 (GitHub Webhook) auf 0.0.0.0 — GEWOLLT (Traefik).
 - Docker-Container erreichen den Host ueber die Docker-Bridge (172.17.0.1).
-- NICHT als Finding melden wenn 8766/9090 auf 0.0.0.0 binden.
+- NICHT als Finding melden wenn 8766/9090/9091 auf 0.0.0.0 binden.
 
 ## Ausgabe-Schema
 

--- a/src/integrations/security_engine/prompts.py
+++ b/src/integrations/security_engine/prompts.py
@@ -100,7 +100,7 @@ zerodox-web (3000 intern), zerodox-db (5434)
 
 - Port 8766 (Health) auf 0.0.0.0 — KORREKT (UFW: nur Docker 172.16.0.0/12)
 - Port 9090 (GitHub Webhook) auf 0.0.0.0 — GEWOLLT (Traefik)
-- Port 9091 (Alerts) auf 127.0.0.1 — KORREKT
+- Port 9091 (Alerts) auf 0.0.0.0 — KORREKT (UFW: nur Docker 172.16.0.0/12, wie 8766)
 - Docker-Container erreichen Host ueber 172.17.0.1 (Docker-Bridge)
 
 ## Ausgabe-Schema


### PR DESCRIPTION
## Summary
- Port 9091 (GuildScout Alerts) war in beiden Prompt-Dateien als `127.0.0.1` dokumentiert
- Tatsächlich läuft er auf `0.0.0.0` (wie 8766 und 9090) — Docker-Container brauchen das für 172.17.0.1 Bridge-Zugriff
- Beide Prompts (security_engine + analyst) korrigiert und konsistent gemacht
- Hinweis auf UFW-Schutz ergänzt

## Security Finding
- **#200**: Contradictory bind address documentation (MEDIUM)

## Test plan
- [ ] `ss -tlnp | grep 9091` bestätigt 0.0.0.0 Binding
- [ ] Security-Scan startet weiterhin ohne Fehlalarme zu Port 9091

🤖 Generated with [Claude Code](https://claude.com/claude-code)