### PR TITLE
docs: korrigiere Slash-Command-Liste, Projektstruktur und API-Referenz

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,27 +242,38 @@ projects:
 - **GitHub Events** - Detaillierte Patch-Notes für Push, PR und Release Events
 - **Deployment Status** - Real-time deployment progress
 
-### 🤖 Slash Commands
+### Slash Commands
 
 #### Security & Monitoring
 - `/status` - Gesamt-Sicherheitsstatus
-- `/scan` - Manuellen Docker-Scan triggern
-- `/threats` - Letzte erkannte Bedrohungen
-- `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
+- `/scan` - Manuellen Docker-Scan triggern (Administrator)
+- `/threats [hours]` - Letzte erkannte Bedrohungen
+- `/bans [limit]` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letzte Docker Scan Ergebnisse
 
 #### Auto-Remediation
-- `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
-- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/remediation-stats` - Auto-Remediation Statistiken (Administrator)
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes (Administrator)
+- `/set-approval-mode [mode]` - Ändere Approval Mode: paranoid/auto/dry-run (Administrator)
+- `/release-notes <project>` - Patch Notes fuer gesammelte Commits veröffentlichen (Administrator)
+- `/pending-notes` - Zeige ausstehende Commits die auf Release warten (Administrator)
+- `/mark-duplicate <parent_id> <child_id>` - Finding als Duplikat markieren
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
-- `/reload-context` - Lade Project-Context neu
+- `/agent-stats` - Agent-Learning Statistiken
+- `/reload-context` - Lade Project-Context neu (Administrator)
 
 #### Multi-Project Management
-- `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
+- `/projekt-status <name>` - Status fuer spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+
+#### Security Engine
+- `/security-engine` - Security Engine v6 Status und Statistiken
+
+#### Customer Setup
+- `/setup-customer-server` - Monitoring-Channels auf Kunden-Server einrichten (Administrator)
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -438,23 +449,29 @@ deployment:
 ```
 Security Commands:
   /status              - Gesamt-Sicherheitsstatus
-  /scan                - Docker Security Scan
+  /scan                - Docker Security Scan (Admin)
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
   /aide                - AIDE Check-Status
+  /docker              - Letzte Docker Scan Ergebnisse
 
 Auto-Remediation:
-  /remediation-stats             - Statistiken
-  /stop-all-fixes                - Emergency Stop
-  /set-approval-mode [mode]      - Approval Mode ändern
+  /remediation-stats             - Statistiken (Admin)
+  /stop-all-fixes                - Emergency Stop (Admin)
+  /set-approval-mode [mode]      - Approval Mode aendern (Admin)
+  /release-notes <project>       - Patch Notes veroeffentlichen (Admin)
+  /pending-notes                 - Ausstehende Commits anzeigen (Admin)
+  /mark-duplicate <p> <c>        - Finding als Duplikat markieren
 
-AI System:
+AI & Security Engine:
   /get-ai-stats                  - AI Provider Status
-  /reload-context                - Context neu laden
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
+  /reload-context                - Context neu laden (Admin)
 
 Multi-Project:
-  /projekt-status [name]         - Detaillierter Projekt-Status
-  /alle-projekte                 - Übersicht aller Projekte
+  /projekt-status <name>         - Detaillierter Projekt-Status
+  /alle-projekte                 - Uebersicht aller Projekte
 ```
 
 ### GitHub Webhook Setup
@@ -472,15 +489,11 @@ Multi-Project:
 pip3 install -r requirements.txt
 pip3 install -r requirements-dev.txt
 
-# Tests ausführen
-pytest tests/ -v
+# Tests ausfuehren (immer einzeln mit -x; nie pytest tests/ ohne -x auf 8 GB VPS)
+pytest tests/unit/test_NAME.py -x -v
 
-# Mit Coverage
-pytest tests/ --cov=src --cov-report=html
-
-# Einzelne Test-Kategorie
-pytest tests/unit/ -v
-pytest tests/integration/ -v
+# Mit Coverage (einzelnes Modul)
+pytest tests/unit/test_NAME.py -x --cov=src --cov-report=html
 
 # Bot lokal testen
 python3 src/bot.py
@@ -492,87 +505,74 @@ tail -f logs/shadowops.log
 sudo systemctl restart shadowops-bot
 ```
 
-## 📁 Projekt-Struktur
+## Projekt-Struktur
 
 ```
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
+│   ├── cogs/                           # Slash Commands (auto-geladen)
 │   │   ├── admin.py
 │   │   ├── inspector.py
-│   │   └── monitoring.py
+│   │   ├── monitoring.py
+│   │   ├── cron_heartbeat.py
+│   │   └── customer_setup_commands.py
+│   ├── commands/                       # Optionale Cogs (manuell laden)
+│   │   ├── ai_learning_admin.py
+│   │   └── knowledge_stats.py
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (Package)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules Workflow (Package)
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
+│   │   ├── security_engine/            # SecurityScanAgent v6 (Package)
+│   │   ├── fixers/                     # Fix-Adapter (fail2ban, crowdsec, aide, trivy, walg)
+│   │   ├── analyst/                    # Legacy Security Analyst (Referenz)
+│   │   ├── ai_learning/                # Continuous Learning Agent
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
+│   ├── patch_notes/                    # Patch Notes Pipeline v6 (Package)
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       └── discord_logger.py           # Discord Channel Logger
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (161)
-│   │   ├── test_config.py
-│   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
-│   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
-│   │   ├── test_orchestrator.py
-│   │   ├── test_knowledge_base.py
-│   │   ├── test_event_watcher.py
-│   │   ├── test_github_integration.py
-│   │   ├── test_project_monitor.py
-│   │   └── test_incident_manager.py
-│   └── integration/
-│       └── test_learning_workflow.py   # End-to-End Tests
+│   ├── unit/                           # Unit Tests
+│   └── integration/                    # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
+│   ├── config.example.yaml             # Template (committed)
+│   ├── config.yaml                     # Hauptconfig (gitignored)
 │   ├── DO-NOT-TOUCH.md                 # Safety Rules
 │   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
-│   ├── config.recommended.yaml         # Empfehlungen
-│   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
-├── deploy/                             # Deployment
+│   └── PROJECT_*.md                    # Per-Projekt-Notizen
+├── deploy/
 │   └── shadowops-bot.service           # systemd Unit
-├── scripts/                            # Utility-Skripte
+├── scripts/
 │   ├── restart.sh                      # Bot neustarten (--pull, --logs)
-│   ├── diagnose-bot.sh                 # Diagnose
-│   ├── setup.sh                        # Erstinstallation
 │   └── ...
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
-├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+├── docs/
+│   ├── reference/api.md                # API-Referenz
 │   ├── adr/                            # Architecture Decision Records
-│   ├── plans/                          # Design-Dokumente
-│   └── archive/                        # Historische Doku
+│   └── plans/                          # Design-Dokumente
 ├── .claude/                            # KI-Konfiguration
-│   ├── rules/                          # Pfad-gefilterte Rules
-│   ├── skills/                         # Workflow-Skills
-│   └── agents/                         # Spezialisierte Agents
-├── requirements.txt                    # Python Dependencies
-├── pyproject.toml                      # Projekt-Definition
+├── requirements.txt
+├── pyproject.toml
 ├── CLAUDE.md                           # KI-Projektinstruktionen
 ├── CHANGELOG.md                        # Version History
 └── README.md                           # This file

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,11 +1,11 @@
 ---
-title: 🔧 ShadowOps API Documentation v5.1
+title: ShadowOps API Documentation
 status: active
-last_reviewed: 2026-04-15
+last_reviewed: 2026-04-28
 owner: CommanderShadow9
 ---
 
-# 🔧 ShadowOps API Documentation v5.1
+# ShadowOps API Documentation
 
 Complete API reference for ShadowOps Security Guardian.
 
@@ -164,10 +164,9 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
-- Active fallback chain
+- Codex CLI status (primary engine, active model, quota)
+- Claude CLI status (fallback engine, active model)
+- Active routing rules (CRITICAL/HIGH/LOW → engine + model)
 - Request counts per provider
 
 **Example:**
@@ -268,23 +267,30 @@ channels:
 # AI CONFIGURATION
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  primary:
+    engine: codex
+    models:
+      fast: gpt-4o
+      standard: gpt-5.3-codex
+      thinking: o3
+    timeout: 300
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  fallback:
+    engine: claude
+    cli_path: /home/user/.local/bin/claude
+    models:
+      fast: claude-sonnet-4-6
+      standard: claude-sonnet-4-6
+      thinking: claude-opus-4-6
+    timeout: 300
+
+  routing:
+    critical_analysis: { engine: codex, model: thinking }
+    high_analysis:     { engine: codex, model: standard }
+    low_analysis:      { engine: codex, model: fast }
+    critical_verify:   { engine: claude, model: thinking }
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -582,8 +588,8 @@ Fallback auf das jeweils andere Modell bei Timeout oder leerer Response.
 ```python
 from src.integrations.knowledge_base import KnowledgeBase
 
-# Initialize
-kb = KnowledgeBase(db_path="data/knowledge_base.db")
+# Initialize (DSN from config or SECURITY_ANALYST_DB_URL env var)
+kb = KnowledgeBase(dsn="postgresql://user:pass@localhost/security_analyst")
 
 # Record a fix
 kb.record_fix(
@@ -791,29 +797,20 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+### Security Analyst DB (PostgreSQL — `security_analyst`)
 
-#### fixes table
-```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
-    severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
-    duration_seconds REAL,
-    error_message TEXT,
-    retry_count INTEGER DEFAULT 0
-);
+The bot uses asyncpg with a connection pool (min 2, max 5).
+DSN from `config.security_analyst_dsn` or env `SECURITY_ANALYST_DB_URL`.
 
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
-```
+Key tables: `fix_attempts_v2`, `remediation_status`, `findings`,
+`jules_pr_reviews`, `jules_daily_stats` (view).
+
+### Agent Learning DB (PostgreSQL — `agent_learning`)
+
+DSN from `config.agent_learning_dsn` or env `AGENT_LEARNING_DB_URL`.
+
+Key tables: `agent_feedback`, `agent_quality_scores`, `agent_knowledge`,
+`pn_generations`, `pn_variants`, `pn_examples`, `jules_review_examples`.
 
 ### Project Monitor State (JSON)
 
@@ -873,9 +870,9 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 - `Missing required field: discord.token` - Required config missing
 
 #### AI Service Errors
-- `No AI providers enabled` - All AI services disabled
-- `Ollama connection failed` - Cannot reach Ollama server
-- `AI request timeout` - AI provider took too long
+- `No AI providers enabled` - All AI services disabled (`ai.enabled: false`)
+- `Codex CLI not found` - `codex` binary missing from PATH
+- `AI request timeout` - AI provider exceeded configured timeout
 
 #### Deployment Errors
 - `Project not found in deployment config` - Unknown project
@@ -894,9 +891,8 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI (primary)**: Timeout configurable via `ai.primary.timeout` (default: 300s)
+- **Claude CLI (fallback)**: Timeout configurable via `ai.fallback.timeout` (default: 300s); automatic fallback on quota or timeout
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)
@@ -951,12 +947,12 @@ debug_mode: true
 
 ### Common API Issues
 
-**Knowledge Base locked:**
+**Knowledge Base connection issues:**
 ```bash
-# Check if database is locked
-sqlite3 data/knowledge_base.db "PRAGMA busy_timeout=5000;"
+# Check PostgreSQL connectivity
+psql "$SECURITY_ANALYST_DB_URL" -c "SELECT 1;"
 
-# If still locked, restart bot
+# Restart bot (pool will reconnect)
 sudo systemctl restart shadowops-bot
 ```
 


### PR DESCRIPTION
## Drift-Korrekturen — README + docs/reference/api.md

### README.md

- **Slash-Commands**: Alle Commands aus `src/cogs/` dokumentiert. Bisher fehlten: `/docker`, `/agent-stats`, `/security-engine`, `/release-notes`, `/pending-notes`, `/mark-duplicate`, `/setup-customer-server`. Administrator-Anforderungen sind jetzt markiert.
- **pytest-Befehle**: `pytest tests/ -v` ohne `-x` durch korrektes Muster ersetzt (`pytest tests/unit/test_NAME.py -x -v`). Grund: Safety-Rule in `.claude/rules/safety.md` — auf 8 GB VPS nie `pytest tests/` ohne `-x`.
- **Doppelter `config/`-Block**: Zeilen mit dem duplizierten config-Abschnitt entfernt.
- **Projektstruktur**: `orchestrator.py` und `github_integration.py` als Packages gekennzeichnet, `src/patch_notes/`, `src/commands/`, `security_engine/`, `fixers/`, `analyst/`, `ai_learning/` ergaenzt. `cron_heartbeat.py` und `customer_setup_commands.py` in Cogs-Liste aufgenommen.

### docs/reference/api.md

- **Ollama entfernt**: Alle Referenzen auf Ollama (`ai.ollama.*`) aus Config-Referenz, Rate-Limiting, Error-Codes und `/get-ai-stats`-Beschreibung entfernt. Ollama wurde in v4.0 vollstaendig aus dem Stack entfernt (1364 Zeilen Dead Code).
- **AI-Config-Referenz**: Zeigt jetzt den echten Stack: Codex CLI (Primary) + Claude CLI (Fallback) mit Routing-Regeln.
- **Knowledge Base**: Von SQLite auf PostgreSQL korrigiert — `security_analyst` und `agent_learning` DBs dokumentiert.
- **KnowledgeBase-Signatur**: `db_path=` → `dsn=` (passt zur echten `__init__`-Signatur).
- **Troubleshooting**: SQLite-Lock-Hinweis durch PostgreSQL-Check ersetzt.
- **Frontmatter**: `last_reviewed` auf 2026-04-28 aktualisiert.

---

Labels: `status:routine-generated`, `worker:doku`, `type:docs`

https://claude.ai/code/session_01SPFA7L4fHQn3xPeBaLADW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPFA7L4fHQn3xPeBaLADW4)_