### PR TITLE
🧪 Add test for get_changelog_parser

### DIFF
--- a/tests/unit/utils/test_changelog_parser.py
+++ b/tests/unit/utils/test_changelog_parser.py
@@ -1,0 +1,11 @@
+import pytest
+from pathlib import Path
+from utils.changelog_parser import get_changelog_parser, ChangelogParser
+
+def test_get_changelog_parser():
+    """Test get_changelog_parser returns an instance with the correct path."""
+    project_path = Path("/mock/project")
+    parser = get_changelog_parser(project_path)
+
+    assert isinstance(parser, ChangelogParser)
+    assert parser.changelog_path == project_path / 'CHANGELOG.md'

--- a/tests/unit/utils/test_changelog_parser.py
+++ b/tests/unit/utils/test_changelog_parser.py
@@ -2,9 +2,10 @@ import pytest
 from pathlib import Path
 from utils.changelog_parser import get_changelog_parser, ChangelogParser
 
-def test_get_changelog_parser():
+
+@pytest.mark.parametrize('project_path', [Path('/mock/project'), Path('relative/project')])
+def test_get_changelog_parser(project_path):
     """Test get_changelog_parser returns an instance with the correct path."""
-    project_path = Path("/mock/project")
     parser = get_changelog_parser(project_path)
 
     assert isinstance(parser, ChangelogParser)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This adds a missing unit test for the `get_changelog_parser` factory function in `src/utils/changelog_parser.py`. 

📊 **Coverage:** What scenarios are now tested
The unit test tests the factory function by providing a mock `Path` object and asserting that the function correctly concatenates `CHANGELOG.md` to it and passes it into a newly initialized instance of `ChangelogParser`.

✨ **Result:** The improvement in test coverage
The code is now covered and regression-tested.

---
*PR created automatically by Jules for task [336347445895714743](https://jules.google.com/task/336347445895714743) started by @Commandershadow9*