### PR TITLE
docs: fix slash-command list, permissions, project structure, API config

### DIFF
--- a/.claude/rules/discord-bot.md
+++ b/.claude/rules/discord-bot.md
@@ -18,9 +18,11 @@ paths:
 | Datei | Cog | Commands |
 |-------|-----|----------|
 | `monitoring.py` | MonitoringCog | `/status`, `/bans`, `/threats`, `/docker`, `/aide` |
-| `admin.py` | AdminCog | `/scan`, `/stop-all-fixes`, `/remediation-stats`, `/set-approval-mode`, `/reload-context` |
-| `inspector.py` | InspectorCog | `/get-ai-stats`, `/projekt-status`, `/alle-projekte` |
+| `admin.py` | AdminCog | `/scan`, `/stop-all-fixes`, `/remediation-stats`, `/set-approval-mode`, `/reload-context`, `/release-notes`, `/pending-notes`, `/mark-duplicate` |
+| `inspector.py` | InspectorCog | `/get-ai-stats`, `/projekt-status`, `/alle-projekte`, `/agent-stats`, `/security-engine` |
 | `customer_setup_commands.py` | CustomerSetupCommands | `/setup-customer-server` |
+
+Alle AdminCog-Commands erfordern `administrator=True` (Discord-Berechtigung).
 
 ## Patterns
 - Alle async: `await` fuer Discord API Calls

--- a/README.md
+++ b/README.md
@@ -244,25 +244,38 @@ projects:
 
 ### 🤖 Slash Commands
 
+Commands mit `(Admin)` erfordern Discord-Administrator-Berechtigung.
+
 #### Security & Monitoring
 - `/status` - Gesamt-Sicherheitsstatus
-- `/scan` - Manuellen Docker-Scan triggern
+- `/scan` - Manuellen Docker-Scan triggern (Admin)
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
+- `/docker` - Letzte Docker Scan Ergebnisse
 - `/aide` - AIDE Integrity Check Status
 
 #### Auto-Remediation
-- `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
-- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/remediation-stats` - Auto-Remediation Statistiken (Admin)
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes (Admin)
+- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run) (Admin)
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
-- `/reload-context` - Lade Project-Context neu
+- `/reload-context` - Lade Project-Context neu (Admin)
+- `/agent-stats` - Agent-Learning Statistiken (Security, Patch Notes, Jules)
+- `/security-engine` - Security Engine v6 Status und Statistiken
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+
+#### Patch Notes
+- `/release-notes [project]` - Gesammelte Commits als Patch Notes veröffentlichen (Admin)
+- `/pending-notes` - Zeige ausstehende Commits die auf Release warten (Admin)
+- `/mark-duplicate` - Markiert ein Finding als Duplikat (Learning-Feedback) (Admin)
+
+#### Setup
+- `/setup-customer-server` - Richtet Monitoring-Channels auf Kunden-Server ein (Admin)
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -438,23 +451,34 @@ deployment:
 ```
 Security Commands:
   /status              - Gesamt-Sicherheitsstatus
-  /scan                - Docker Security Scan
+  /scan                - Docker Security Scan (Admin)
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
+  /docker              - Letzte Docker Scan Ergebnisse
   /aide                - AIDE Check-Status
 
 Auto-Remediation:
-  /remediation-stats             - Statistiken
-  /stop-all-fixes                - Emergency Stop
-  /set-approval-mode [mode]      - Approval Mode ändern
+  /remediation-stats             - Statistiken (Admin)
+  /stop-all-fixes                - Emergency Stop (Admin)
+  /set-approval-mode [mode]      - Approval Mode ändern (Admin)
 
-AI System:
+AI & Learning:
   /get-ai-stats                  - AI Provider Status
-  /reload-context                - Context neu laden
+  /reload-context                - Context neu laden (Admin)
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+
+Patch Notes:
+  /release-notes [project]       - Patch Notes veröffentlichen (Admin)
+  /pending-notes                 - Ausstehende Commits anzeigen (Admin)
+  /mark-duplicate                - Finding als Duplikat markieren (Admin)
+
+Setup:
+  /setup-customer-server         - Kunden-Server einrichten (Admin)
 ```
 
 ### GitHub Webhook Setup
@@ -498,84 +522,70 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
-│   │   ├── admin.py
-│   │   ├── inspector.py
-│   │   └── monitoring.py
+│   ├── cogs/                           # Modulare Slash Commands
+│   │   ├── admin.py                    # Admin: /scan, /stop-all-fixes, /release-notes, ...
+│   │   ├── inspector.py                # Inspector: /get-ai-stats, /agent-stats, /security-engine, ...
+│   │   ├── monitoring.py               # Monitoring: /status, /bans, /threats, /docker, /aide
+│   │   └── customer_setup_commands.py  # Setup: /setup-customer-server
+│   ├── patch_notes/                    # Patch-Notes Pipeline v6 (State Machine)
+│   │   ├── pipeline.py
+│   │   ├── stages/
+│   │   └── templates/
 │   ├── integrations/
-│   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
+│   │   ├── ai_engine.py                # Dual-Engine Router (Codex Primary, Claude Fallback)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (Mixin-Architektur)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules + Agent-Review
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
+│   │   ├── security_engine/            # Security Engine v6 (Scan, Fix, Learning)
+│   │   ├── fixers/                     # Fix-Adapter pro Tool (fail2ban, walg, trivy, ...)
+│   │   ├── ai_learning/                # Agent-Learning DB und Synthesizer
+│   │   ├── analyst/                    # Legacy Security Analyst (Referenz)
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       └── discord_logger.py           # Discord Channel Logger
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (161)
-│   │   ├── test_config.py
-│   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
-│   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
-│   │   ├── test_orchestrator.py
-│   │   ├── test_knowledge_base.py
-│   │   ├── test_event_watcher.py
-│   │   ├── test_github_integration.py
-│   │   ├── test_project_monitor.py
-│   │   └── test_incident_manager.py
-│   └── integration/
-│       └── test_learning_workflow.py   # End-to-End Tests
+│   ├── unit/                           # Unit Tests
+│   └── integration/                    # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
+│   ├── config.example.yaml             # Config-Template (committed)
+│   ├── config.yaml                     # Hauptconfig (gitignored)
 │   ├── DO-NOT-TOUCH.md                 # Safety Rules
 │   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
-│   ├── config.recommended.yaml         # Empfehlungen
-│   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
-├── deploy/                             # Deployment
+│   └── PROJECT_*.md                    # Projekt-Notizen
+├── deploy/
 │   └── shadowops-bot.service           # systemd Unit
-├── scripts/                            # Utility-Skripte
-│   ├── restart.sh                      # Bot neustarten (--pull, --logs)
-│   ├── diagnose-bot.sh                 # Diagnose
-│   ├── setup.sh                        # Erstinstallation
-│   └── ...
+├── scripts/                            # Wartungs-Skripte
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
-├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+├── docs/
+│   ├── reference/api.md                # API-Referenz
+│   ├── SECURITY_ANALYST.md
+│   ├── SETUP_GUIDE.md
 │   ├── adr/                            # Architecture Decision Records
 │   ├── plans/                          # Design-Dokumente
-│   └── archive/                        # Historische Doku
+│   └── archive/
 ├── .claude/                            # KI-Konfiguration
-│   ├── rules/                          # Pfad-gefilterte Rules
-│   ├── skills/                         # Workflow-Skills
-│   └── agents/                         # Spezialisierte Agents
-├── requirements.txt                    # Python Dependencies
-├── pyproject.toml                      # Projekt-Definition
+├── requirements.txt
 ├── CLAUDE.md                           # KI-Projektinstruktionen
-├── CHANGELOG.md                        # Version History
-└── README.md                           # This file
+├── CHANGELOG.md
+└── README.md
 ```
 
 ## 🛡️ Security

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -164,11 +164,11 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
+- Codex CLI status (primary engine, model, last used)
+- Claude CLI status (fallback engine, model, last used)
 - Active fallback chain
 - Request counts per provider
+- Circuit breaker state
 
 **Example:**
 ```
@@ -266,25 +266,36 @@ channels:
 
 # ========================================
 # AI CONFIGURATION
+# Codex CLI ist Primary (97% der Anfragen), Claude CLI ist Fallback + Verification.
+# Ollama wurde vollstaendig entfernt (v4.0).
+# API-Keys werden NICHT hier gesetzt — nur ueber Env-Vars (OPENAI_API_KEY, ANTHROPIC_API_KEY).
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  codex:
+    enabled: true
+    cli_path: "codex"                        # Pfad zur Codex CLI
+    models:
+      fast: "gpt-5.3-codex"
+      standard: "gpt-5.3-codex"
+      thinking: "o3"
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  claude:
+    enabled: true
+    cli_path: "/home/user/.local/bin/claude" # Pfad zur Claude CLI
+    models:
+      fast: "claude-sonnet-4-6"
+      standard: "claude-sonnet-4-6"
+      thinking: "claude-opus-4-6"
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  timeouts:
+    codex_seconds: 300
+    claude_seconds: 300
+
+  routing:
+    critical_analysis: { engine: codex, model: thinking }
+    high_analysis:     { engine: codex, model: standard }
+    low_analysis:      { engine: codex, model: fast }
+    critical_verify:   { engine: claude, model: thinking }
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -583,7 +594,7 @@ Fallback auf das jeweils andere Modell bei Timeout oder leerer Response.
 from src.integrations.knowledge_base import KnowledgeBase
 
 # Initialize
-kb = KnowledgeBase(db_path="data/knowledge_base.db")
+kb = KnowledgeBase(dsn=config.security_analyst_dsn)  # PostgreSQL DSN aus config.yaml
 
 # Record a fix
 kb.record_fix(
@@ -791,28 +802,42 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+Das System nutzt **PostgreSQL** (nicht SQLite). Drei Datenbanken:
 
-#### fixes table
+| Datenbank | DSN-Config-Key | Zweck |
+|-----------|----------------|-------|
+| `security_analyst` | `security_analyst_dsn` / Env: `SECURITY_ANALYST_DB_URL` | Security-Findings, Sessions, Fix-Attempts |
+| `agent_learning` | `agent_learning_dsn` / Env: `AGENT_LEARNING_DB_URL` | Few-Shot-Learning, Patch-Notes-Feedback |
+| `seo_agent` | (sep. Config) | SEO-Agent-spezifische Tabellen |
+
+### Wichtige Tabellen (security_analyst DB)
+
+#### fix_attempts_v2
 ```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
+-- Alle Fix-Ergebnisse: success, failed, no_op, skipped_duplicate
+CREATE TABLE fix_attempts_v2 (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    event_source TEXT NOT NULL,
+    event_type TEXT NOT NULL,
     severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
+    strategy JSONB,
+    result TEXT NOT NULL,
     duration_seconds REAL,
     error_message TEXT,
-    retry_count INTEGER DEFAULT 0
+    retry_count INT DEFAULT 0
 );
+```
 
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
+#### remediation_status
+```sql
+-- Cross-Mode Lock: verhindert doppelte Fix-Ausfuehrung
+CREATE TABLE remediation_status (
+    event_id TEXT PRIMARY KEY,
+    claimed_by TEXT,
+    claimed_at TIMESTAMPTZ,
+    status TEXT
+);
 ```
 
 ### Project Monitor State (JSON)
@@ -874,7 +899,8 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 
 #### AI Service Errors
 - `No AI providers enabled` - All AI services disabled
-- `Ollama connection failed` - Cannot reach Ollama server
+- `Codex CLI not found` - `codex` binary nicht im PATH
+- `Claude CLI not found` - Claude CLI-Pfad nicht korrekt (siehe `ai.claude.cli_path`)
 - `AI request timeout` - AI provider took too long
 
 #### Deployment Errors
@@ -894,9 +920,9 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI**: Kein eingebautes Rate-Limiting — Codex CLI selbst drosselt bei API-Limits
+- **Claude CLI**: Kein eingebautes Rate-Limiting — Claude CLI selbst drosselt bei API-Limits
+- Bei Timeout: automatischer Failover auf das jeweils andere Modell (Sonnet ↔ Opus)
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)


### PR DESCRIPTION
## Drift-Korrekturen (Doku-Kurator Routine)

### README.md — Slash Commands
- **7 fehlende Commands ergaenzt:** `/docker`, `/agent-stats`, `/security-engine`, `/release-notes`, `/pending-notes`, `/mark-duplicate`, `/setup-customer-server`
- **Falsche Permissions korrigiert:** `/scan` und `/remediation-stats` wurden als permission-los gelistet, sind aber `administrator=True` (wie alle AdminCog-Commands)
- Admin-only Commands jetzt mit `(Admin)` Marker in beiden Listen (Features-Sektion + Usage-Sektion)

### README.md — Projekt-Struktur
- Doppelter `config/`-Block entfernt (Copy-Paste-Fehler)
- `github_integration.py` → `github_integration/` (ist seit langem ein Verzeichnis)
- `docs/API.md` → `docs/reference/api.md` (korrekter Pfad)
- `src/patch_notes/` ergaenzt (Patch-Notes Pipeline v6)
- Integrations-Subdirectories ergaenzt: `orchestrator/`, `security_engine/`, `fixers/`, `ai_learning/`, `analyst/`
- `cogs/customer_setup_commands.py` in Struktur ergaenzt

### docs/reference/api.md — AI Configuration
- **Ollama-Konfiguration entfernt** (Ollama wurde in v4.0 vollstaendig entfernt, 1364 Zeilen Dead Code)
- AI-Config-Block ersetzt durch aktuelles Format: `ai.codex` (Primary) + `ai.claude` (Fallback) + `ai.routing`
- `/get-ai-stats` Returns: Ollama-Zeilen ersetzt durch Codex/Claude CLI Status
- Rate-Limiting-Sektion: Ollama entfernt, Codex/Claude CLI korrekt dokumentiert
- Error-Sektion: `Ollama connection failed` ersetzt durch `Codex CLI not found` / `Claude CLI not found`

### docs/reference/api.md — Database Schema
- Knowledge Base von SQLite auf PostgreSQL korrigiert
- Tabellen-Uebersicht der 3 DBs ergaenzt (security_analyst, agent_learning, seo_agent)
- `fix_attempts_v2` und `remediation_status` Tabellenschemas dokumentiert
- Python-API-Beispiel: `db_path=` (SQLite) → `dsn=` (PostgreSQL)

### .claude/rules/discord-bot.md — Cog-Tabelle
- AdminCog: `/release-notes`, `/pending-notes`, `/mark-duplicate` ergaenzt
- InspectorCog: `/agent-stats`, `/security-engine` ergaenzt
- Hinweis: Alle AdminCog-Commands erfordern `administrator=True`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnvugVqVnPVjJCF16NkBeP)_