### PR TITLE
⚡ Optimize N+1 Query in SEO Agent Stats

### DIFF
--- a/benchmark_seo_stats.py
+++ b/benchmark_seo_stats.py
@@ -1,0 +1,44 @@
+import asyncio
+import time
+from unittest.mock import MagicMock, AsyncMock
+
+async def benchmark():
+    # Mock pool
+    class MockPool:
+        async def fetchval(self, query):
+            await asyncio.sleep(0.01) # simulated network latency
+            return 42
+
+        async def fetchrow(self, query):
+            await asyncio.sleep(0.01) # simulated network latency
+            return {'impact_count': 42, 'cross_knowledge': 42}
+
+    pool = MockPool()
+
+    # Original approach
+    start_orig = time.time()
+    for _ in range(100):
+        impact_count = await pool.fetchval("SELECT COUNT(*) FROM seo_fix_impact")
+        cross_knowledge = await pool.fetchval("SELECT COUNT(*) FROM agent_knowledge")
+    end_orig = time.time()
+
+    # Optimized approach
+    start_opt = time.time()
+    for _ in range(100):
+        row = await pool.fetchrow("""
+            SELECT
+                (SELECT COUNT(*) FROM seo_fix_impact) as impact_count,
+                (SELECT COUNT(*) FROM agent_knowledge) as cross_knowledge
+        """)
+        impact_count = row['impact_count']
+        cross_knowledge = row['cross_knowledge']
+    end_opt = time.time()
+
+    orig_time = end_orig - start_orig
+    opt_time = end_opt - start_opt
+
+    print(f"Original Time: {orig_time:.4f}s")
+    print(f"Optimized Time: {opt_time:.4f}s")
+    print(f"Improvement: {(orig_time - opt_time) / orig_time * 100:.2f}%")
+
+asyncio.run(benchmark())

--- a/src/cogs/inspector.py
+++ b/src/cogs/inspector.py
@@ -216,17 +216,16 @@ class InspectorCog(commands.Cog):
                 from integrations.patch_notes_learning import PatchNotesLearning
                 pn2 = PatchNotesLearning()
                 await pn2.connect()
-                impact_count = await pn2.pool.fetchval(
-                    "SELECT COUNT(*) FROM seo_fix_impact"
-                )
-                cross_knowledge = await pn2.pool.fetchval(
-                    "SELECT COUNT(*) FROM agent_knowledge"
-                )
+                row = await pn2.pool.fetchrow("""
+                    SELECT
+                        (SELECT COUNT(*) FROM seo_fix_impact) as impact_count,
+                        (SELECT COUNT(*) FROM agent_knowledge) as cross_knowledge
+                """)
                 await pn2.close()
 
                 seo_text = (
-                    f"**Fix-Impacts gemessen:** {impact_count}\n"
-                    f"**Cross-Agent Knowledge:** {cross_knowledge} Einträge"
+                    f"**Fix-Impacts gemessen:** {row['impact_count']}\n"
+                    f"**Cross-Agent Knowledge:** {row['cross_knowledge']} Einträge"
                 )
                 embed.add_field(name="🔍 SEO Agent", value=seo_text, inline=True)
             except Exception:

--- a/test_verify.py
+++ b/test_verify.py
@@ -1,0 +1,8 @@
+import sys
+from unittest.mock import MagicMock
+sys.modules['discord'] = MagicMock()
+sys.modules['discord.ext'] = MagicMock()
+sys.modules['discord.ext.commands'] = MagicMock()
+sys.modules['discord.app_commands'] = MagicMock()
+from src.cogs.inspector import InspectorCog
+print("Success")


### PR DESCRIPTION
💡 **What:** 
Replaced two sequential `fetchval` statements gathering count data from the `seo_fix_impact` and `agent_knowledge` tables with a single `fetchrow` query utilizing subqueries. 

🎯 **Why:** 
The previous implementation performed two back-to-back database round trips over the network to gather simple aggregation statistics. This N+1 query pattern creates unnecessary latency, especially under load or slow network conditions.

📊 **Measured Improvement:** 
A benchmark simulating a 10ms network latency per database call was run 100 times.
- **Original Time:** 2.1335s
- **Optimized Time:** 1.0415s
- **Improvement:** 51.18%

The simulated network latency test confirmed that halving the database network round-trips correctly results in a ~50% reduction in execution time for this block of code.

---
*PR created automatically by Jules for task [5773065101300874725](https://jules.google.com/task/5773065101300874725) started by @Commandershadow9*