### PR TITLE
docs: add missing slash commands to README and api.md

### DIFF
--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,13 +2,37 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": null,
-  "last_drift_check": null,
-  "open_prs": [],
+  "last_run": "2026-05-06T00:00:00Z",
+  "last_drift_check": "2026-05-06T00:00:00Z",
+  "open_prs": [
+    {
+      "branch": "claude/jolly-hamilton-ADjL9",
+      "title": "docs: fix drift — Ollama config removed, permissions corrected, module paths updated",
+      "scope": "drift",
+      "files": ["docs/reference/api.md", "CLAUDE.md", "README.md"]
+    },
+    {
+      "branch": "claude/doku/command-gaps",
+      "title": "docs: add missing slash commands to README and api.md",
+      "scope": "gaps",
+      "files": ["README.md", "docs/reference/api.md"]
+    }
+  ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": null },
-    "CLAUDE.md": { "last_synced_with_code_at": null },
-    "docs/reference/api.md": { "last_synced_with_code_at": null }
+    "README.md": { "last_synced_with_code_at": "2026-05-06T00:00:00Z" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-06T00:00:00Z" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-06T00:00:00Z" }
   },
-  "open_questions": []
+  "open_questions": [
+    {
+      "id": "anti-bloat-highlights",
+      "created": "2026-05-06",
+      "note": "README ist 773+ Zeilen. Highlights v3.1 bis v3.4 (ca. 170 Zeilen) koennen in CHANGELOG.md migriert werden gemaess Anti-Bloat-Regel. Ausserdem referenzieren Highlights v3.4 Slash-Commands (/ai-stats, /ai-variants, /ai-tune, /ai-export-finetune) die nicht mehr im Code existieren — sie wurden durch /agent-stats ersetzt. Separater PR empfohlen."
+    },
+    {
+      "id": "knowledge-base-sqlite-vs-postgres",
+      "created": "2026-05-06",
+      "note": "api.md Python API section zeigt KnowledgeBase mit SQLite (db_path='data/knowledge_base.db') und SQLite CREATE TABLE Syntax. Wenn KB auf PostgreSQL migriert wurde, muss dieses Beispiel angepasst werden. Bitte bestaetigen."
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -246,23 +246,34 @@ projects:
 
 #### Security & Monitoring
 - `/status` - Gesamt-Sicherheitsstatus
-- `/scan` - Manuellen Docker-Scan triggern
+- `/scan` - Manuellen Docker-Scan triggern (Admin)
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letzte Docker-Scan-Ergebnisse
 
 #### Auto-Remediation
-- `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
-- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/remediation-stats` - Auto-Remediation Statistiken (Admin)
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes (Admin)
+- `/set-approval-mode [mode]` - Ändere Approval Mode: paranoid/auto/dry-run (Admin)
 
 #### AI & Learning System
-- `/get-ai-stats` - AI-Provider Status und Fallback-Chain
-- `/reload-context` - Lade Project-Context neu
+- `/get-ai-stats` - AI-Provider Status (Codex/Claude Engine)
+- `/agent-stats` - Agent-Learning Statistiken (Security, Patch Notes, SEO)
+- `/security-engine` - Security Engine v6 Status und Statistiken
+- `/reload-context` - Lade Project-Context neu (Admin)
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+
+#### Patch Notes
+- `/release-notes [project]` - Gesammelte Commits als Patch Notes veröffentlichen (Admin)
+- `/pending-notes` - Zeige ausstehende Commits die auf Release warten (Admin)
+
+#### Admin
+- `/setup-customer-server` - Customer-Discord-Server mit Monitoring-Channels einrichten (Admin)
+- `/mark-duplicate <parent_id> <child_id>` - Finding als Duplikat markieren (Learning-Feedback)
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -438,23 +449,34 @@ deployment:
 ```
 Security Commands:
   /status              - Gesamt-Sicherheitsstatus
-  /scan                - Docker Security Scan
+  /scan                - Docker Security Scan starten (Admin)
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
   /aide                - AIDE Check-Status
+  /docker              - Letzte Docker Scan Ergebnisse
 
 Auto-Remediation:
-  /remediation-stats             - Statistiken
-  /stop-all-fixes                - Emergency Stop
-  /set-approval-mode [mode]      - Approval Mode ändern
+  /remediation-stats             - Statistiken (Admin)
+  /stop-all-fixes                - Emergency Stop (Admin)
+  /set-approval-mode [mode]      - Approval Mode ändern (Admin)
 
 AI System:
-  /get-ai-stats                  - AI Provider Status
-  /reload-context                - Context neu laden
+  /get-ai-stats                  - AI Provider Status (Codex / Claude)
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
+  /reload-context                - Context neu laden (Admin)
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+
+Patch Notes:
+  /release-notes [project]       - Patch Notes veröffentlichen (Admin)
+  /pending-notes                 - Ausstehende Commits anzeigen (Admin)
+
+Admin:
+  /setup-customer-server         - Customer-Server einrichten (Admin)
+  /mark-duplicate <pid> <cid>    - Finding als Duplikat markieren
 ```
 
 ### GitHub Webhook Setup

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -97,6 +97,18 @@ Shows AIDE File Integrity Check status.
 /aide
 ```
 
+#### `/docker`
+Shows last Docker security scan results (Trivy).
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Embed with last scan timestamp and vulnerability counts by severity
+
+**Example:**
+```
+/docker
+```
+
 ---
 
 ### Auto-Remediation Commands


### PR DESCRIPTION
## Summary

Luecken-Fuellung aus dem ersten Doku-Kurator-Lauf (2026-05-06). Sieben Slash-Commands existieren im Code, fehlten aber vollstaendig in der Dokumentation.

### Fehlende Commands (aus Code verifiziert)

| Command | Cog | Permissions | Beschreibung |
|---------|-----|-------------|--------------|
| `/docker` | `monitoring.py:127` | None | Letzte Docker/Trivy-Scan-Ergebnisse |
| `/agent-stats` | `inspector.py:123` | None | Agent-Learning Statistiken (Security, Patch Notes, SEO) |
| `/security-engine` | `inspector.py:243` | None | Security Engine v6 Status + Stats |
| `/release-notes [project]` | `admin.py:163` | Administrator | Patch Notes fuer Projekt veroeffentlichen |
| `/pending-notes` | `admin.py:324` | Administrator | Ausstehende Commits anzeigen |
| `/setup-customer-server` | `customer_setup_commands.py:22` | Administrator | Customer-Discord-Server einrichten |
| `/mark-duplicate <pid> <cid>` | `admin.py:368` | None | Finding als Duplikat markieren |

### Aenderungen

**README.md:**
- Alle sieben Commands in die Slash-Commands-Uebersicht aufgenommen (Feature-List + Code-Block in "Commands in Discord")
- Neuer Abschnitt "Patch Notes" fuer `/release-notes` und `/pending-notes`
- Neuer Abschnitt "Admin" fuer `/setup-customer-server` und `/mark-duplicate`
- Alle Admin-only Commands mit `(Admin)` gekennzeichnet

**docs/reference/api.md:**
- `/docker` mit vollstaendigem Eintrag in "Security & Monitoring Commands" ergaenzt

**.routines/state/doku.json:**
- Status des ersten Laufs persistiert
- Zwei offene Folgefragen dokumentiert (anti-bloat Highlights v3.x, KB SQLite→PostgreSQL in api.md)

## Offene Folgepunkte (keine Blocker fuer diesen PR)

1. **Anti-Bloat**: README ist 773+ Zeilen. Highlights v3.1–v3.4 (~170 Zeilen) koennen in CHANGELOG.md migriert werden. Highlights v3.4 referenzieren ausserdem Commands (`/ai-stats`, `/ai-variants`, `/ai-tune`, `/ai-export-finetune`) die nicht mehr existieren (ersetzt durch `/agent-stats`).
2. **api.md Knowledge Base Beispiel**: Python-API-Section zeigt `KnowledgeBase(db_path="data/knowledge_base.db")` mit SQLite-Schema — wenn KB auf PostgreSQL migriert ist, muss das Beispiel aktualisiert werden.

## Test plan

- [ ] Alle sieben aufgefuehrten Commands in den Cog-Dateien bestaetigen
- [ ] Permissions fuer `/mark-duplicate` bestaetigen (kein `has_permissions`-Decorator in admin.py:368ff)
- [ ] README rendern und pruefen ob die neuen Sektionen sauber aussehen

Labels: `status:routine-generated`, `worker:doku`, `type:docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8gaaJHB8LLaTzeLrxXPiF)_