### PR TITLE
🧪 Add unit tests for get_patch_notes_batcher factory

### DIFF
--- a/tests/unit/test_patch_notes_batcher.py
+++ b/tests/unit/test_patch_notes_batcher.py
@@ -6,7 +6,7 @@ Stellt sicher, dass Batching, Release und die verschiedenen Freigabe-Methoden ko
 import pytest
 from pathlib import Path
 
-from src.integrations.patch_notes_batcher import PatchNotesBatcher
+from src.integrations.patch_notes_batcher import PatchNotesBatcher, get_patch_notes_batcher
 
 
 # ============================================================================
@@ -164,3 +164,25 @@ class TestPersistence:
         assert batcher2.has_pending('test_project')
         summary = batcher2.get_pending_summary()
         assert summary['test_project']['count'] == 4
+
+
+# ============================================================================
+# FACTORY FUNCTION
+# ============================================================================
+
+class TestFactoryFunction:
+    def test_get_patch_notes_batcher_default(self, monkeypatch, tmp_path):
+        """Standard-Verhalten der Factory-Funktion."""
+        monkeypatch.setattr('src.integrations.patch_notes_batcher.Path.home', lambda: tmp_path)
+
+        batcher = get_patch_notes_batcher()
+        expected_dir = tmp_path / '.shadowops' / 'patch_notes_training'
+        assert batcher.data_dir == expected_dir
+        assert batcher.batch_threshold == 8
+        assert expected_dir.exists()
+
+    def test_get_patch_notes_batcher_custom(self, tmp_path):
+        """Factory-Funktion mit eigenen Parametern."""
+        batcher = get_patch_notes_batcher(data_dir=tmp_path, batch_threshold=15)
+        assert batcher.data_dir == tmp_path
+        assert batcher.batch_threshold == 15

--- a/tests/unit/test_patch_notes_batcher.py
+++ b/tests/unit/test_patch_notes_batcher.py
@@ -173,7 +173,7 @@ class TestPersistence:
 class TestFactoryFunction:
     def test_get_patch_notes_batcher_default(self, monkeypatch, tmp_path):
         """Standard-Verhalten der Factory-Funktion."""
-        monkeypatch.setattr('src.integrations.patch_notes_batcher.Path.home', lambda: tmp_path)
+        monkeypatch.setattr(Path, 'home', lambda: tmp_path)
 
         batcher = get_patch_notes_batcher()
         expected_dir = tmp_path / '.shadowops' / 'patch_notes_training'
@@ -183,6 +183,8 @@ class TestFactoryFunction:
 
     def test_get_patch_notes_batcher_custom(self, tmp_path):
         """Factory-Funktion mit eigenen Parametern."""
-        batcher = get_patch_notes_batcher(data_dir=tmp_path, batch_threshold=15)
-        assert batcher.data_dir == tmp_path
+        custom_dir = tmp_path / 'custom_dir'
+        batcher = get_patch_notes_batcher(data_dir=custom_dir, batch_threshold=15)
+        assert batcher.data_dir == custom_dir
         assert batcher.batch_threshold == 15
+        assert custom_dir.exists()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was a missing unit test for the `get_patch_notes_batcher` factory function in `src/integrations/patch_notes_batcher.py`.
📊 **Coverage:** The scenarios now tested include validating the default fallback directory creation based on the user's home folder, as well as passing custom parameters (`data_dir` and `batch_threshold`) directly to the factory.
✨ **Result:** A tangible improvement in test coverage, ensuring future modifications to the factory function handle defaults safely without polluting the host's actual file system during tests.

---
*PR created automatically by Jules for task [7958068529917651973](https://jules.google.com/task/7958068529917651973) started by @Commandershadow9*