### PR TITLE
Security: Traefik v3 HIGH CVEs (Go stdlib) & Upgrade Path Refactoring

### DIFF
--- a/config/safe_upgrades.yaml
+++ b/config/safe_upgrades.yaml
@@ -124,6 +124,20 @@ nginx:
     notes: "Multiple versions behind, upgrade recommended"
     risk: medium
 
+traefik:
+  "3.0":
+    next: "3.3"
+    notes: "Security Update: Mitigates HIGH severity CVEs in Go stdlib. Rebuild/Restart required."
+    risk: critical
+    migration_url: "https://doc.traefik.io/traefik/release-notes/"
+    breaking_changes:
+      - "Verify dynamic configuration and certificates after restart"
+      - "Downtime for all external services during restart"
+  "v3":
+    next: "v3"
+    notes: "Security Update: Always pull latest patch release to mitigate Go stdlib CVEs."
+    risk: critical
+
 apache:
   "2.4":
     next: "2.4"

--- a/src/integrations/docker_image_analyzer.py
+++ b/src/integrations/docker_image_analyzer.py
@@ -7,6 +7,7 @@ import logging
 import re
 import os
 import json
+import yaml
 import subprocess
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -230,66 +231,39 @@ class DockerImageAnalyzer:
         Returns:
             Dict with upgrade info or None if not recommended
         """
-        # Known safe upgrade paths with migration notes
-        safe_upgrades = {
-            'postgres': {
-                '15': {
-                    'next': '16',
-                    'notes': 'Requires pg_upgrade or dump/restore. Breaking changes: logical replication changes, new pg_hba.conf defaults',
-                    'risk': 'medium',
-                    'migration_url': 'https://www.postgresql.org/docs/16/release-16.html'
-                },
-                '14': {
-                    'next': '15',
-                    'notes': 'Minor breaking changes in config. Check SECURITY INVOKER views',
-                    'risk': 'low',
-                    'migration_url': 'https://www.postgresql.org/docs/15/release-15.html'
-                },
-                '13': {
-                    'next': '14',
-                    'notes': 'Mostly compatible. Check server encoding changes',
-                    'risk': 'low',
-                    'migration_url': 'https://www.postgresql.org/docs/14/release-14.html'
-                },
-            },
-            'redis': {
-                '7': {
-                    'next': '8',
-                    'notes': 'NOT YET RELEASED - Monitor redis.io for Redis 8.0',
-                    'risk': 'unknown',
-                    'migration_url': 'https://redis.io/'
-                },
-                '6': {
-                    'next': '7',
-                    'notes': 'Check for deprecated commands. Review ACL changes. Functions vs EVAL changes',
-                    'risk': 'medium',
-                    'migration_url': 'https://redis.io/docs/about/releases/'
-                },
-            },
-            'mysql': {
-                '8.0': {
-                    'next': '8.4',
-                    'notes': 'LTS upgrade. Check authentication plugin changes',
-                    'risk': 'low',
-                    'migration_url': 'https://dev.mysql.com/doc/relnotes/mysql/8.4/en/'
-                },
-            },
-            'nginx': {
-                '1.24': {
-                    'next': '1.26',
-                    'notes': 'Stable to stable upgrade. Review new directives',
-                    'risk': 'low',
-                    'migration_url': 'https://nginx.org/en/CHANGES'
-                },
-            },
-        }
+        # Load safe upgrade paths from YAML config
+        config_path = os.path.join(os.getcwd(), 'config', 'safe_upgrades.yaml')
+        safe_upgrades = {}
+
+        if os.path.exists(config_path):
+            try:
+                with open(config_path, 'r') as f:
+                    safe_upgrades = yaml.safe_load(f) or {}
+                logger.debug(f"   Loaded {len(safe_upgrades)} safe upgrade paths from config")
+            except Exception as e:
+                logger.error(f"❌ Could not load safe_upgrades.yaml: {e}")
+        else:
+            logger.warning(f"⚠️  safe_upgrades.yaml not found at {config_path}")
 
         # Extract major version from tag
-        version_match = re.match(r'^(\d+)(?:\.(\d+))?', current_tag)
+        version_match = re.match(r'^v?(\d+)(?:\.(\d+))?', current_tag)
         if not version_match:
+            # Fallback for non-numeric tags like 'v3' if exact match exists
+            if image_name in safe_upgrades and current_tag in safe_upgrades[image_name]:
+                upgrade_info = safe_upgrades[image_name][current_tag]
+                return {
+                    'current_version': current_tag,
+                    'recommended_version': upgrade_info['next'],
+                    'upgrade_type': 'major',
+                    'notes': upgrade_info['notes'],
+                    'risk_level': upgrade_info['risk'],
+                    'migration_url': upgrade_info.get('migration_url'),
+                    'requires_manual_migration': True
+                }
             return None
 
         current_major = version_match.group(1)
+        major_only = current_major
         if version_match.group(2):
             current_major += f".{version_match.group(2)}"
 
@@ -297,10 +271,15 @@ class DockerImageAnalyzer:
         if image_name not in safe_upgrades:
             return None
 
-        if current_major not in safe_upgrades[image_name]:
+        # Check both major.minor and major only versions
+        if current_major in safe_upgrades[image_name]:
+            upgrade_info = safe_upgrades[image_name][current_major]
+        elif major_only in safe_upgrades[image_name]:
+            upgrade_info = safe_upgrades[image_name][major_only]
+        elif current_tag in safe_upgrades[image_name]:
+            upgrade_info = safe_upgrades[image_name][current_tag]
+        else:
             return None
-
-        upgrade_info = safe_upgrades[image_name][current_major]
 
         # Preserve tag variant (e.g., -alpine, -slim)
         tag_variant = ''
@@ -314,7 +293,7 @@ class DockerImageAnalyzer:
             'upgrade_type': 'major',
             'notes': upgrade_info['notes'],
             'risk_level': upgrade_info['risk'],
-            'migration_url': upgrade_info['migration_url'],
+            'migration_url': upgrade_info.get('migration_url'),
             'requires_manual_migration': True
         }
 

--- a/tests/unit/test_docker_image_analyzer.py
+++ b/tests/unit/test_docker_image_analyzer.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import yaml
+from src.integrations.docker_image_analyzer import DockerImageAnalyzer
+
+class TestDockerImageAnalyzer(unittest.TestCase):
+    def setUp(self):
+        self.analyzer = DockerImageAnalyzer()
+
+    def test_safe_upgrades_traefik_is_implemented(self):
+        # Check if 'traefik' is correctly loaded from safe_upgrades.yaml
+        upgrade_info = self.analyzer.check_major_version_upgrade('traefik', '3.0')
+        self.assertIsNotNone(upgrade_info)
+        self.assertEqual(upgrade_info['recommended_version'], '3.3')
+        self.assertEqual(upgrade_info['risk_level'], 'critical')
+
+    def test_safe_upgrades_traefik_v3_exact_tag(self):
+        # Check if 'v3' tag for traefik is correctly loaded
+        upgrade_info = self.analyzer.check_major_version_upgrade('traefik', 'v3')
+        self.assertIsNotNone(upgrade_info)
+        self.assertEqual(upgrade_info['recommended_version'], 'v3')
+
+    def test_safe_upgrades_postgres_exists(self):
+        # Confirming current hardcoded behavior
+        upgrade_info = self.analyzer.check_major_version_upgrade('postgres', '15')
+        self.assertIsNotNone(upgrade_info)
+        self.assertEqual(upgrade_info['recommended_version'], '16')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have updated the Traefik v3 security configuration to address high-severity Go stdlib vulnerabilities by adding a clear upgrade path to `config/safe_upgrades.yaml`. 

Additionally, I've refactored the `DockerImageAnalyzer` to move hardcoded upgrade metadata into that same YAML file, making the system more maintainable and consistent. I also improved the regex logic in `DockerImageAnalyzer` to correctly handle common tag formats like `v3` and ensure that major version upgrades (like 15 -> 16 for Postgres) are correctly identified even when minor versions are present.

New unit tests have been added and verified to confirm that the new configuration is correctly loaded and utilized.

Fixes #121

---
*PR created automatically by Jules for task [1201774337133682232](https://jules.google.com/task/1201774337133682232) started by @Commandershadow9*