### PR TITLE
docs: fix drift — Ollama config removed, permissions corrected, module paths updated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@
 shadowops-bot/
 ├── src/
 │   ├── bot.py                    # Haupt-Bot
-│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring)
+│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring, customer_setup_commands)
 │   ├── integrations/             # Externe Systeme (siehe unten)
+│   ├── patch_notes/              # Patch-Notes Pipeline v6 (5-Stufen State Machine)
+│   ├── schemas/                  # Codex Structured Output JSON-Schemas
 │   └── utils/                    # config, logging, embeds, state
 ├── tests/
 │   ├── unit/                     # 161+ Unit-Tests
@@ -52,7 +54,6 @@ shadowops-bot/
 ├── config/
 │   ├── config.example.yaml       # Template (commited)
 │   ├── config.yaml               # Real config (gitignored)
-│   ├── DO-NOT-TOUCH.md           # Critical files protection
 │   ├── INFRASTRUCTURE.md
 │   └── PROJECT_*.md              # Per-projekt-Notizen
 ├── deploy/
@@ -75,17 +76,19 @@ shadowops-bot/
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (Untermodule: core, batch_mixin, planner_mixin, executor_mixin, recovery_mixin, discord_mixin, models)
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
 - `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
+- `github_integration/` — Webhooks mit HMAC-SHA256 Verification + Jules SecOps Workflow + Multi-Agent Review Pipeline (Untermodule: core, webhook_mixin, jules_workflow_mixin, agent_review/, ...)
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
 - `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
+- `security_engine/` — Security Engine v6: ScanAgent (autonomer AI-Security-Engineer), CircuitBreaker, DB-Pool (asyncpg), Fixer-Adapters, LearningBridge
+- `fixers/` — Security-Fixers: fail2ban_fixer, crowdsec_fixer, aide_fixer, trivy_fixer, walg_fixer
 
 ## Coding-Conventions
 

--- a/README.md
+++ b/README.md
@@ -498,79 +498,67 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
-│   │   ├── admin.py
-│   │   ├── inspector.py
-│   │   └── monitoring.py
+│   ├── cogs/                           # Slash-Commands
+│   │   ├── admin.py                    # Admin-Commands (scan, stop-all-fixes, ...)
+│   │   ├── inspector.py                # Inspect-Commands (get-ai-stats, projekt-status, ...)
+│   │   ├── monitoring.py               # Monitoring-Commands (status, bans, threats, ...)
+│   │   └── customer_setup_commands.py  # Customer-Server-Setup
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (Multi-Mixin)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules SecOps + Multi-Agent Review
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
+│   │   ├── security_engine/            # Security Engine v6 (ScanAgent, DB, Fixers)
+│   │   ├── fixers/                     # Security-Fixers (fail2ban, crowdsec, aide, trivy, walg)
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
+│   ├── patch_notes/                    # Patch-Notes Pipeline v6 (5-Stufen State Machine)
+│   ├── schemas/                        # Codex Structured Output JSON-Schemas
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       └── discord_logger.py           # Discord Channel Logger
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (161)
-│   │   ├── test_config.py
-│   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
-│   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
-│   │   ├── test_orchestrator.py
-│   │   ├── test_knowledge_base.py
-│   │   ├── test_event_watcher.py
-│   │   ├── test_github_integration.py
-│   │   ├── test_project_monitor.py
-│   │   └── test_incident_manager.py
-│   └── integration/
-│       └── test_learning_workflow.py   # End-to-End Tests
+│   ├── unit/                           # Unit Tests
+│   └── integration/                    # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
-│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
+│   ├── config.example.yaml             # Template (committed)
+│   ├── config.yaml                     # Real Config (gitignored)
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
-├── deploy/                             # Deployment
+│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
+│   └── PROJECT_*.md                    # Per-Projekt-Notizen
+├── deploy/
 │   └── shadowops-bot.service           # systemd Unit
 ├── scripts/                            # Utility-Skripte
 │   ├── restart.sh                      # Bot neustarten (--pull, --logs)
 │   ├── diagnose-bot.sh                 # Diagnose
-│   ├── setup.sh                        # Erstinstallation
-│   └── ...
+│   └── setup.sh                        # Erstinstallation
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
-├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+├── docs/
+│   ├── reference/api.md                # API-Referenz
+│   ├── SECURITY_ANALYST.md
+│   ├── SETUP_GUIDE.md
 │   ├── adr/                            # Architecture Decision Records
-│   ├── plans/                          # Design-Dokumente
-│   └── archive/                        # Historische Doku
+│   └── plans/                          # Design-Dokumente
 ├── .claude/                            # KI-Konfiguration
-│   ├── rules/                          # Pfad-gefilterte Rules
-│   ├── skills/                         # Workflow-Skills
-│   └── agents/                         # Spezialisierte Agents
+│   └── rules/                          # Pfad-gefilterte Rules
+├── .routines/                          # Worker State + Prompts
 ├── requirements.txt                    # Python Dependencies
 ├── pyproject.toml                      # Projekt-Definition
 ├── CLAUDE.md                           # KI-Projektinstruktionen

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -48,7 +48,7 @@ Shows overall security status across all systems.
 #### `/scan`
 Triggers a manual Docker security scan using Trivy.
 
-**Permissions:** None
+**Permissions:** Administrator
 **Parameters:** None
 **Returns:** Scan results with vulnerabilities by severity
 
@@ -104,7 +104,7 @@ Shows AIDE File Integrity Check status.
 #### `/remediation-stats`
 Shows auto-remediation statistics and performance metrics.
 
-**Permissions:** None
+**Permissions:** Administrator
 **Parameters:** None
 **Returns:** Embed with:
 - Total fixes executed
@@ -164,11 +164,10 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
-- Active fallback chain
-- Request counts per provider
+- Codex CLI status (primary engine, models fast/standard/thinking)
+- Claude CLI status (fallback engine, models fast/standard/thinking)
+- Active engine routing table
+- Request counts per engine
 
 **Example:**
 ```
@@ -266,25 +265,34 @@ channels:
 
 # ========================================
 # AI CONFIGURATION
+# Dual-Engine: Codex CLI (Primary) + Claude CLI (Fallback)
+# Ollama wurde in v4.0 entfernt. Keine API-Keys nötig — beide Engines
+# laufen als CLI-Prozesse (codex / claude).
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  # === CODEX CLI (PRIMARY) ===
+  codex:
+    cli_path: "codex"                       # Pfad zur Codex CLI (im PATH)
+    models:
+      fast: "gpt-5.3-codex"                 # Schnelle Analysen
+      standard: "gpt-5.3-codex"            # Standard-Analysen + Structured Output
+      thinking: "o3"                        # Komplexe Planungsaufgaben
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  # === CLAUDE CLI (FALLBACK) ===
+  claude:
+    cli_path: "/home/user/.local/bin/claude"  # Pfad zur Claude CLI
+    models:
+      fast: "claude-sonnet-4-6"
+      standard: "claude-sonnet-4-6"
+      thinking: "claude-opus-4-6"           # Security Analyst Sessions
+
+  # === TIMEOUTS ===
+  timeouts:
+    codex_seconds: 300                      # 5 Min für Codex CLI
+    claude_seconds: 300                     # 5 Min für Claude CLI
+    analyst_seconds: 1800                   # 30 Min für Security Analyst Sessions
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION


### PR DESCRIPTION
## Summary

Drift-Korrekturen aus dem ersten Doku-Kurator-Lauf (2026-05-06). Alle Aenderungen sind direkt aus dem Code verifiziert.

### docs/reference/api.md

- **AI Config Section komplett ersetzt**: Der `ai.ollama` / `ai.anthropic` / `ai.openai` Block war veraltet (Ollama wurde in v4.0 entfernt, README bestaetigt das explizit: "Ollama komplett entfernt"). Ersetzt durch den tatsaechlichen `ai.codex` + `ai.claude` Block aus `config/config.example.yaml`.
- **`/scan` Permissions**: `None` → `Administrator` (Code: `@app_commands.checks.has_permissions(administrator=True)` in `admin.py:20`)
- **`/remediation-stats` Permissions**: `None` → `Administrator` (Code: `admin.py:78`)
- **`/get-ai-stats` Return-Embed**: Ollama/Claude/OpenAI-Beschreibung entfernt, ersetzt durch Codex/Claude CLI.

### CLAUDE.md

- `orchestrator.py` → `orchestrator/` (ist seit langem ein Multi-Mixin-Package mit `core.py`, `batch_mixin.py`, etc.)
- `github_integration.py` → `github_integration/` (Package mit Jules-Workflow, agent_review/, etc.)
- `security_engine/` und `fixers/` dem Modul-Verzeichnis hinzugefuegt — beide existieren und sind im Safety-File ausfuehrlich dokumentiert, fehlten aber im Modul-Listing
- Verzeichnis-Struktur: `patch_notes/` und `schemas/` ergaenzt; Referenz auf `config/DO-NOT-TOUCH.md` entfernt (Datei existiert nicht im Repo)

### README.md

- Doppelter `config/`-Block in der Projekt-Struktur entfernt (war ein offensichtlicher Copy-Paste-Fehler)
- `docs/API.md` → `docs/reference/api.md` (korrekte Pfad)
- Integrations-Baum aktualisiert: `orchestrator/`, `github_integration/`, `security_engine/`, `fixers/`, `patch_notes/`, `schemas/`

## Test plan

- [ ] Prose pruefen: Sind alle geaenderten Pfade korrekt? (`ls src/integrations/orchestrator/`, `ls src/integrations/github_integration/`, `ls src/integrations/security_engine/`, `ls src/integrations/fixers/`, `ls src/patch_notes/`, `ls src/schemas/`)
- [ ] config.example.yaml pruefen: Stimmen die AI-Config-Schluessel (`ai.codex`, `ai.claude`, `ai.timeouts`) mit dem neuen api.md-Block ueberein?
- [ ] Permissions in admin.py bestaetigen: `/scan` und `/remediation-stats` haben `has_permissions(administrator=True)`

Labels: `status:routine-generated`, `worker:doku`, `type:docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8gaaJHB8LLaTzeLrxXPiF)_