### PR TITLE
docs: fix drift in README and CLAUDE.md (structure, slash commands)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,9 @@
 shadowops-bot/
 ├── src/
 │   ├── bot.py                    # Haupt-Bot
-│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring)
+│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring, customer_setup, ...)
+│   ├── commands/                 # Zusaetzliche Command-Cogs (ai_learning_admin, knowledge_stats)
+│   ├── patch_notes/              # Patch Notes Pipeline v6 (5-Stufen State Machine)
 │   ├── integrations/             # Externe Systeme (siehe unten)
 │   └── utils/                    # config, logging, embeds, state
 ├── tests/
@@ -50,20 +52,20 @@ shadowops-bot/
 │   ├── integration/              # End-to-End-Workflows
 │   └── conftest.py
 ├── config/
-│   ├── config.example.yaml       # Template (commited)
+│   ├── config.example.yaml       # Template (committed)
 │   ├── config.yaml               # Real config (gitignored)
-│   ├── DO-NOT-TOUCH.md           # Critical files protection
-│   ├── INFRASTRUCTURE.md
-│   └── PROJECT_*.md              # Per-projekt-Notizen
+│   ├── config.recommended.yaml   # Empfehlungen
+│   ├── safe_upgrades.yaml        # Upgrade-Pfade
+│   └── logrotate.conf            # Log-Rotation
 ├── deploy/
 │   └── shadowops-bot.service     # systemd Unit
 ├── scripts/                      # Wartungs-Skripte
 ├── docs/
-│   ├── SECURITY_ANALYST.md
-│   ├── SETUP_GUIDE.md
-│   ├── reference/api.md
+│   ├── reference/api.md          # API-Referenz
 │   ├── adr/                      # Architecture Decision Records
-│   └── plans/                    # Design-Dokumente
+│   ├── design/                   # Design-Dokumente
+│   ├── operations/               # Runbooks und Setup-Anleitungen
+│   └── plans/                    # Design-Dokumente (aeltere)
 ├── data/                         # Runtime-Daten (gitignored)
 ├── logs/                         # Logs (gitignored)
 ├── .claude/                      # KI-spezifische Configs
@@ -75,17 +77,21 @@ shadowops-bot/
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (Package: core, batch_mixin, executor_mixin, recovery_mixin, ...)
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
 - `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
+- `github_integration/` — Webhooks + Jules SecOps Workflow + Agent-Review Pipeline (Package: core, jules_workflow_mixin, agent_review/, ...)
+- `security_engine/` — SecurityScanAgent v6: autonome taegl./woechentl. Scans, deterministische Pre-Checks, Fix-Phase mit Cross-Mode-Lock
+- `fixers/` — Fixer-Klassen fuer konkrete Systeme: fail2ban_fixer, crowdsec_fixer, aide_fixer, trivy_fixer, walg_fixer
+- `ai_learning/` — Kontinuierliches Lernsystem: ContinuousLearningAgent, KnowledgeDB, KnowledgeSynthesizer
+- `analyst/` — Legacy SecurityAnalyst (nicht mehr aktiv gestartet, bleibt als Referenz)
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
-- `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
+- `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen (Event-Quellen)
 
 ## Coding-Conventions
 
@@ -157,7 +163,7 @@ sudo journalctl -u shadowops-bot -f
 2. Im `event_watcher.py` registrieren.
 3. Config-Key in `config.example.yaml` ergaenzen.
 4. Test mit Mock-Subprocess-Output.
-5. README + `docs/SECURITY_ANALYST.md` updaten.
+5. README + `docs/reference/api.md` updaten.
 
 ### Neuen AI-Provider als Engine
 1. Klasse in `ai_engine.py` analog zu `CodexEngine` / `ClaudeEngine`.
@@ -181,17 +187,15 @@ Worker-Konventionen:
 
 ## Statistik (Stand v5.1)
 
-20.000+ LoC, 150+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
+20.000+ LoC, 150+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 20+ Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
 
 ## Aktuelle Doku
 
 - [README.md](./README.md)
-- [docs/SECURITY_ANALYST.md](./docs/SECURITY_ANALYST.md)
-- [docs/SETUP_GUIDE.md](./docs/SETUP_GUIDE.md)
 - [docs/reference/api.md](./docs/reference/api.md)
-- [DOCS_OVERVIEW.md](./DOCS_OVERVIEW.md)
-- [config/DO-NOT-TOUCH.md](./config/DO-NOT-TOUCH.md)
+- [docs/operations/setup.md](./docs/operations/setup.md)
+- [docs/operations/quickstart.md](./docs/operations/quickstart.md)
 
 ## Letztes Update dieser Datei
 
-2026-04-26 — initiales Setup, generiert aus Worker-Bundle.
+2026-05-07 — Doku-Kurator: Verzeichnisstruktur aktualisiert (orchestrator/, github_integration/ Packages; security_engine/, fixers/, ai_learning/ ergaenzt; src/commands/, src/patch_notes/ ergaenzt); Broken Links entfernt.

--- a/README.md
+++ b/README.md
@@ -249,20 +249,29 @@ projects:
 - `/scan` - Manuellen Docker-Scan triggern
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
+- `/docker` - Letzte Docker Scan Ergebnisse anzeigen
 - `/aide` - AIDE Integrity Check Status
 
 #### Auto-Remediation
 - `/remediation-stats` - Auto-Remediation Statistiken
 - `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
 - `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/mark-duplicate [parent_id] [child_id]` - Finding als Duplikat markieren (Learning-Feedback)
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
 - `/reload-context` - Lade Project-Context neu
+- `/agent-stats` - Agent-Learning Statistiken (Session-Tokens, Findings, DB-Status)
+- `/security-engine` - Security Engine v6 Status und Statistiken
+
+#### Patch Notes
+- `/release-notes [project]` - Gesammelte Commits als Patch Notes veröffentlichen
+- `/pending-notes` - Ausstehende Commits anzeigen (warten auf Release)
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+- `/setup-customer-server` - Kunden-Server mit Monitoring-Channels einrichten
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -441,20 +450,29 @@ Security Commands:
   /scan                - Docker Security Scan
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
+  /docker              - Letzte Docker Scan Ergebnisse
   /aide                - AIDE Check-Status
 
 Auto-Remediation:
   /remediation-stats             - Statistiken
   /stop-all-fixes                - Emergency Stop
   /set-approval-mode [mode]      - Approval Mode ändern
+  /mark-duplicate [p] [c]        - Finding als Duplikat markieren
 
 AI System:
   /get-ai-stats                  - AI Provider Status
   /reload-context                - Context neu laden
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
+
+Patch Notes:
+  /release-notes [project]       - Patch Notes veröffentlichen
+  /pending-notes                 - Ausstehende Commits anzeigen
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+  /setup-customer-server         - Kunden-Server einrichten
 ```
 
 ### GitHub Webhook Setup
@@ -498,20 +516,37 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
-│   │   ├── admin.py
-│   │   ├── inspector.py
-│   │   └── monitoring.py
+│   ├── cogs/                           # Modulare Slash Commands
+│   │   ├── admin.py                    # /scan, /stop-all-fixes, /release-notes, ...
+│   │   ├── inspector.py                # /get-ai-stats, /projekt-status, /security-engine, ...
+│   │   ├── monitoring.py               # /status, /bans, /threats, /docker, /aide
+│   │   ├── customer_setup_commands.py  # /setup-customer-server
+│   │   ├── cron_heartbeat.py           # Interne Heartbeat-Tasks
+│   │   └── phase_5e_health_aggregator.py  # Health-Aggregator (Phase 5e)
+│   ├── commands/                       # Zusaetzliche Command-Cogs
+│   │   ├── ai_learning_admin.py        # /ai-stats, /ai-variants, /ai-tune, /ai-export-finetune
+│   │   └── knowledge_stats.py          # /knowledge-stats
+│   ├── patch_notes/                    # Patch Notes Pipeline v6 (5-Stufen State Machine)
+│   │   ├── pipeline.py                 # Haupt-Pipeline mit asyncio Lock + Circuit Breaker
+│   │   ├── stages/                     # collect, classify, generate, validate, distribute
+│   │   ├── templates/                  # gaming, saas, devops Templates
+│   │   ├── grouping.py                 # Commit-Gruppierung (kein Cap)
+│   │   ├── versioning.py               # SemVer aus Changelog-DB
+│   │   └── state.py                    # State-Persistenz nach jeder Stufe
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (Package)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules SecOps Workflow (Package)
+│   │   ├── security_engine/            # SecurityScanAgent v6 (autonomer Scanner)
+│   │   ├── fixers/                     # Fixer-Klassen: fail2ban, crowdsec, aide, trivy, walg
+│   │   ├── ai_learning/                # Kontinuierliches Lernsystem
+│   │   ├── analyst/                    # Legacy SecurityAnalyst (Referenz, nicht aktiv)
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
@@ -522,55 +557,37 @@ shadowops-bot/
 │   │   └── docker.py                   # Docker Scan Integration
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       └── discord_logger.py           # Discord Channel Logger
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (161)
-│   │   ├── test_config.py
-│   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
-│   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
-│   │   ├── test_orchestrator.py
-│   │   ├── test_knowledge_base.py
-│   │   ├── test_event_watcher.py
-│   │   ├── test_github_integration.py
-│   │   ├── test_project_monitor.py
-│   │   └── test_incident_manager.py
-│   └── integration/
-│       └── test_learning_workflow.py   # End-to-End Tests
+│   ├── unit/                           # Unit Tests
+│   └── integration/                    # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
-│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
+│   ├── config.example.yaml             # Template (committed)
 │   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
 │   └── logrotate.conf                  # Log-Rotation
-├── deploy/                             # Deployment
+├── deploy/
 │   └── shadowops-bot.service           # systemd Unit
 ├── scripts/                            # Utility-Skripte
 │   ├── restart.sh                      # Bot neustarten (--pull, --logs)
 │   ├── diagnose-bot.sh                 # Diagnose
-│   ├── setup.sh                        # Erstinstallation
-│   └── ...
+│   └── setup.sh                        # Erstinstallation
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
 ├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+│   ├── reference/api.md                # API-Referenz
 │   ├── adr/                            # Architecture Decision Records
 │   ├── plans/                          # Design-Dokumente
 │   └── archive/                        # Historische Doku
 ├── .claude/                            # KI-Konfiguration
 │   ├── rules/                          # Pfad-gefilterte Rules
-│   ├── skills/                         # Workflow-Skills
-│   └── agents/                         # Spezialisierte Agents
+│   └── skills/                         # Workflow-Skills
+├── .routines/                          # Worker State + Prompts
 ├── requirements.txt                    # Python Dependencies
 ├── pyproject.toml                      # Projekt-Definition
 ├── CLAUDE.md                           # KI-Projektinstruktionen


### PR DESCRIPTION
## Summary

Drift-Korrekturen nach Phase 1 des Doku-Kurator-Laufs (2026-05-07).

### README.md

- **Slash Commands Sektion**: 7 fehlende Commands ergaenzt:
  - `/docker` (monitoring.py:127) — Letzte Docker Scan Ergebnisse
  - `/security-engine` (inspector.py:243) — Security Engine v6 Status
  - `/agent-stats` (inspector.py:123) — Agent-Learning Statistiken
  - `/release-notes` (admin.py:163) — Patch Notes veroeffentlichen
  - `/pending-notes` (admin.py:323) — Ausstehende Commits anzeigen
  - `/mark-duplicate` (admin.py:367) — Finding als Duplikat markieren
  - `/setup-customer-server` (customer_setup_commands.py) — Kunden-Server einrichten
- **"Commands in Discord" Textblock**: Gleiche Commands ergaenzt, neue Sektionen "Patch Notes" und `/setup-customer-server`
- **Projekt-Struktur**:
  - `orchestrator.py` → `orchestrator/` (Package seit mehreren Monaten)
  - `github_integration.py` → `github_integration/` (Package)
  - Neue Cogs: `cron_heartbeat.py`, `customer_setup_commands.py`, `phase_5e_health_aggregator.py`
  - Neue Verzeichnisse: `src/commands/`, `src/patch_notes/`
  - Doppelter `config/`-Eintrag entfernt
  - `docs/API.md` → `docs/reference/api.md` (korrekter Pfad)

### CLAUDE.md

- **Verzeichnisstruktur**: `src/commands/` und `src/patch_notes/` ergaenzt; `docs/` Unterstruktur an tatsaechliche Verzeichnisse angepasst (design/, operations/ vorhanden; SECURITY_ANALYST.md/SETUP_GUIDE.md existieren nicht)
- **Module unter `src/integrations/`**:
  - `orchestrator.py` → `orchestrator/` (Package)
  - `github_integration.py` → `github_integration/` (Package mit Jules-Workflow + Agent-Review)
  - `security_engine/` ergaenzt (SecurityScanAgent v6 — in safety.md ausfuehrlich dokumentiert aber in CLAUDE.md nicht gelistet)
  - `fixers/` ergaenzt (fail2ban_fixer, crowdsec_fixer, aide_fixer, trivy_fixer, walg_fixer)
  - `ai_learning/` ergaenzt (ContinuousLearningAgent, KnowledgeDB, KnowledgeSynthesizer)
  - `analyst/` ergaenzt (Legacy SecurityAnalyst, bleibt als Referenz)
- **Broken Links** in "Aktuelle Doku" entfernt: `docs/SECURITY_ANALYST.md`, `docs/SETUP_GUIDE.md`, `DOCS_OVERVIEW.md`, `config/DO-NOT-TOUCH.md` existieren nicht; durch vorhandene Links ersetzt
- **Statistik**: Discord-Commands 15 → 20+ (tatsaechlich 20+ Commands in Cogs + commands/)
- **Beispiel-Task**: `docs/SECURITY_ANALYST.md` → `docs/reference/api.md`
- **Letztes Update**: aktualisiert auf 2026-05-07

## Motivation

KI-Tools (Claude Code, Codex) laden CLAUDE.md als Erstes. Fehlende Module-Eintraege (`security_engine/`, `fixers/`) und falsche Paket-Namen (`orchestrator.py` statt `orchestrator/`) fuehren zu falschen Annahmen beim Navigieren im Code. Broken Links in "Aktuelle Doku" erzeugen 404s.

## Keine Verhaltensaenderung

Reine Dokumentationsaenderung. Kein Produktionscode beruehrt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rg4GbMSUoMRriwv8coeNnV)_