### PR TITLE
refactor(monitor): Phase 5c DB-Pool auf Health-Schema v1 (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@
   Migriert auf `async for pin in channel.pins():` analog zu `bot.py:2063`.
   Drift-Detection und Trend-Report waren nicht betroffen (closes #565).
 
+### Refactor — Phase 5c DB-Pool auf Health-Schema v1 migriert (Issue #568)
+
+**ProjectMonitor — partielle Schema-v1-Migration:**
+- Phase-5c **DB-Pool-Saturation-Check** liest jetzt `components.database.pool_saturation_percent` aus dem ZERODOX `/api/internal/health` Endpoint (Schema v1, auth-frei). Vorher pollte der Check den deprecated `/api/internal/health-stats` Endpoint mit X-Agent-Key.
+- Neue Helper-Methode `_fetch_health_schema_v1()` mit Schema-Version-Validation (`schema_version == "1.0"`) und HTTP-200/503-Handling.
+- Endpoint-URL wird aus `monitor.health_v1_endpoint` (neu, optional) ODER per String-Replace aus `internal_health_endpoint` abgeleitet — bestehende Configs funktionieren ohne Änderung weiter.
+- Phase-5c **Failed-Login-Rate-Check** bleibt bewusst auf altem `/api/internal/health-stats` (DEPRECATED, mit `logger.warning` einmal pro Bot-Run): Schema v1 hat noch keine `failed-login`-Komponente. Folge-Issue im ZERODOX-Repo trackt die Schema-Erweiterung, danach Bot-Folge-Issue für Migration. Failed-Login-Detection darf nicht ausfallen (Brute-Force-/Credential-Stuffing-Security).
+
+**Out-of-Scope dokumentiert:**
+- Phase 5a (`/api/internal/health-stats` Endpoint-Schaffung): war ZERODOX-seitig (PR #279). Bot-seitige Konsumenten sind die Phase-5c-Checks.
+- Phase 5b (Disk/Memory/Container/SSL/Backup-Freshness): nutzt SSH/Subprocess, KEIN HTTP-Health-Endpoint. Schema-v1-Migration nicht anwendbar.
+- Phase 5d (Onboarding-Submit-Functional-Smoke): nutzt eigenständigen Probe-Endpoint mit anderem Format (`{ready, checks}`). Migration auf Schema v1 erfordert Cross-Repo-Erweiterung in ZERODOX. Folge-Issue erstellt.
+
+**Tests:**
+- 4 neue Tests für `_fetch_health_schema_v1` (Skip ohne Endpoint, String-Replace-Fallback, Schema-Version-Reject, HTTP-503 für critical).
+- DB-Pool-Tests umgeschrieben auf Schema-v1-Format mit `components.database.pool_saturation_percent`.
+- Failed-Login-Tests unverändert (Legacy-Endpoint).
+- Helper `_schema_v1_body()` für Test-Fixtures.
+
 ## [5.0.0] - 2026-04-23
 
 ### Enterprise Level Cleanup & Security Hardening

--- a/src/integrations/project_monitor.py
+++ b/src/integrations/project_monitor.py
@@ -1317,6 +1317,11 @@ class ProjectMonitor:
     # ════════════════════════════════════════════════════════════════════════
     # Enterprise-Health-Check-Erweiterung (Phase 5b, Issue #278)
     # ════════════════════════════════════════════════════════════════════════
+    # Schema-v1-Migration (Issue #568, 2026-05-03): Phase-5b-Checks (Disk/
+    # Memory/Container-Restarts/SSL/Backup-Freshness) sind SSH- und Subprocess-
+    # basiert (shutil.disk_usage, docker stats, openssl s_client, file mtime)
+    # — sie pollen KEINEN HTTP-Health-Endpoint. Schema-v1-Migration ist
+    # nicht anwendbar. Bleibt unverändert.
 
     def _get_project_config(self, project_name: str) -> Dict[str, Any]:
         """Liefert die volle Projekt-Config (config.yaml -> projects.<name>)."""
@@ -1874,15 +1879,94 @@ class ProjectMonitor:
             self._clear_health_alert_cooldown(project, 'backup_freshness')
 
     # === Phase 5c — App-Health-Checks via internal API ===
-    # Diese Checks pollen einen ZERODOX-API-Endpoint der DB-Pool-Saturation und
-    # Failed-Login-Rate exposed. Nur Projekte mit `monitor.internal_health_endpoint`
-    # in config.yaml werden geprüft (graceful skip bei fehlender Konfiguration).
+    # Diese Checks pollen ZERODOX-API-Endpoints für DB-Pool-Saturation und
+    # Failed-Login-Rate. Nur Projekte mit `monitor.internal_health_endpoint`
+    # ODER `monitor.health_v1_endpoint` werden geprüft (graceful skip).
     #
-    # Auth: X-Agent-Key Header mit ZERODOX_AGENT_API_KEY (env-var).
-    # Endpoint: ZERODOX/api/internal/health-stats (Phase 5a, PR #279)
+    # Schema-v1-Migration (Issue #568, 2026-05-03):
+    #   - DB-Pool: liest aus `/api/internal/health` (Schema v1, auth-frei)
+    #     → components.database.pool_saturation_percent
+    #   - Failed-Login: bleibt auf altem `/api/internal/health-stats`
+    #     (Schema v1 hat noch keine failed-login-Komponente; Folge-Issue
+    #     in ZERODOX-Repo trackt die Erweiterung)
+    #
+    # Auth-Modi:
+    #   - Schema v1 (`/api/internal/health`): kein Header (rate-limited public)
+    #   - Legacy (`/api/internal/health-stats`): X-Agent-Key Header
+
+    async def _fetch_health_schema_v1(self, project: ProjectStatus) -> Optional[Dict[str, Any]]:
+        """HTTP-Call zum Schema-v1-Health-Endpoint des Projekts.
+
+        Endpoint wird aus `monitor.health_v1_endpoint` gelesen, mit Fallback
+        auf String-Replace `health-stats` -> `health` aus `internal_health_endpoint`,
+        damit bestehende Configs ohne Änderung weiter funktionieren.
+
+        Schema v1 ist auth-frei (Rate-Limit pro IP). Akzeptiert HTTP 200 (ok/degraded)
+        und HTTP 503 (critical) — beide haben validen Schema-v1-Body.
+
+        Returnt None wenn:
+          - Kein Endpoint konfiguriert oder ableitbar
+          - HTTP-Fehler (Timeout, andere Status als 200/503)
+          - JSON-Parse-Fehler
+          - Schema-Version != "1.0"
+        """
+        proj_cfg = self._get_project_config(project.name)
+        if not isinstance(proj_cfg, dict):
+            return None
+
+        monitor_cfg = proj_cfg.get('monitor', {})
+        if not isinstance(monitor_cfg, dict):
+            return None
+
+        endpoint = monitor_cfg.get('health_v1_endpoint')
+        if not endpoint:
+            base_endpoint = monitor_cfg.get('internal_health_endpoint')
+            if base_endpoint:
+                endpoint = str(base_endpoint).replace('/health-stats', '/health')
+        if not endpoint:
+            return None
+
+        timeout = aiohttp.ClientTimeout(total=10)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    endpoint,
+                    headers={'Accept': 'application/json', 'User-Agent': 'shadowops-bot/health'},
+                ) as resp:
+                    if resp.status not in (200, 503):
+                        self.logger.warning(
+                            f"⚠️ Health-v1 {project.name}: HTTP {resp.status} von {endpoint}"
+                        )
+                        return None
+                    body = await resp.json()
+        except asyncio.TimeoutError:
+            self.logger.warning(f"⚠️ Health-v1 {project.name}: Timeout nach 10s")
+            return None
+        except aiohttp.ClientError as exc:
+            self.logger.warning(f"⚠️ Health-v1 {project.name}: ClientError — {exc}")
+            return None
+        except (ValueError, KeyError) as exc:
+            self.logger.warning(f"⚠️ Health-v1 {project.name}: JSON-Fehler — {exc}")
+            return None
+
+        if not isinstance(body, dict):
+            self.logger.warning(f"⚠️ Health-v1 {project.name}: Body ist kein dict")
+            return None
+        if body.get('schema_version') != '1.0':
+            self.logger.warning(
+                f"⚠️ Health-v1 {project.name}: unerwartete schema_version "
+                f"{body.get('schema_version')!r} — erwarte '1.0'"
+            )
+            return None
+        return body
 
     async def _fetch_app_health_stats(self, project: ProjectStatus) -> Optional[Dict[str, Any]]:
         """HTTP-Call zur internal Health-Stats-API des Projekts.
+
+        DEPRECATED: ZERODOX Schema v1 hat noch keine failed-login-Komponente —
+        diese Methode wird ausschließlich von _check_failed_login_rate genutzt,
+        bis ZERODOX-Folge-Issue die Komponente ergänzt. NICHT entfernen ohne
+        Migration. Für DB-Pool-Saturation siehe _fetch_health_schema_v1.
 
         Returnt None wenn:
           - Kein internal_health_endpoint konfiguriert
@@ -1944,27 +2028,41 @@ class ProjectMonitor:
         Cooldown: 30 Min.
         Frequenz: alle 5 Min.
 
-        Datenquelle: ZERODOX /api/internal/health-stats Response.dbPool.saturationPercent.
+        Datenquelle (seit 2026-05-03 Issue #568): ZERODOX /api/internal/health
+        Schema v1 → components.database.pool_saturation_percent. Vorher pollte
+        diese Methode den deprecated /api/internal/health-stats Endpoint.
         """
         if not self._should_run_health_check(project, 'db_pool_saturation'):
             return
         self._mark_health_check_ran(project, 'db_pool_saturation')
 
-        stats = await self._fetch_app_health_stats(project)
-        if not stats:
+        body = await self._fetch_health_schema_v1(project)
+        if not body:
             return
 
-        db_pool = stats.get('dbPool')
-        if not isinstance(db_pool, dict):
+        components = body.get('components')
+        if not isinstance(components, dict):
+            return
+
+        database = components.get('database')
+        if not isinstance(database, dict):
             return
 
         threshold = float(self._get_health_threshold(project, 'db_pool_saturation_warn'))
+        sat_raw = database.get('pool_saturation_percent')
+        if sat_raw is None:
+            # Schema-v1-Endpoint exposed pool_saturation_percent als optional —
+            # ohne diesen Wert können wir keinen Saturation-Alert generieren.
+            return
         try:
-            saturation = float(db_pool.get('saturationPercent', 0))
+            saturation = float(sat_raw)
         except (TypeError, ValueError):
             return
 
         if saturation > threshold:
+            latency = database.get('latency_ms')
+            ok = database.get('ok')
+            version = database.get('version')
             await self._send_health_alert(
                 project=project,
                 check_type='db_pool_saturation',
@@ -1979,9 +2077,9 @@ class ProjectMonitor:
                 fields=[
                     {"name": "Saturation", "value": f"{saturation:.0f}%", "inline": True},
                     {"name": "Schwelle", "value": f"> {threshold:.0f}%", "inline": True},
-                    {"name": "Active", "value": str(db_pool.get('active', '?')), "inline": True},
-                    {"name": "Idle", "value": str(db_pool.get('idle', '?')), "inline": True},
-                    {"name": "Total / Max", "value": f"{db_pool.get('total', '?')} / {db_pool.get('max', '?')}", "inline": True},
+                    {"name": "Latency", "value": f"{latency} ms" if latency is not None else "?", "inline": True},
+                    {"name": "DB OK", "value": "✅" if ok else "❌" if ok is False else "?", "inline": True},
+                    {"name": "Version", "value": str(version) if version else "?", "inline": True},
                 ],
                 channel_key='ci_zerodox',
                 fallback_channel_id=1463512208083521577,
@@ -2001,10 +2099,26 @@ class ProjectMonitor:
 
         Datenquelle: ZERODOX /api/internal/health-stats Response.failedLogins.count.
         DSGVO-konform: nur Counts, keine Email-Adressen oder User-IDs.
+
+        DEPRECATED: ZERODOX Schema v1 hat noch keine failed-login-Komponente —
+        Folge-Issue im ZERODOX-Repo trackt die Erweiterung. Sobald Schema v1
+        `components.failed_logins` exposed, auf _fetch_health_schema_v1 migrieren.
+        NICHT entfernen ohne Migration — Failed-Login-Detection ist
+        Security-kritisch (Brute-Force, Credential-Stuffing).
         """
         if not self._should_run_health_check(project, 'failed_login_rate'):
             return
         self._mark_health_check_ran(project, 'failed_login_rate')
+
+        # Deprecation-Hinweis einmal pro Bot-Run (nicht pro Call), damit
+        # Operator weiß, dass dieser Pfad noch auf den alten Endpoint pollt.
+        if not getattr(self, '_failed_login_deprecation_logged', False):
+            self.logger.warning(
+                "[5c] Failed-Login pollt deprecated /api/internal/health-stats — "
+                "Schema v1 hat noch keine failed-login-Komponente. Folge-Issue im "
+                "ZERODOX-Repo trackt die Erweiterung."
+            )
+            self._failed_login_deprecation_logged = True
 
         stats = await self._fetch_app_health_stats(project)
         if not stats:
@@ -2066,6 +2180,14 @@ class ProjectMonitor:
     # Endpoint: /api/internal/onboarding-smoke (read-only Dry-Run, PR add)
     # Severity: HIGH — Buchungen sind blockiert, Kunden gehen verloren.
     # Channel:  ci_zerodox (#🧪-ci-zerodox), Fallback critical bei Auth/Network-Fehler.
+    #
+    # Schema-v1-Migration (Issue #568, 2026-05-03): Onboarding-Smoke ist ein
+    # eigenständiger Functional-Probe-Endpoint mit anderem Response-Format
+    # (`{ready: bool, checks: {...}}`), KEIN Schema-v1-Health. Migration auf
+    # Schema v1 würde Cross-Repo-Änderung in ZERODOX erfordern (z.B. neue
+    # `components.onboarding`-Komponente in /api/internal/health). Tracked in
+    # shadowops-bot Folge-Issue. NICHT entfernen ohne Migration —
+    # Customer-Loss-Detection ist Live-kritisch.
 
     async def _fetch_onboarding_smoke_status(
         self, project: ProjectStatus

--- a/tests/unit/test_health_checks_extension.py
+++ b/tests/unit/test_health_checks_extension.py
@@ -410,17 +410,36 @@ def _build_monitor_with_api(
     return monitor, project, channel
 
 
+def _schema_v1_body(*, pool_saturation: int | None = 5, status: str = "ok") -> dict:
+    """Baut einen minimalen Schema-v1-Health-Response (Issue #568)."""
+    database: dict = {"latency_ms": 8.4, "ok": True, "version": "16.4"}
+    if pool_saturation is not None:
+        database["pool_saturation_percent"] = pool_saturation
+    return {
+        "schema_version": "1.0",
+        "host": "zerodox-web-prod",
+        "role": "web-prod",
+        "timestamp": "2026-05-03T20:00:00Z",
+        "uptime_seconds": 3600,
+        "status": status,
+        "components": {
+            "database": database,
+            "disk": {"used_percent": 5, "free_gb": 220, "total_gb": 240},
+            "memory": {"used_percent": 12, "available_mb": 14000, "total_mb": 16000},
+            "load": {"1min": 0.5, "5min": 0.3, "15min": 0.2, "cpu_count": 4},
+        },
+        "alerts": [],
+    }
+
+
 @pytest.mark.asyncio
 async def test_db_pool_saturation_above_threshold_triggers_alert(tmp_path):
-    """DB-Pool > 80% → HIGH-Alert in ci-zerodox."""
+    """DB-Pool > 80% → HIGH-Alert in ci-zerodox (Schema v1, Issue #568)."""
     monitor, project, channel = _build_monitor_with_api()
 
-    fake_stats = {
-        "timestamp": "2026-04-26T20:00:00Z",
-        "dbPool": {"active": 85, "idle": 5, "total": 90, "max": 100, "saturationPercent": 90},
-        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
-    }
-    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+    monitor._fetch_health_schema_v1 = AsyncMock(
+        return_value=_schema_v1_body(pool_saturation=90, status="degraded")
+    )
 
     await monitor._check_db_pool_saturation(project)
 
@@ -432,14 +451,26 @@ async def test_db_pool_saturation_above_threshold_triggers_alert(tmp_path):
 
 @pytest.mark.asyncio
 async def test_db_pool_saturation_below_threshold_no_alert(tmp_path):
-    """DB-Pool <= 80% → kein Alert."""
+    """DB-Pool <= 80% → kein Alert (Schema v1, Issue #568)."""
     monitor, project, channel = _build_monitor_with_api()
 
-    fake_stats = {
-        "dbPool": {"active": 10, "idle": 5, "total": 15, "max": 100, "saturationPercent": 15},
-        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
-    }
-    monitor._fetch_app_health_stats = AsyncMock(return_value=fake_stats)
+    monitor._fetch_health_schema_v1 = AsyncMock(
+        return_value=_schema_v1_body(pool_saturation=15)
+    )
+
+    await monitor._check_db_pool_saturation(project)
+
+    channel.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_db_pool_saturation_no_pool_field_no_alert(tmp_path):
+    """Schema v1 ohne pool_saturation_percent (optional) → kein Alert, kein Crash."""
+    monitor, project, channel = _build_monitor_with_api()
+
+    monitor._fetch_health_schema_v1 = AsyncMock(
+        return_value=_schema_v1_body(pool_saturation=None)
+    )
 
     await monitor._check_db_pool_saturation(project)
 
@@ -500,7 +531,7 @@ async def test_failed_login_rate_below_threshold_no_alert(tmp_path):
 
 @pytest.mark.asyncio
 async def test_app_health_check_skip_when_no_endpoint_configured(tmp_path):
-    """Kein internal_health_endpoint → graceful skip ohne Crash."""
+    """Kein internal_health_endpoint → graceful skip ohne Crash (beide Pfade)."""
     # _build_monitor (ohne _with_api) hat KEIN internal_health_endpoint
     monitor, project, channel = _build_monitor(project_path=str(tmp_path))
 
@@ -512,29 +543,28 @@ async def test_app_health_check_skip_when_no_endpoint_configured(tmp_path):
 
 @pytest.mark.asyncio
 async def test_app_health_check_skip_when_api_key_missing(tmp_path):
-    """Kein API-Key in env → graceful skip."""
+    """Kein API-Key → Failed-Login-Pfad skippt (Schema v1 ist auth-frei,
+    DB-Pool funktioniert daher unabhängig vom env-Key)."""
     monitor, project, channel = _build_monitor_with_api(api_key=None)
 
-    # _fetch_app_health_stats sollte None returnen wenn Key fehlt
+    # _fetch_app_health_stats (Legacy, Failed-Login) returnt None ohne Key
     result = await monitor._fetch_app_health_stats(project)
     assert result is None
 
-    # Folge: Checks senden nichts
-    await monitor._check_db_pool_saturation(project)
+    # Failed-Login-Check sendet nichts ohne Key
     await monitor._check_failed_login_rate(project)
     channel.send.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_app_health_check_recovery_clears_cooldown(tmp_path):
-    """Nach Recovery (Wert wieder OK) sollte Cooldown geloescht werden."""
+    """Nach Recovery (Wert wieder OK) sollte Cooldown geloescht werden (Schema v1)."""
     monitor, project, channel = _build_monitor_with_api()
 
     # 1. Trigger: hohe Saturation → Alert + Cooldown
-    monitor._fetch_app_health_stats = AsyncMock(return_value={
-        "dbPool": {"saturationPercent": 95},
-        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
-    })
+    monitor._fetch_health_schema_v1 = AsyncMock(
+        return_value=_schema_v1_body(pool_saturation=95, status="degraded")
+    )
     await monitor._check_db_pool_saturation(project)
     assert channel.send.call_count == 1
     cooldown_key = f"{project.name}:db_pool_saturation"
@@ -545,11 +575,144 @@ async def test_app_health_check_recovery_clears_cooldown(tmp_path):
         del monitor._health_check_last_run[cooldown_key]
 
     # 2. Recovery: niedrige Saturation → kein Alert + Cooldown geloescht
-    monitor._fetch_app_health_stats = AsyncMock(return_value={
-        "dbPool": {"saturationPercent": 10},
-        "failedLogins": {"count": 0, "windowMinutes": 5, "uniqueEmails": 0},
-    })
+    monitor._fetch_health_schema_v1 = AsyncMock(
+        return_value=_schema_v1_body(pool_saturation=10)
+    )
     await monitor._check_db_pool_saturation(project)
     # Channel.send wurde nur 1x gerufen (initial), nicht 2x
     assert channel.send.call_count == 1
     assert cooldown_key not in monitor._health_check_alerts
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Phase 5c — Schema v1 Endpoint-Helper (Issue #568)
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_fetch_health_schema_v1_skip_when_no_endpoint(tmp_path):
+    """Ohne health_v1_endpoint UND ohne internal_health_endpoint → None."""
+    monitor, project, _ = _build_monitor(project_path=str(tmp_path))
+
+    result = await monitor._fetch_health_schema_v1(project)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_health_schema_v1_falls_back_via_string_replace(tmp_path):
+    """Ohne expliziten health_v1_endpoint wird er aus internal_health_endpoint
+    abgeleitet (string-replace 'health-stats' -> 'health'). HTTP-Call wird
+    gemockt; getestet wird hier nur die Endpoint-URL."""
+    monitor, project, _ = _build_monitor_with_api()
+
+    captured: dict = {}
+
+    class _FakeResp:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def json(self):
+            return _schema_v1_body(pool_saturation=10)
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def get(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers or {}
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", return_value=_FakeSession()):
+        body = await monitor._fetch_health_schema_v1(project)
+
+    assert body is not None
+    assert body["schema_version"] == "1.0"
+    # Replace hat den Endpoint-Pfad korrekt umgeschrieben
+    assert captured["url"].endswith("/api/internal/health"), captured["url"]
+    # Schema v1 ist auth-frei: KEIN X-Agent-Key-Header
+    assert "X-Agent-Key" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_health_schema_v1_rejects_wrong_version(tmp_path):
+    """Schema-Version != '1.0' → None (forward-incompatible)."""
+    monitor, project, _ = _build_monitor_with_api()
+
+    class _FakeResp:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def json(self):
+            return {
+                "schema_version": "2.0",
+                "host": "x",
+                "role": "web-prod",
+                "timestamp": "2026-05-03T20:00:00Z",
+                "uptime_seconds": 1,
+                "status": "ok",
+                "components": {},
+                "alerts": [],
+            }
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def get(self, *_args, **_kwargs):
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", return_value=_FakeSession()):
+        body = await monitor._fetch_health_schema_v1(project)
+
+    assert body is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_health_schema_v1_accepts_503_for_critical(tmp_path):
+    """HTTP 503 (Schema v1 status='critical') liefert trotzdem den Body."""
+    monitor, project, _ = _build_monitor_with_api()
+
+    class _FakeResp:
+        status = 503
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def json(self):
+            return _schema_v1_body(pool_saturation=99, status="critical")
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def get(self, *_args, **_kwargs):
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", return_value=_FakeSession()):
+        body = await monitor._fetch_health_schema_v1(project)
+
+    assert body is not None
+    assert body["status"] == "critical"


### PR DESCRIPTION
## Summary

Partielle Schema-v1-Migration für Phase 5c gemäß Issue #568. Lead-Entscheidung Variante A nach Stop-and-Discuss-Iteration: DB-Pool-Saturation migriert, Failed-Login bleibt bewusst auf Legacy-Endpoint, Phase 5a/5b/5d dokumentiert no-op oder Folge-Issue.

## Migrated

**Phase 5c — DB-Pool-Saturation → Schema v1**

- Pollt `/api/internal/health` (Schema v1, auth-frei) statt `/api/internal/health-stats`
- Liest aus `components.database.pool_saturation_percent` (in ZERODOX `route.ts` exposed)
- Neue Helper-Methode `_fetch_health_schema_v1()` mit:
  - Schema-Version-Validation (`schema_version == \"1.0\"`)
  - HTTP-200 (ok/degraded) + HTTP-503 (critical) Handling
  - Endpoint-Ableitung aus `monitor.health_v1_endpoint` ODER String-Replace `health-stats` → `health` aus `internal_health_endpoint`
- Embed-Felder erweitert: Latency, DB-OK-Flag, Postgres-Version aus Schema v1
- Graceful-Skip wenn `pool_saturation_percent` fehlt (Field ist optional in Schema v1)

**Schema-Diff (vorher → nachher):**
```diff
- stats = await self._fetch_app_health_stats(project)  # /health-stats, X-Agent-Key
- db_pool = stats.get('dbPool')
- saturation = float(db_pool.get('saturationPercent', 0))
+ body = await self._fetch_health_schema_v1(project)  # /health (Schema v1), no auth
+ database = body['components'].get('database')
+ saturation = float(database.get('pool_saturation_percent'))
```

## Partial-Migration (Security-Reason)

**Phase 5c — Failed-Login-Rate bleibt auf `/health-stats`**

Schema v1 hat noch keine `failed-login`-Komponente. Failed-Login-Rate-Detection ist Security-kritisch (Brute-Force, Credential-Stuffing) und darf nicht ausfallen. Daher:

- `_check_failed_login_rate` pollt weiterhin `/api/internal/health-stats` mit X-Agent-Key
- `logger.warning` einmal pro Bot-Run beim ersten Call: `\"[5c] Failed-Login pollt deprecated /api/internal/health-stats — Folge-Issue #585 trackt Schema-Erweiterung\"` (via `_failed_login_deprecation_logged` Flag, kein Log-Spam)
- Inline-Comment im Code an `_fetch_app_health_stats`-Docstring + an `_check_failed_login_rate`-Docstring: \"NICHT entfernen ohne Migration\"

## Out-of-Scope

**Phase 5a — Endpoint-Schaffung war ZERODOX-seitig (PR #279)**
Bot-seitige Konsumenten waren die zwei 5c-Checks oben. Keine eigene 5a-Methode existiert in shadowops-bot. → No-op auf Bot-Seite.

**Phase 5b — Enterprise-Health-Checks (Disk/Memory/Container/SSL/Backup-Freshness)**
Pollt KEINEN HTTP-Health-Endpoint. Nutzt `shutil.disk_usage()`, `docker stats`, `openssl s_client`, file mtime — alles SSH/Subprocess-basiert. Schema-v1-Migration nicht anwendbar. Inline-Comment in `project_monitor.py` ergänzt.

**Phase 5d — Onboarding-Submit-Functional-Smoke**
Eigenständiger Probe-Endpoint mit anderem Format (`{ready: bool, checks: {...}}`). Migration auf Schema v1 erfordert Cross-Repo-Erweiterung in ZERODOX (`components.onboarding`). Customer-Loss-Detection ist Live-kritisch. → Folge-Issue #210 (shadowops-bot).

## Folge-Issues

- **ZERODOX #585**: \"Schema v1: failed-login-Komponente in /api/internal/health ergänzen\" — Voraussetzung für Failed-Login-Migration in shadowops-bot
- **shadowops-bot #210**: \"Phase 5d Onboarding-Smoke auf Schema v1 migrieren\" — wartet auf ZERODOX-seitige `components.onboarding`-Erweiterung

## Deprecation-Strategy

- `_fetch_app_health_stats` (Legacy-Endpoint-Helper): bleibt aktiv für Failed-Login. Docstring markiert DEPRECATED + Migration-Pfad.
- `logger.warning` einmal pro Bot-Run dokumentiert Legacy-Pfad-Nutzung (nicht pro Call → kein Log-Spam, aber sichtbar im Bootup-Log)
- Nach Merge von ZERODOX #585 + Bot-seitige Migration: 30-Tage Soak, dann `/api/internal/health-stats` Endpoint deprecation in ZERODOX (separater Folge-Issue)

## Tests

**Test-Datei:** `tests/unit/test_health_checks_extension.py`

Neu/geändert:
- 3 DB-Pool-Tests umgestellt auf `_fetch_health_schema_v1`-Mock mit Schema-v1-Body
- 1 neuer Test `test_db_pool_saturation_no_pool_field_no_alert` (optional-Field-Handling)
- 4 neue Tests für `_fetch_health_schema_v1`:
  - `skip_when_no_endpoint` — Graceful-Skip ohne Config
  - `falls_back_via_string_replace` — verifiziert URL-Ableitung + auth-frei
  - `rejects_wrong_version` — Schema-Version-Check (`!= '1.0'` → None)
  - `accepts_503_for_critical` — HTTP-503 wird als gültig akzeptiert
- Helper `_schema_v1_body()` für Test-Fixtures
- Failed-Login-Tests UNVERÄNDERT (Legacy-Pfad bleibt)

**Test-Status:**
- `tests/unit/test_health_checks_extension.py`: 26/26 grün
- `tests/unit/test_project_monitor.py`: 14/14 grün (TestHealthChecks-Failures sind pre-existing state-pollution, nicht durch diesen PR verursacht — vor und nach den Commits identisch)
- Voll-Suite ohne pre-existing-broken Module: **916 passed**, 70 skipped, 3 pre-existing failures, 10 pre-existing errors (psycopg2 fehlt im venv — bestand schon vor diesem PR)

Run-Befehl: `uv run pytest tests/unit/test_health_checks_extension.py -x --no-cov --override-ini=\"addopts=\"`

## Whitelist-Compliance

Geänderte Dateien:
- ✅ `src/integrations/project_monitor.py` (nur Phase-5c-Methoden + Schema-v1-Helper, kein Refactoring außerhalb)
- ✅ `tests/unit/test_health_checks_extension.py` (DB-Pool-Tests + neue Schema-v1-Helper-Tests)
- ✅ `CHANGELOG.md` (Unreleased-Sektion)

NICHT angefasst (Whitelist-konform):
- ❌ `config/config.yaml` (gitignored, Secrets)
- ❌ systemctl, deploy/, scripts/deploy*
- ❌ ZERODOX-Code (Cross-Repo)
- ❌ phase_5e_health_aggregator.py (worker-cog-fix Job)
- ❌ project_monitor.py-Bereiche außerhalb Phase 5c (kein \"wenn ich schon dabei bin\"-Cleanup)

Issue: #568
Folge-Issues: #210 (shadowops-bot), #585 (ZERODOX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)