### PR TITLE
feat(monitor): App-Health-Checks via internal API (Phase 5c, Issue #278)

### DIFF
--- a/docs/runbooks/health-checks-overview.md
+++ b/docs/runbooks/health-checks-overview.md
@@ -1,0 +1,138 @@
+# Enterprise-Health-Checks — Vollständige Übersicht
+
+**Status:** Live seit 2026-04-26 (Issue #278, PRs #184 + Phase 5c)
+**Pfad:** `src/integrations/project_monitor.py` + `src/cogs/cron_heartbeat.py`
+
+## Defense-in-Depth-Map
+
+```
+                         User-Browser → Production
+                              │
+                              ▼
+    ┌─────────────────────────────────────────────────────┐
+    │  ZERODOX-API (Next.js)                              │
+    │   ├─ /api/health (HTTP 200 = liveness)             │
+    │   └─ /api/internal/health-stats (DB-Pool, Logins)  │ ← Auth via X-Agent-Key
+    └─────────────────────────────────────────────────────┘
+                              │
+                              │ aiohttp polling
+                              ▼
+    ┌─────────────────────────────────────────────────────┐
+    │  ShadowOps-Bot (systemd-Service mit Restart=on-failure)
+    │   ProjectMonitor — _monitor_project() Loop         │
+    │   ┌─────────────────────────────────────────────┐  │
+    │   │  Existing (Phase 1-3):                      │  │
+    │   │   • _check_project_health (HTTP-Liveness)   │  │
+    │   │   • _check_systemd_health                   │  │
+    │   │   • _check_tcp_ports                        │  │
+    │   │   • _check_project_logs                     │  │
+    │   ├─────────────────────────────────────────────┤  │
+    │   │  Phase 5b (Server-Resources):               │  │
+    │   │   • _check_disk_space          → critical   │  │
+    │   │   • _check_memory_usage        → critical   │  │
+    │   │   • _check_container_restart_count → bot-status │
+    │   │   • _check_ssl_cert_expiry     → bot-status │  │
+    │   │   • _check_backup_freshness    → backups    │  │
+    │   ├─────────────────────────────────────────────┤  │
+    │   │  Phase 5c (App-Insights via internal API):  │  │
+    │   │   • _check_db_pool_saturation  → ci-zerodox │  │
+    │   │   • _check_failed_login_rate   → critical   │  │
+    │   └─────────────────────────────────────────────┘  │
+    │                                                     │
+    │  CronHeartbeatCog (separate task.loop)              │
+    │   • Watcht /home/cmdshadow/ZERODOX/logs/synthetic-monitor.log
+    │   • Mtime > 35 Min → ci-zerodox                     │
+    └─────────────────────────────────────────────────────┘
+```
+
+## Check-Tabelle (alle 7 Health-Checks)
+
+| Check | Was geprüft | Schwelle | Severity | Channel | Cooldown | Frequenz |
+|-------|-------------|----------|----------|---------|----------|----------|
+| **Disk-Space** | `shutil.disk_usage(path)` | < 15% frei | CRITICAL | `🚨-critical` | 60 Min | 5 Min |
+| **Memory** | `docker stats --no-stream` | > 90% | CRITICAL | `🚨-critical` | 60 Min | 60s |
+| **Restart-Count** | `docker inspect → RestartCount` | > 3 / 24h | MEDIUM | `🤖-bot-status` | 6h | 1h |
+| **SSL-Cert** | `asyncio.open_connection` + cert.notAfter | < 30 Tage | HIGH (<7d), MEDIUM | `🤖-bot-status` | 24h | 6h |
+| **Backup** | Mtime von `<path>/backups/daily/` neuestem File | > 25h alt | HIGH | `backup-dashboard` | 60 Min | 30 Min |
+| **DB-Pool-Saturation** | `pg_stat_activity` / `max_connections` via API | > 80% | HIGH | `🧪-ci-zerodox` | 30 Min | 5 Min |
+| **Failed-Login-Rate** | `LoginAttempt.success=false WHERE createdAt > NOW()-5min` via API | > 100 / 5 Min | HIGH (CRITICAL >500) | `🚨-critical` | 15 Min | 60s |
+
+## Konfiguration
+
+`config/config.yaml` pro Projekt:
+
+```yaml
+projects:
+  zerodox:
+    monitor:
+      url: https://zerodox.de/api/health
+      check_interval: 60
+      container: zerodox-web
+      # Phase 5c: App-Insights API
+      internal_health_endpoint: https://zerodox.de/api/internal/health-stats
+      health_api_key_env: ZERODOX_AGENT_API_KEY
+      # Schwellen pro Projekt überschreibbar (Defaults siehe HEALTH_CHECK_DEFAULTS)
+      thresholds:
+        disk_warn_percent: 15
+        memory_warn_percent: 90
+        restart_count_warn: 3
+        ssl_cert_warn_days: 30
+        backup_max_age_hours: 25
+        db_pool_saturation_warn: 80
+        failed_login_per_5min_warn: 100
+```
+
+## Auth: ZERODOX_AGENT_API_KEY
+
+Der Bot-Service (`/etc/systemd/system/shadowops-bot.service`) lädt env-vars aus `/home/cmdshadow/shadowops-bot/.env`. Dort muss stehen:
+
+```
+ZERODOX_AGENT_API_KEY=<gleicher Wert wie in /home/cmdshadow/ZERODOX/.env>
+```
+
+**Wichtig:** Der Key muss in BEIDEN .env-Dateien identisch sein. Bei Rotation:
+1. Neuen Key in ZERODOX `.env`
+2. Gleichen Key in shadowops-bot `.env`
+3. Beide Services restarten
+
+## Anti-Spam-Pattern
+
+- **Cooldown pro Check + Project**: nach Alert wird `f"{project.name}:{check_type}"` in `_health_check_alerts: Dict[str, datetime]` gespeichert. Zweiter Trigger innerhalb der Cooldown-Zeit → kein neuer Alert.
+- **Recovery-Reset**: bei Threshold wieder OK → `_clear_health_alert_cooldown()` löscht den Eintrag. Nächste Verletzung alarmiert sofort.
+- **Min-Intervall-Filter**: `_should_run_health_check()` skippt Checks die noch im Min-Intervall sind (auch wenn der Loop sie aufruft).
+
+## Wenn ein neuer Check hinzukommt
+
+1. Methode `_check_<name>` schreiben (Pattern: `_check_disk_space`)
+2. Defaults in `HEALTH_CHECK_DEFAULTS` ergänzen
+3. Min-Intervall in `HEALTH_CHECK_MIN_INTERVAL_SECONDS`
+4. Cooldown in `HEALTH_CHECK_ALERT_COOLDOWNS`
+5. In `_monitor_project()` Loop aufrufen
+6. Tests in `tests/unit/test_health_checks_extension.py` (mind. 3 Tests pro Check: trigger, no-trigger, cooldown)
+7. Diese Doku updaten
+
+## Slash-Commands für Manual-Test
+
+(Folgeaufgabe — aktuell nicht implementiert): `/healthcheck zerodox <type>` würde einen einzelnen Check sofort triggern, unabhängig vom Min-Intervall. Sinnvoll für Debugging.
+
+## Lehre aus dem 11-Tage-CSP-Outage
+
+Vor Phase 5 hatten wir nur HTTP-Liveness-Checks. Der Outage konnte 11 Tage unbemerkt bleiben weil:
+- HTTP 200 ✓ (Liveness OK, aber Frontend tot)
+- Container running ✓
+- Keine Server-Resource-Issues ✓
+
+Mit Phase 5b/c hätten wir zusätzliche Signale gehabt:
+- DB-Pool wäre niedrig gewesen → erwartbar, aber im Vergleich zum Vorzustand seltsam
+- Failed-Login-Rate wäre niedrig gewesen → User können nicht buchen, also weniger Aktivität
+
+Für DEN spezifischen CSP-Bug ist der Synthetic-Monitor (Phase 4) der richtige Layer. Phase 5 ergänzt für klassische Server-Outages.
+
+---
+
+**Verwandt:**
+- `docs/runbooks/deploy-hardening.md` — Auto-Deploy via deploy.sh
+- `docs/runbooks/discord-routing.md` — Channel-Map aller Notifications
+- ZERODOX `docs/SECURITY_CSP.md` — CSP-Strategie + Defense-in-Depth
+
+**Erstellt:** 2026-04-26 nach Abschluss Issue #278.

--- a/src/integrations/project_monitor.py
+++ b/src/integrations/project_monitor.py
@@ -34,6 +34,9 @@ HEALTH_CHECK_DEFAULTS: Dict[str, Any] = {
     'restart_count_warn': 3,      # > 3 Restarts in 24h -> Alert
     'ssl_cert_warn_days': 30,     # < 30 Tage -> Alert
     'backup_max_age_hours': 25,   # > 25h alt -> Alert
+    # Phase 5c: App-Health-Checks (DB-Pool, Failed-Login)
+    'db_pool_saturation_warn': 80,        # > 80% Pool-Sat -> Alert
+    'failed_login_per_5min_warn': 100,    # > 100 Fehlversuche/5 Min -> Brute-Force-Verdacht
 }
 
 # Min-Intervall pro Check-Typ (Sekunden). Verhindert dass teure Checks
@@ -44,6 +47,9 @@ HEALTH_CHECK_MIN_INTERVAL_SECONDS: Dict[str, int] = {
     'restart_count': 60 * 60,       # 1h (Trend)
     'ssl_cert_expiry': 6 * 60 * 60, # 6h (langsam-bewegender Wert)
     'backup_freshness': 30 * 60,    # 30 Min (taeglicher Cron)
+    # Phase 5c: App-Health-Checks via /api/internal/health-stats
+    'db_pool_saturation': 5 * 60,   # 5 Min (Pool-Sat ist Trend, nicht Spike)
+    'failed_login_rate': 60,        # 60s (Brute-Force kann schnell hochlaufen)
 }
 
 # Anti-Spam: pro Check-Typ wie lange ein bereits ausgeloester Alert
@@ -54,6 +60,9 @@ HEALTH_CHECK_ALERT_COOLDOWNS: Dict[str, timedelta] = {
     'restart_count': timedelta(hours=6),
     'ssl_cert_expiry': timedelta(hours=24),
     'backup_freshness': timedelta(minutes=60),
+    # Phase 5c
+    'db_pool_saturation': timedelta(minutes=30),  # Sat-Trend braucht keine sofortige Re-Alarmierung
+    'failed_login_rate': timedelta(minutes=15),   # Brute-Force-Burst kann mehrfach kommen
 }
 
 
@@ -393,7 +402,7 @@ class ProjectMonitor:
                 await self._check_project_logs(project)
                 await self._check_project_health(project)
 
-                # Health-Check-Erweiterung (Phase 5b, Issue #278).
+                # Health-Check-Erweiterung (Phase 5b + 5c, Issue #278).
                 # Jede Methode hat ihren eigenen Min-Intervall-Filter — die werden
                 # bei jedem Loop-Tick aufgerufen, fuehren aber nur dann tatsaechlich
                 # die Pruefung aus, wenn der Filter es erlaubt.
@@ -402,6 +411,9 @@ class ProjectMonitor:
                 await self._check_container_restart_count(project)
                 await self._check_ssl_cert_expiry(project)
                 await self._check_backup_freshness(project)
+                # Phase 5c: App-Health-Checks via internal API (skip wenn nicht konfiguriert)
+                await self._check_db_pool_saturation(project)
+                await self._check_failed_login_rate(project)
 
                 await asyncio.sleep(project.check_interval)
 
@@ -1845,3 +1857,188 @@ class ProjectMonitor:
             )
         else:
             self._clear_health_alert_cooldown(project, 'backup_freshness')
+
+    # === Phase 5c — App-Health-Checks via internal API ===
+    # Diese Checks pollen einen ZERODOX-API-Endpoint der DB-Pool-Saturation und
+    # Failed-Login-Rate exposed. Nur Projekte mit `monitor.internal_health_endpoint`
+    # in config.yaml werden geprüft (graceful skip bei fehlender Konfiguration).
+    #
+    # Auth: X-Agent-Key Header mit ZERODOX_AGENT_API_KEY (env-var).
+    # Endpoint: ZERODOX/api/internal/health-stats (Phase 5a, PR #279)
+
+    async def _fetch_app_health_stats(self, project: ProjectStatus) -> Optional[Dict[str, Any]]:
+        """HTTP-Call zur internal Health-Stats-API des Projekts.
+
+        Returnt None wenn:
+          - Kein internal_health_endpoint konfiguriert
+          - Keine API-Key env-var gesetzt
+          - HTTP-Fehler (Timeout, 4xx, 5xx)
+          - JSON-Parse-Fehler
+        """
+        proj_cfg = self._get_project_config(project.name)
+        if not isinstance(proj_cfg, dict):
+            return None
+
+        monitor_cfg = proj_cfg.get('monitor', {})
+        if not isinstance(monitor_cfg, dict):
+            return None
+
+        endpoint = monitor_cfg.get('internal_health_endpoint')
+        if not endpoint:
+            return None
+
+        api_key_env = monitor_cfg.get('health_api_key_env', 'ZERODOX_AGENT_API_KEY')
+        import os
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            self.logger.debug(
+                f"ℹ️ App-Health-Check {project.name}: env-var {api_key_env} nicht gesetzt — skip"
+            )
+            return None
+
+        timeout = aiohttp.ClientTimeout(total=10)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    endpoint,
+                    headers={'X-Agent-Key': api_key, 'Accept': 'application/json'},
+                ) as resp:
+                    if resp.status != 200:
+                        self.logger.warning(
+                            f"⚠️ App-Health-Stats {project.name}: HTTP {resp.status} von {endpoint}"
+                        )
+                        return None
+                    return await resp.json()
+        except asyncio.TimeoutError:
+            self.logger.warning(f"⚠️ App-Health-Stats {project.name}: Timeout nach 10s")
+            return None
+        except aiohttp.ClientError as exc:
+            self.logger.warning(f"⚠️ App-Health-Stats {project.name}: ClientError — {exc}")
+            return None
+        except (ValueError, KeyError) as exc:
+            self.logger.warning(f"⚠️ App-Health-Stats {project.name}: JSON-Fehler — {exc}")
+            return None
+
+    async def _check_db_pool_saturation(self, project: ProjectStatus) -> None:
+        """
+        Check 6 (Phase 5c): DB-Connection-Pool-Saturation.
+
+        Schwelle: > db_pool_saturation_warn (default 80) % -> Alert.
+        Channel:  🧪-ci-zerodox (1463512208083521577), key='ci_zerodox'.
+        Severity: HIGH.
+        Cooldown: 30 Min.
+        Frequenz: alle 5 Min.
+
+        Datenquelle: ZERODOX /api/internal/health-stats Response.dbPool.saturationPercent.
+        """
+        if not self._should_run_health_check(project, 'db_pool_saturation'):
+            return
+        self._mark_health_check_ran(project, 'db_pool_saturation')
+
+        stats = await self._fetch_app_health_stats(project)
+        if not stats:
+            return
+
+        db_pool = stats.get('dbPool')
+        if not isinstance(db_pool, dict):
+            return
+
+        threshold = float(self._get_health_threshold(project, 'db_pool_saturation_warn'))
+        try:
+            saturation = float(db_pool.get('saturationPercent', 0))
+        except (TypeError, ValueError):
+            return
+
+        if saturation > threshold:
+            await self._send_health_alert(
+                project=project,
+                check_type='db_pool_saturation',
+                title=f"DB-Pool-Saturation hoch — {project.name}",
+                description=(
+                    f"Connection-Pool ist zu **{saturation:.0f}%** ausgelastet "
+                    f"(Schwelle: > {threshold:.0f}%).\n\n"
+                    f"Bei voll laufendem Pool kommen Auth-Logins und API-Requests zum Erliegen. "
+                    f"Mögliche Ursachen: Long-running Queries, Pool-Limit zu niedrig, Verbindungs-Leak."
+                ),
+                severity=Severity.HIGH,
+                fields=[
+                    {"name": "Saturation", "value": f"{saturation:.0f}%", "inline": True},
+                    {"name": "Schwelle", "value": f"> {threshold:.0f}%", "inline": True},
+                    {"name": "Active", "value": str(db_pool.get('active', '?')), "inline": True},
+                    {"name": "Idle", "value": str(db_pool.get('idle', '?')), "inline": True},
+                    {"name": "Total / Max", "value": f"{db_pool.get('total', '?')} / {db_pool.get('max', '?')}", "inline": True},
+                ],
+                channel_key='ci_zerodox',
+                fallback_channel_id=1463512208083521577,
+            )
+        else:
+            self._clear_health_alert_cooldown(project, 'db_pool_saturation')
+
+    async def _check_failed_login_rate(self, project: ProjectStatus) -> None:
+        """
+        Check 7 (Phase 5c): Failed-Login-Rate (5-Min-Fenster).
+
+        Schwelle: > failed_login_per_5min_warn (default 100) -> Alert (Brute-Force-Verdacht).
+        Channel:  🚨-critical (1441655480840617994), key='critical'.
+        Severity: HIGH (CRITICAL bei > 500).
+        Cooldown: 15 Min.
+        Frequenz: alle 60s (Brute-Force kann schnell hochlaufen).
+
+        Datenquelle: ZERODOX /api/internal/health-stats Response.failedLogins.count.
+        DSGVO-konform: nur Counts, keine Email-Adressen oder User-IDs.
+        """
+        if not self._should_run_health_check(project, 'failed_login_rate'):
+            return
+        self._mark_health_check_ran(project, 'failed_login_rate')
+
+        stats = await self._fetch_app_health_stats(project)
+        if not stats:
+            return
+
+        failed = stats.get('failedLogins')
+        if not isinstance(failed, dict):
+            return
+
+        threshold = int(self._get_health_threshold(project, 'failed_login_per_5min_warn'))
+        try:
+            count = int(failed.get('count', 0))
+        except (TypeError, ValueError):
+            return
+
+        unique_emails = failed.get('uniqueEmails', 0)
+        window_minutes = failed.get('windowMinutes', 5)
+
+        if count > threshold:
+            # Severity skaliert mit Volumen — > 500 ist klarer Brute-Force-Angriff
+            severity = Severity.CRITICAL if count > threshold * 5 else Severity.HIGH
+
+            # Verteilung gibt Hinweise: viele Versuche auf wenige Accounts = Credential-Stuffing
+            distribution_hint = ""
+            if unique_emails > 0:
+                ratio = count / max(unique_emails, 1)
+                if ratio > 10:
+                    distribution_hint = " (Credential-Stuffing-Verdacht: viele Versuche pro Account)"
+                elif ratio < 2:
+                    distribution_hint = " (verteilt über viele Accounts: möglicher Broad-Sweep)"
+
+            await self._send_health_alert(
+                project=project,
+                check_type='failed_login_rate',
+                title=f"Failed-Login-Rate hoch — {project.name}",
+                description=(
+                    f"**{count} fehlgeschlagene Logins** in den letzten {window_minutes} Min "
+                    f"(Schwelle: > {threshold}){distribution_hint}.\n\n"
+                    f"Möglicherweise Brute-Force oder Credential-Stuffing. "
+                    f"Bei Bedarf Account-Lockout-Schwellen prüfen oder IP-Sperren via Fail2ban."
+                ),
+                severity=severity,
+                fields=[
+                    {"name": "Versuche", "value": str(count), "inline": True},
+                    {"name": "Schwelle", "value": f"> {threshold} / {window_minutes} Min", "inline": True},
+                    {"name": "Unique Emails", "value": str(unique_emails), "inline": True},
+                ],
+                channel_key='critical',
+                fallback_channel_id=1441655480840617994,
+            )
+        else:
+            self._clear_health_alert_cooldown(project, 'failed_login_rate')

--- a/tests/unit/test_health_checks_extension.py
+++ b/tests/unit/test_health_checks_extension.py
@@ -353,3 +353,203 @@ async def test_memory_usage_skip_when_no_container(tmp_path):
     # Sollte ohne docker-stats-Aufruf stille zurueckkehren.
     await monitor._check_memory_usage(project)
     channel.send.assert_not_called()
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Phase 5c — App-Health-Checks via internal API
+# ════════════════════════════════════════════════════════════════════════
+
+
+def _build_monitor_with_api(
+    *,
+    api_key: str | None = "test-key-12345",
+    thresholds: dict | None = None,
+) -> tuple[ProjectMonitor, ProjectStatus, MagicMock]:
+    """Wie _build_monitor, aber mit internal_health_endpoint konfiguriert."""
+    monitor_cfg: dict = {
+        "enabled": True,
+        "url": "https://zerodox.de/api/health",
+        "expected_status": 200,
+        "check_interval": 60,
+        "container": "zerodox-web",
+        "internal_health_endpoint": "https://zerodox.de/api/internal/health-stats",
+        "health_api_key_env": "ZERODOX_AGENT_API_KEY_TEST",
+    }
+    if thresholds:
+        monitor_cfg["thresholds"] = thresholds
+
+    project_cfg: dict = {
+        "enabled": True,
+        "tag": "📘 [ZERODOX]",
+        "monitor": monitor_cfg,
+    }
+
+    config = MagicMock()
+    config.projects = {"zerodox": project_cfg}
+    config.customer_status_channel = 11111
+    config.customer_alerts_channel = 22222
+    config.channels = {
+        "critical": 1441655480840617994,
+        "bot_status": 1441655486981214309,
+        "ci_zerodox": 1463512208083521577,
+        "backups": 1486479593602023486,
+    }
+
+    bot = MagicMock()
+    channel = AsyncMock()
+    channel.send = AsyncMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    if api_key:
+        os.environ["ZERODOX_AGENT_API_KEY_TEST"] = api_key
+    elif "ZERODOX_AGENT_API_KEY_TEST" in os.environ:
+        del os.environ["ZERODOX_AGENT_API_KEY_TEST"]
+
+    monitor = ProjectMonitor(bot, config)
+    project = monitor.projects["zerodox"]
+    return monitor, project, channel
+
+
+@pytest.mark.asyncio
+async def test_db_pool_saturation_above_threshold_triggers_alert(tmp_path):
+    """DB-Pool > 80% → HIGH-Alert in ci-zerodox."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    fake_stats = {
+        "timestamp": "2026-04-26T20:00:00Z",
+        "dbPool": {"active": 85, "idle": 5, "total": 90, "max": 100, "saturationPercent": 90},
+        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
+    }
+    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+
+    await monitor._check_db_pool_saturation(project)
+
+    channel.send.assert_called_once()
+    sent_embed = channel.send.call_args.kwargs["embed"]
+    assert "DB-Pool-Saturation hoch" in sent_embed.title
+    assert sent_embed.color.value == Severity.HIGH.color
+
+
+@pytest.mark.asyncio
+async def test_db_pool_saturation_below_threshold_no_alert(tmp_path):
+    """DB-Pool <= 80% → kein Alert."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    fake_stats = {
+        "dbPool": {"active": 10, "idle": 5, "total": 15, "max": 100, "saturationPercent": 15},
+        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
+    }
+    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+
+    await monitor._check_db_pool_saturation(project)
+
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failed_login_rate_above_threshold_triggers_alert(tmp_path):
+    """Failed-Login > 100 in 5 Min → HIGH-Alert in critical."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    fake_stats = {
+        "dbPool": {"saturationPercent": 5},
+        "failedLogins": {"count": 200, "windowMinutes": 5, "uniqueEmails": 50},
+    }
+    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+
+    await monitor._check_failed_login_rate(project)
+
+    channel.send.assert_called_once()
+    sent_embed = channel.send.call_args.kwargs["embed"]
+    assert "Failed-Login-Rate hoch" in sent_embed.title
+
+
+@pytest.mark.asyncio
+async def test_failed_login_rate_extreme_volume_critical_severity(tmp_path):
+    """Failed-Login > 500 (5x Threshold) → CRITICAL-Severity."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    fake_stats = {
+        "dbPool": {"saturationPercent": 5},
+        "failedLogins": {"count": 600, "windowMinutes": 5, "uniqueEmails": 5},
+    }
+    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+
+    await monitor._check_failed_login_rate(project)
+
+    channel.send.assert_called_once()
+    sent_embed = channel.send.call_args.kwargs["embed"]
+    assert sent_embed.color.value == Severity.CRITICAL.color
+
+
+@pytest.mark.asyncio
+async def test_failed_login_rate_below_threshold_no_alert(tmp_path):
+    """Failed-Login <= 100 → kein Alert."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    fake_stats = {
+        "dbPool": {"saturationPercent": 5},
+        "failedLogins": {"count": 50, "windowMinutes": 5, "uniqueEmails": 30},
+    }
+    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+
+    await monitor._check_failed_login_rate(project)
+
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_app_health_check_skip_when_no_endpoint_configured(tmp_path):
+    """Kein internal_health_endpoint → graceful skip ohne Crash."""
+    # _build_monitor (ohne _with_api) hat KEIN internal_health_endpoint
+    monitor, project, channel = _build_monitor(project_path=str(tmp_path))
+
+    await monitor._check_db_pool_saturation(project)
+    await monitor._check_failed_login_rate(project)
+
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_app_health_check_skip_when_api_key_missing(tmp_path):
+    """Kein API-Key in env → graceful skip."""
+    monitor, project, channel = _build_monitor_with_api(api_key=None)
+
+    # _fetch_app_health_stats sollte None returnen wenn Key fehlt
+    result = await monitor._fetch_app_health_stats(project)
+    assert result is None
+
+    # Folge: Checks senden nichts
+    await monitor._check_db_pool_saturation(project)
+    await monitor._check_failed_login_rate(project)
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_app_health_check_recovery_clears_cooldown(tmp_path):
+    """Nach Recovery (Wert wieder OK) sollte Cooldown geloescht werden."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    # 1. Trigger: hohe Saturation → Alert + Cooldown
+    monitor._fetch_app_health_stats = AsyncMock(return_value={
+        "dbPool": {"saturationPercent": 95},
+        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
+    })
+    await monitor._check_db_pool_saturation(project)
+    assert channel.send.call_count == 1
+    cooldown_key = f"{project.name}:db_pool_saturation"
+    assert cooldown_key in monitor._health_check_alerts
+
+    # Min-Intervall zuruecksetzen, damit Recovery-Run direkt laeuft
+    if cooldown_key in monitor._health_check_last_run:
+        del monitor._health_check_last_run[cooldown_key]
+
+    # 2. Recovery: niedrige Saturation → kein Alert + Cooldown geloescht
+    monitor._fetch_app_health_stats = AsyncMock(return_value={
+        "dbPool": {"saturationPercent": 10},
+        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
+    })
+    await monitor._check_db_pool_saturation(project)
+    # Channel.send wurde nur 1x gerufen (initial), nicht 2x
+    assert channel.send.call_count == 1
+    assert cooldown_key not in monitor._health_check_alerts


### PR DESCRIPTION
## 🛡️ Phase 5c — App-Health-Checks komplett

Erweitert `ProjectMonitor` um zwei App-Insight-Checks die per HTTP-Polling die ZERODOX `/api/internal/health-stats` Route aus Phase 5a abfragen.

### Neue Checks

| Check | Schwelle | Channel | Severity |
|-------|----------|---------|----------|
| `_check_db_pool_saturation` | > 80% | `🧪-ci-zerodox` | HIGH |
| `_check_failed_login_rate` | > 100 / 5 Min | `🚨-critical` | HIGH (CRITICAL > 500) |

### Helper-Methode

`_fetch_app_health_stats()` macht den HTTP-Call mit `aiohttp` + `X-Agent-Key` Header. **Graceful skip** wenn:
- `internal_health_endpoint` nicht in config.yaml
- API-Key env-var nicht gesetzt
- HTTP 4xx/5xx oder Timeout
- JSON-Parse-Error

### Tests

**21/21 Tests grün** (13 Phase 5b + 8 neu für Phase 5c):
- DB-Pool above/below threshold
- Failed-Login above/below + extreme volume → CRITICAL severity
- Skip wenn endpoint/key fehlt
- Recovery löscht Cooldown

### Doku

Neue Datei `docs/runbooks/health-checks-overview.md` mit kompletter 7-Check-Tabelle, Defense-in-Depth-Map, Auth-Setup, Anti-Spam-Pattern.

### Auth-Setup (gitignored, manuell)

Bot-`.env` ergänzt um `ZERODOX_AGENT_API_KEY` (gleicher Wert wie ZERODOX-`.env`). Bei Rotation in beiden synchron updaten.

### Schließt Issue #278

Mit diesem PR sind alle 7 Health-Checks aus Issue #278 implementiert: Disk, Memory, Restart-Count, SSL, Backup (Phase 5b) + DB-Pool, Failed-Login (Phase 5c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
