### PR TITLE
fix(cogs): phase_5e_health_aggregator pins() discord.py 2.6+ Migration (#565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # ShadowOps Bot - Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Phase 5e Health-Aggregator Cog**: 5-Min-Status-Embed im `📊-dashboard` Channel
+  postet seit dem discord.py 2.6+ Upgrade nicht mehr. Ursache: `TextChannel.pins()`
+  ist seit discord.py 2.6 ein `AsyncIterator` statt einer awaitable List —
+  `pins = await channel.pins()` warf damit `TypeError`, der vom
+  `with suppress(discord.HTTPException)` nicht gefangen wurde, den embed_loop
+  aber lautlos sterben liess (TypeError ist nicht in `tasks.Loop._valid_exception`).
+  Migriert auf `async for pin in channel.pins():` analog zu `bot.py:2063`.
+  Drift-Detection und Trend-Report waren nicht betroffen (closes #565).
+
 ## [5.0.0] - 2026-04-23
 
 ### Enterprise Level Cleanup & Security Hardening

--- a/src/cogs/phase_5e_health_aggregator.py
+++ b/src/cogs/phase_5e_health_aggregator.py
@@ -457,10 +457,9 @@ class Phase5eHealthAggregator(commands.Cog):
 
             # Editiere bestehendes Bot-Embed wenn moeglich, sonst sende neues
             if self._dashboard_message is None:
-                # 1. Pinned messages durchsuchen
-                with suppress(discord.HTTPException):
-                    pins = await channel.pins()
-                    for pin in pins:
+                # 1. Pinned messages durchsuchen (discord.py 2.6+: pins() ist AsyncIterator)
+                try:
+                    async for pin in channel.pins():
                         if (
                             pin.author.id == self.bot.user.id
                             and pin.embeds
@@ -469,9 +468,11 @@ class Phase5eHealthAggregator(commands.Cog):
                         ):
                             self._dashboard_message = pin
                             break
+                except (discord.HTTPException, discord.Forbidden) as exc:
+                    self.logger.debug("[5e] embed_loop: pins() nicht verfuegbar: %s", exc)
                 # 2. Letzte 20 Bot-Nachrichten durchsuchen
                 if self._dashboard_message is None:
-                    with suppress(discord.HTTPException):
+                    try:
                         async for msg in channel.history(limit=20):
                             if (
                                 msg.author.id == self.bot.user.id
@@ -481,6 +482,8 @@ class Phase5eHealthAggregator(commands.Cog):
                             ):
                                 self._dashboard_message = msg
                                 break
+                    except (discord.HTTPException, discord.Forbidden) as exc:
+                        self.logger.debug("[5e] embed_loop: history() nicht verfuegbar: %s", exc)
 
             if self._dashboard_message is not None:
                 try:

--- a/tests/unit/test_phase_5e_health_aggregator.py
+++ b/tests/unit/test_phase_5e_health_aggregator.py
@@ -1,0 +1,299 @@
+"""Tests fuer Phase-5e Health-Aggregator Cog.
+
+Regressionstest fuer Bug #565: discord.py 2.6+ hat `TextChannel.pins()` von
+einem awaitable List-Returner zu einem AsyncIterator umgebaut. Die alte
+`pins = await channel.pins()` Form wirft daher `TypeError`, der vom
+`with suppress(discord.HTTPException)` nicht mehr gefangen wird und den
+gesamten 5-Min-Status-Embed-Loop killt.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+# Cog-Modul importieren — DB-Pfad in Temp umbiegen
+SRC = Path(__file__).resolve().parents[2] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture
+def cog_module(tmp_path, monkeypatch):
+    """Importiert Cog mit Temp-DB."""
+    import importlib
+
+    # DB-Pfad auf tmp umlenken vor Modul-Import-Init
+    from cogs import phase_5e_health_aggregator as mod
+
+    importlib.reload(mod)
+    monkeypatch.setattr(mod, "DB_PATH", tmp_path / "health_history.db")
+    return mod
+
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    bot.user = MagicMock()
+    bot.user.id = 999
+    bot.wait_until_ready = AsyncMock()
+    return bot
+
+
+@pytest.fixture
+def cog(cog_module, mock_bot):
+    return cog_module.Phase5eHealthAggregator(mock_bot)
+
+
+def _make_async_iterator(items):
+    """Erzeugt einen Async-Iterator fuer Mock-Channels."""
+
+    class _AIter:
+        def __init__(self, data):
+            self._data = list(data)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._data:
+                raise StopAsyncIteration
+            return self._data.pop(0)
+
+    return _AIter(items)
+
+
+def _make_poll_result(cog_module, name="Runner-VM", status="ok"):
+    target = cog_module.HealthTarget(
+        name=name, url="http://test.local/health", role_hint="ci-runner"
+    )
+    response = MagicMock()
+    response.status = status
+    response.host = name
+    response.role = "ci-runner"
+    response.uptime_seconds = 3600
+    response.components = {"docker": {}, "redis": {}}
+    response.critical_alerts = []
+    response.warning_alerts = []
+    response.alerts = []
+    response.http_status = 200
+    return cog_module.PollResult(
+        target=target,
+        polled_at=datetime.now(timezone.utc),
+        response=response,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Regressionstest #565: pins() ist AsyncIterator in discord.py 2.6+
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestEmbedLoopPinsCompat:
+    """pins() darf nicht mehr awaited werden — nur async-for."""
+
+    @pytest.mark.asyncio
+    async def test_pins_is_consumed_via_async_for(self, cog, cog_module):
+        """Smoke: embed_loop nutzt async-for fuer pins(), nicht await."""
+        cog._latest_results = [_make_poll_result(cog_module)]
+
+        channel = MagicMock()
+        channel.pins = MagicMock(return_value=_make_async_iterator([]))
+        channel.history = MagicMock(return_value=_make_async_iterator([]))
+        channel.send = AsyncMock(return_value=MagicMock(spec=discord.Message))
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        # Wenn der alte Code (`pins = await channel.pins()`) noch vorhanden
+        # waere, wuerde ein TypeError fliegen (kann _AIter nicht awaiten).
+        await cog.embed_loop.coro(cog)
+
+        channel.pins.assert_called_once()
+        channel.send.assert_called_once()
+        assert cog._dashboard_message is not None
+
+    @pytest.mark.asyncio
+    async def test_pins_raises_forbidden_falls_back_to_history(self, cog, cog_module):
+        """pins() Forbidden → history() wird trotzdem versucht."""
+        cog._latest_results = [_make_poll_result(cog_module)]
+
+        class _ForbiddenIter:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise discord.Forbidden(MagicMock(status=403, reason="Missing perms"), "no")
+
+        existing_msg = MagicMock(spec=discord.Message)
+        existing_msg.author.id = cog.bot.user.id
+        existing_msg.embeds = [MagicMock(title="ShadowOps Phase 5e — Health-Aggregator")]
+        existing_msg.edit = AsyncMock()
+
+        channel = MagicMock()
+        channel.pins = MagicMock(return_value=_ForbiddenIter())
+        channel.history = MagicMock(return_value=_make_async_iterator([existing_msg]))
+        channel.send = AsyncMock()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog.embed_loop.coro(cog)
+
+        # history-fallback fand existing message und editierte
+        existing_msg.edit.assert_called_once()
+        channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pins_finds_existing_pinned_dashboard_embed(self, cog, cog_module):
+        """Wenn ein Phase-5e Embed gepinnt ist, wird es geladen + editiert."""
+        cog._latest_results = [_make_poll_result(cog_module)]
+
+        pinned = MagicMock(spec=discord.Message)
+        pinned.author.id = cog.bot.user.id
+        pinned.embeds = [MagicMock(title="🟢 ShadowOps Phase 5e — Health-Aggregator")]
+        pinned.edit = AsyncMock()
+
+        channel = MagicMock()
+        channel.pins = MagicMock(return_value=_make_async_iterator([pinned]))
+        channel.history = MagicMock(return_value=_make_async_iterator([]))
+        channel.send = AsyncMock()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog.embed_loop.coro(cog)
+
+        pinned.edit.assert_called_once()
+        assert cog._dashboard_message is pinned
+        channel.send.assert_not_called()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Generelle Resilienz: embed_loop darf nicht silent sterben
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestEmbedLoopResilience:
+    @pytest.mark.asyncio
+    async def test_no_results_returns_silently(self, cog):
+        """Beim ersten Loop ohne Poll-Ergebnisse → silent return."""
+        cog._latest_results = []
+        channel = MagicMock()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog.embed_loop.coro(cog)
+
+        channel.send.assert_not_called() if hasattr(channel.send, "assert_not_called") else None
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found_returns_silently(self, cog, cog_module):
+        """get_channel returnt None → silent return, kein Crash."""
+        cog._latest_results = [_make_poll_result(cog_module)]
+        cog.bot.get_channel = MagicMock(return_value=None)
+
+        await cog.embed_loop.coro(cog)  # darf nicht raisen
+
+    @pytest.mark.asyncio
+    async def test_edit_notfound_falls_back_to_send(self, cog, cog_module):
+        """Wenn Cached-Message weg ist, wird neue Nachricht gesendet."""
+        cog._latest_results = [_make_poll_result(cog_module)]
+
+        stale_msg = MagicMock(spec=discord.Message)
+        stale_msg.edit = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404, reason="x"), "x"))
+        cog._dashboard_message = stale_msg
+
+        new_msg = MagicMock(spec=discord.Message)
+        new_msg.pin = AsyncMock()
+
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=new_msg)
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog.embed_loop.coro(cog)
+
+        stale_msg.edit.assert_called_once()
+        channel.send.assert_called_once()
+        assert cog._dashboard_message is new_msg
+
+    @pytest.mark.asyncio
+    async def test_outer_exception_is_caught_and_logged(self, cog, cog_module):
+        """Unerwarteter Fehler killt den Loop nicht (logger.exception)."""
+        cog._latest_results = [_make_poll_result(cog_module)]
+        cog.logger = MagicMock()
+
+        channel = MagicMock()
+        # Provoziere TypeError durch kaputte pins()
+        channel.pins = MagicMock(side_effect=TypeError("kaputt"))
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog.embed_loop.coro(cog)  # darf nicht raisen
+
+        cog.logger.exception.assert_called_once()
+        assert "[5e] embed_loop" in cog.logger.exception.call_args[0][0]
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Drift-Embed: discord.NotFound darf nicht den Loop killen
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestDriftHandling:
+    @pytest.mark.asyncio
+    async def test_drift_first_run_no_alert(self, cog, cog_module):
+        """Erster Lauf lernt nur, alertet nicht."""
+        result = _make_poll_result(cog_module, status="ok")
+
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog._handle_drifts([result])
+
+        assert cog._last_status_per_host[result.target.name] == "ok"
+        channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drift_status_change_sends_embed(self, cog, cog_module):
+        """Status-Wechsel ok → critical loest Embed aus."""
+        cog._last_status_per_host = {"Runner-VM": "ok"}
+        result = _make_poll_result(cog_module, name="Runner-VM", status="critical")
+
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog._handle_drifts([result])
+
+        channel.send.assert_called_once()
+        assert cog._last_status_per_host["Runner-VM"] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_drift_no_change_no_embed(self, cog, cog_module):
+        """Identischer Status → kein Embed."""
+        cog._last_status_per_host = {"Runner-VM": "degraded"}
+        result = _make_poll_result(cog_module, name="Runner-VM", status="degraded")
+
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog._handle_drifts([result])
+
+        channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drift_http_error_does_not_kill_loop(self, cog, cog_module):
+        """HTTPException beim Senden wird gefangen + geloggt."""
+        cog._last_status_per_host = {"Runner-VM": "ok"}
+        cog.logger = MagicMock()
+        result = _make_poll_result(cog_module, name="Runner-VM", status="critical")
+
+        channel = MagicMock()
+        channel.send = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(status=500, reason="x"), "fail")
+        )
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog._handle_drifts([result])  # darf nicht raisen
+
+        cog.logger.error.assert_called_once()


### PR DESCRIPTION
## Issue

Closes #565 — Phase 5e Health-Aggregator postet seit 2026-05-02 22:30 kein 5-Min-Status-Embed mehr in `📊-dashboard` (1479615549356114124).

## Root-Cause

**discord.py 2.6 Breaking Change in `TextChannel.pins()`** — von einer awaitable `List[Message]` auf einen `AsyncIterator` (Source: `inspect.signature(discord.TextChannel.pins)` zeigt Return-Type `_PinsIterator`).

Der bisherige Code in `src/cogs/phase_5e_health_aggregator.py:462`:

```python
with suppress(discord.HTTPException):
    pins = await channel.pins()   # discord.py 2.7.1 → TypeError!
    for pin in pins: ...
```

wirft seit dem Upgrade `TypeError: object _PinsIterator can't be used in 'await' expression`. Weil:

1. `TypeError` ist **keine** `discord.HTTPException` → wird vom `suppress` nicht gefangen
2. `TypeError` ist **nicht** in `tasks.Loop._valid_exception` (default: `OSError, GatewayNotFound, ConnectionClosed, aiohttp.ClientError, asyncio.TimeoutError`) → `tasks.loop` retried nicht, sondern killt den Loop nach `_call_loop_function('error', exc)`

→ `embed_loop` ist seit dem Upgrade nach dem ersten Run silent gestorben.

**Nicht betroffen:**
- `_handle_drifts` (DRIFT-Embeds in `🚨-critical`) — nutzt kein `pins()`, postet weiterhin (verifiziert: 11:58/12:13/12:23/12:33 heute)
- `trend_report_loop` (Trend in `📊-dashboard`) — kein `pins()`, postete heute 09:00:00 erfolgreich
- `poll_loop` — pollt weiter (1232/1140/931 Einträge in `health_history.db` letzte 24h)

`src/bot.py:2063` nutzte schon die neue Form (`async for pin in channel.pins()`) — nur diese Cog war zurückgeblieben.

## Diagnose-Logs

```
$ python3 -c "import discord; import inspect; print(inspect.signature(discord.TextChannel.pins))"
(self, *, limit, before, oldest_first) -> '_PinsIterator'

$ ls -la data/health_history.db
-rw-r--r-- 1 cmdshadow cmdshadow 1916928 May 3 14:32  # poll_loop läuft

$ grep DRIFT logs/shadowops_20260503.log | wc -l
81  # nur Runner-VM, weil _last_status_per_host stabil ist

$ Discord-Channel 📊-dashboard letzte Embeds:
  - 2026-05-02 16:04  # letzter embed_loop-Erfolg
  - 2026-05-03 09:00  # trend_report_loop
  ...               # nichts dazwischen → embed_loop tot
```

## Fix

`src/cogs/phase_5e_health_aggregator.py` — embed_loop pins/history-Suche:

- `async for pin in channel.pins():` (statt `pins = await channel.pins(); for pin in pins`)
- `try/except (HTTPException, Forbidden)` + `logger.debug` statt silent `suppress(HTTPException)`
- Damit ist `embed_loop` resilient gegen Permissions-Fehler ohne lautlos zu sterben

## Tests

- 11 neue Unit-Tests in `tests/unit/test_phase_5e_health_aggregator.py`
- `TestEmbedLoopPinsCompat` (3 Tests) — explicit Regression auf #565
- `TestEmbedLoopResilience` (4 Tests) — None-Channel, Edit-Fail, leere Results, outer-Exception-Logging
- `TestDriftHandling` (4 Tests) — first-run, Status-Wechsel, no-change, HTTP-Error

## Smoke-Test-Plan (nach Merge)

- [ ] User: `sudo systemctl restart shadowops-bot` (Bot-Lifecycle ist Worker-extern, siehe Verbote)
- [ ] Logs: `journalctl -u shadowops-bot --since "5 min ago" | grep "[5e]"` — sollte `Phase-5e Health-Aggregator gestartet` zeigen
- [ ] Discord `📊-dashboard`: Innerhalb 5-7 min sollte ein neuer "ShadowOps Phase 5e — Health-Aggregator" Embed erscheinen
- [ ] Pin sollte funktionieren (kein "drift-embed senden fehlgeschlagen")

## Hinweis

**Bot-Restart nach Merge nötig** (User-Aufgabe extern). Der laufende Prozess (PID 2430819 seit 02.05.) ist ein manueller Standalone-Run; systemd-Service ist seit 02.05. 18:32 dead — beim nächsten manuellen Restart oder systemd-Reaktivierung greift der Fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)