### PR TITLE
docs: sync README, CLAUDE.md, api.md with current codebase state

### DIFF
--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,13 +2,20 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": null,
-  "last_drift_check": null,
+  "last_run": "2026-05-01T00:00:00Z",
+  "last_drift_check": "2026-05-01T00:00:00Z",
   "open_prs": [],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": null },
-    "CLAUDE.md": { "last_synced_with_code_at": null },
-    "docs/reference/api.md": { "last_synced_with_code_at": null }
+    "README.md": { "last_synced_with_code_at": "2026-05-01T00:00:00Z" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-01T00:00:00Z" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-01T00:00:00Z" }
   },
-  "open_questions": []
+  "open_questions": [
+    {
+      "id": "antibloom-readme-highlights",
+      "file": "README.md",
+      "created": "2026-05-01",
+      "note": "README ist 773+ Zeilen (Schwelle: 500). Highlights v3.1–v3.4 sind veraltet (aktuell v5.1). Vorschlag: in CHANGELOG.md auslagern und Sektion aus README entfernen. Warten auf Bestaetigung durch Maintainer."
+    }
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,11 @@
 shadowops-bot/
 ├── src/
 │   ├── bot.py                    # Haupt-Bot
-│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring)
+│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring, customer_setup_commands, cron_heartbeat)
+│   ├── commands/                 # Standalone-Command-Handler (ai_learning_admin, knowledge_stats)
 │   ├── integrations/             # Externe Systeme (siehe unten)
+│   ├── patch_notes/              # Patch-Notes-Pipeline v6 (5-Stufen State Machine)
+│   ├── schemas/                  # JSON-Schemas fuer Structured Output (Codex)
 │   └── utils/                    # config, logging, embeds, state
 ├── tests/
 │   ├── unit/                     # 161+ Unit-Tests
@@ -72,20 +75,61 @@ shadowops-bot/
 
 ### Module unter `src/integrations/`
 
+**Kern-AI:**
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
+- `approval_modes.py` — Approval-Mode-Logik (paranoid/auto/dry-run)
+
+**Orchestrierung:**
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (Paket mit Mixins)
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
-- `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
+- `auto_fix_manager.py` — Fix-Manager-Koordination
+- `backup_manager.py` — Backup vor destruktiven Aktionen
+- `self_healing.py` — Self-Healing-Koordinator
+- `service_manager.py` — Systemd-Service-Management
+- `command_executor.py` — Sichere Shell-Kommando-Ausfuehrung
+
+**Wissen & Lernen:**
+- `knowledge_base.py` — SQL Learning (PostgreSQL, security_analyst DB)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
+- `git_history_analyzer.py` — Git-Commit-Analyse
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
+- `log_analyzer.py` — Log-Pattern-Analyse
+- `learning_notifier.py` — Discord-Benachrichtigungen fuer Agent-Learning
+- `ai_learning/` — AI-Learning-Subsystem (separate Tabellen in agent_learning DB)
+- `llm_fine_tuning.py` — Fine-Tuning Export (JSONL/LoRA)
+- `prompt_ab_testing.py` — A/B-Testing fuer Prompts
+- `prompt_auto_tuner.py` — Auto-Tuning Engine
+
+**GitHub-Integration:**
+- `github_integration/` — Webhooks + Jules-Workflow + Multi-Agent-Review (Paket mit Mixins)
+
+**Sicherheits-Engine:**
+- `security_engine/` — SecurityScanAgent, CircuitBreaker, DB, Fixers, Prompts (siehe CLAUDE.md Safety)
+- `fixers/` — Einzelne Fixer-Adapter (aide, crowdsec, fail2ban, trivy, walg)
+
+**Multi-Projekt:**
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
+- `customer_server_setup.py` — Guild-Setup fuer Customer-Channels
+- `guildscout_alerts.py` — GuildScout-spezifische Alert-Logik
+- `impact_analyzer.py` — Projekt-Impact-Analyse vor Fix
+
+**Patch Notes:**
+- `patch_notes_batcher.py` / `patch_notes_feedback.py` / `patch_notes_learning.py` — Batch-System
+- `patch_notes_trainer.py` / `patch_notes_web_exporter.py` — Training + Web-Export
+- `changelog_db.py` — Changelog-Datenbank-Interface
+
+**Sonstiges:**
 - `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
+- `docker_image_analyzer.py` — Docker-Image-Analyse (Trivy-Output-Parsing)
+- `content_sanitizer.py` — Sanitierung von AI-Output (Pfade, IPs, Secrets)
+- `research_fetcher.py` — Externe CVE/Advisory-Recherche
+- `server_assistant.py` — Server-Assistent-Integration
+- `analyst/` — Alter Security-Analyst (deprecated, Referenz behalten)
 
 ## Coding-Conventions
 

--- a/README.md
+++ b/README.md
@@ -247,22 +247,33 @@ projects:
 #### Security & Monitoring
 - `/status` - Gesamt-Sicherheitsstatus
 - `/scan` - Manuellen Docker-Scan triggern
-- `/threats` - Letzte erkannte Bedrohungen
-- `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
+- `/threats [hours]` - Letzte erkannte Bedrohungen (Standard: 24h)
+- `/bans [limit]` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letzte Docker-Scan-Ergebnisse (Trivy)
 
 #### Auto-Remediation
 - `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes
 - `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
 - `/reload-context` - Lade Project-Context neu
+- `/agent-stats` - Agent-Learning Statistiken (DB-Metriken)
+- `/security-engine` - Security Engine v6 Status und Statistiken
+
+#### Patch Notes
+- `/release-notes [project]` - Manueller Batch-Release fuer ein Projekt (Admin)
+- `/pending-notes` - Uebersicht aller ausstehenden Batches
+- `/mark-duplicate [parent_id] [child_id]` - Markiert Eintrag als Duplikat (Admin)
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+
+#### Admin
+- `/setup-customer-server` - Richtet Monitoring-Channels für GuildScout ein (Admin)
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -442,19 +453,30 @@ Security Commands:
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
   /aide                - AIDE Check-Status
+  /docker              - Letzte Docker-Scan-Ergebnisse (Trivy)
 
 Auto-Remediation:
   /remediation-stats             - Statistiken
   /stop-all-fixes                - Emergency Stop
-  /set-approval-mode [mode]      - Approval Mode ändern
+  /set-approval-mode [mode]      - Approval Mode aendern
 
 AI System:
   /get-ai-stats                  - AI Provider Status
   /reload-context                - Context neu laden
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
+
+Patch Notes:
+  /release-notes [project]       - Manueller Batch-Release
+  /pending-notes                 - Ausstehende Batches
+  /mark-duplicate [p] [c]        - Duplikat markieren
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+
+Admin:
+  /setup-customer-server         - GuildScout Monitoring-Channels einrichten
 ```
 
 ### GitHub Webhook Setup
@@ -498,10 +520,12 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
+│   ├── cogs/                           # Modulare Slash Commands
 │   │   ├── admin.py
 │   │   ├── inspector.py
-│   │   └── monitoring.py
+│   │   ├── monitoring.py
+│   │   ├── customer_setup_commands.py
+│   │   └── cron_heartbeat.py
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
@@ -541,17 +565,14 @@ shadowops-bot/
 │   └── integration/
 │       └── test_learning_workflow.py   # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
-│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
+│   ├── config.example.yaml             # Template (committed)
+│   ├── config.yaml                     # Real Config (gitignored)
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
+│   ├── logrotate.conf                  # Log-Rotation
+│   ├── DO-NOT-TOUCH.md                 # Safety Rules
+│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
+│   └── PROJECT_*.md                    # Per-Projekt-Notizen
 ├── deploy/                             # Deployment
 │   └── shadowops-bot.service           # systemd Unit
 ├── scripts/                            # Utility-Skripte
@@ -562,8 +583,9 @@ shadowops-bot/
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
 ├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+│   ├── reference/api.md                # API-Referenz
+│   ├── SECURITY_ANALYST.md             # Security Analyst Doku
+│   ├── SETUP_GUIDE.md                  # Setup-Anleitung
 │   ├── adr/                            # Architecture Decision Records
 │   ├── plans/                          # Design-Dokumente
 │   └── archive/                        # Historische Doku

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -164,11 +164,11 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
+- Codex CLI status (primary engine, model, quota)
+- Claude CLI status (fallback engine, model)
 - Active fallback chain
 - Request counts per provider
+- Last failure reason (if any)
 
 **Example:**
 ```
@@ -268,23 +268,30 @@ channels:
 # AI CONFIGURATION
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  primary:
+    engine: codex
+    models:
+      fast: gpt-4o
+      standard: gpt-5.3-codex
+      thinking: o3
+    timeout: 300
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  fallback:
+    engine: claude
+    cli_path: /home/user/.local/bin/claude  # Path to Claude CLI binary
+    models:
+      fast: claude-sonnet-4-6
+      standard: claude-sonnet-4-6
+      thinking: claude-opus-4-6
+    timeout: 300
+
+  routing:
+    critical_analysis: { engine: codex, model: thinking }
+    high_analysis: { engine: codex, model: standard }
+    low_analysis: { engine: codex, model: fast }
+    critical_verify: { engine: claude, model: thinking }
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -582,8 +589,8 @@ Fallback auf das jeweils andere Modell bei Timeout oder leerer Response.
 ```python
 from src.integrations.knowledge_base import KnowledgeBase
 
-# Initialize
-kb = KnowledgeBase(db_path="data/knowledge_base.db")
+# Initialize (DSN comes from config.security_analyst_dsn or SECURITY_ANALYST_DB_URL env var)
+kb = KnowledgeBase(dsn="postgresql://user:pass@localhost:5433/security_analyst")
 
 # Record a fix
 kb.record_fix(
@@ -791,29 +798,13 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+### Knowledge Base (PostgreSQL — `security_analyst` DB, Port 5433)
 
-#### fixes table
-```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
-    severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
-    duration_seconds REAL,
-    error_message TEXT,
-    retry_count INTEGER DEFAULT 0
-);
+Core tables (subset): `orchestrator_fixes`, `orchestrator_strategies`, `threat_patterns`,
+`orchestrator_plans`, `orchestrator_vulnerabilities`, `fix_attempts_v2`, `remediation_status`,
+`jules_pr_reviews`.
 
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
-```
+DSN: `config.security_analyst_dsn` or env var `SECURITY_ANALYST_DB_URL`.
 
 ### Project Monitor State (JSON)
 
@@ -894,9 +885,8 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI (primary)**: Quota-aware failover; CLI output parsed for limit markers.
+- **Claude CLI (fallback)**: Built-in retry with exponential backoff (1s, 2s, 4s). Timeout per routing rule (120s Sonnet, 180s Opus).
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)
@@ -951,12 +941,13 @@ debug_mode: true
 
 ### Common API Issues
 
-**Knowledge Base locked:**
+**Knowledge Base connection issues:**
 ```bash
-# Check if database is locked
-sqlite3 data/knowledge_base.db "PRAGMA busy_timeout=5000;"
+# Check PostgreSQL connectivity (security_analyst DB, Port 5433)
+psql "$SECURITY_ANALYST_DB_URL" -c "SELECT 1;"
 
-# If still locked, restart bot
+# If unreachable, check service
+sudo systemctl status postgresql
 sudo systemctl restart shadowops-bot
 ```
 


### PR DESCRIPTION
## Doku-Kurator Lauf — 2026-05-01

Routine-generierter PR. Behebt Drift zwischen Code und Dokumentation sowie Luecken in CLAUDE.md.

---

### Drift-Korrekturen (README.md)

- **Fehlende Slash Commands** in beiden Command-Sektionen ergaenzt:
  - `/docker` — Docker-Scan-Ergebnisse (Trivy), monitoring.py
  - `/agent-stats` — Agent-Learning-Statistiken, inspector.py
  - `/security-engine` — Security Engine v6 Status, inspector.py
  - `/release-notes [project]` — manueller Batch-Release, admin.py
  - `/pending-notes` — ausstehende Batches, admin.py
  - `/mark-duplicate [p] [c]` — Duplikat markieren, admin.py
  - `/setup-customer-server` — war nur in Highlights erwaehnt, fehlte in der Command-Liste
- **Doppelter `config/`-Block** in Projekt-Struktur entfernt.
- **`docs/API.md`** → `docs/reference/api.md` korrigiert (Pfad existierte nicht).
- **`cogs/`-Liste** um `customer_setup_commands.py` + `cron_heartbeat.py` ergaenzt.

### Drift-Korrekturen (docs/reference/api.md)

- **Ollama komplett aus Configuration Reference entfernt** und durch aktuelle `ai.primary`/`ai.fallback`-Struktur ersetzt. Ollama wurde in v4.0 entfernt (0 Referenzen im Quellcode).
- **`/get-ai-stats` Response**: Ollama-Zeilen durch Codex CLI / Claude CLI ersetzt.
- **Knowledge Base Python API**: `KnowledgeBase(db_path="data/knowledge_base.db")` (SQLite) → `KnowledgeBase(dsn="...")` (PostgreSQL). `knowledge_base.py` verwendet psycopg2, kein SQLite.
- **Database Schema**: SQLite `CREATE TABLE fixes` durch korrekte PostgreSQL-Beschreibung ersetzt.
- **Troubleshooting**: `sqlite3 data/knowledge_base.db ...` durch `psql "$SECURITY_ANALYST_DB_URL"` ersetzt.
- **Rate Limiting**: Ollama-Zeile durch Codex/Claude-CLI-Beschreibung ersetzt.

### Luecken-Fuellung (CLAUDE.md)

- **Verzeichnisstruktur** um `src/commands/`, `src/patch_notes/`, `src/schemas/` ergaenzt.
- **`src/integrations/`-Modulliste** grundlegend aktualisiert: alle seit v4.0 hinzugekommenen Module aufgenommen (orchestrator/, security_engine/, fixers/, github_integration/, ai_learning/, analyst/, auto_fix_manager, backup_manager, changelog_db, content_sanitizer, docker_image_analyzer, git_history_analyzer, guildscout_alerts, impact_analyzer, learning_notifier, llm_fine_tuning, log_analyzer, prompt_ab_testing, prompt_auto_tuner, research_fetcher, self_healing, server_assistant, service_manager).

### Offene Frage (kein PR — Issue-Kandidat)

README hat 773 Zeilen (Schwelle: 500). Die Highlights-Sektionen v3.1–v3.4 sind bei aktuellem Stand v5.1 veraltet. Vorschlag: in CHANGELOG.md auslagern. Warte auf Bestaetigung, bevor ich das in einem separaten PR umsetze.

---

Labels: `status:routine-generated`, `worker:doku`, `type:docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_017x6HuUgxAPqrPXQfUbr6rs)_