### PR TITLE
Add memory limits to shadowops-bot service

### DIFF
--- a/deploy/shadowops-bot.service
+++ b/deploy/shadowops-bot.service
@@ -30,6 +30,9 @@ StartLimitBurst=3
 
 # Limits
 LimitNOFILE=65536
+# Memory-Limits gegen unkontrolliertes Wachstum
+MemoryHigh=1536M
+MemoryMax=2048M
 
 # Logs
 StandardOutput=journal


### PR DESCRIPTION
This PR adds memory limits to the `shadowops-bot.service` configuration to address issues with swap exhaustion and excessive RAM usage (Finding #216).

Changes:
- Added `MemoryHigh=1536M` to trigger throttling and reclaim once the bot reaches 1.5GB.
- Added `MemoryMax=2048M` as a hard limit at 2GB to protect system stability.

After merging, the following commands should be run on the production server to apply the changes:
```bash
sudo cp deploy/shadowops-bot.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl restart shadowops-bot
```

Fixes #130

---
*PR created automatically by Jules for task [13856164583152470467](https://jules.google.com/task/13856164583152470467) started by @Commandershadow9*