### PR TITLE
docs: fix drift + fill gaps in api.md, CLAUDE.md, README.md

### DIFF
--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,13 +2,31 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": null,
-  "last_drift_check": null,
+  "last_run": "2026-05-08T00:00:00Z",
+  "last_drift_check": "2026-05-08T00:00:00Z",
   "open_prs": [],
+  "open_issues": [
+    {
+      "number": 221,
+      "url": "https://github.com/Commandershadow9/shadowops-bot/issues/221",
+      "title": "docs: README anti-bloat — migrate v3.x Highlights sections to CHANGELOG.md",
+      "created_at": "2026-05-08T00:00:00Z"
+    }
+  ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": null },
-    "CLAUDE.md": { "last_synced_with_code_at": null },
-    "docs/reference/api.md": { "last_synced_with_code_at": null }
+    "README.md": {
+      "last_synced_with_code_at": "2026-05-08T00:00:00Z",
+      "notes": "Added /docker, /agent-stats, /security-engine commands; fixed project structure (packages vs flat files, removed duplicate config/ section, fixed docs/API.md -> docs/reference/api.md); added missing cogs"
+    },
+    "CLAUDE.md": {
+      "last_synced_with_code_at": "2026-05-08T00:00:00Z",
+      "notes": "Updated integrations list to reflect package structure (orchestrator/, github_integration/, security_engine/, fixers/, analyst/, ai_learning/); added patch_notes/, schemas/, commands/ to directory structure; updated cogs listing"
+    },
+    "docs/reference/api.md": {
+      "last_synced_with_code_at": "2026-05-08T00:00:00Z",
+      "notes": "Removed all Ollama references (ai.ollama config block, /get-ai-stats description, rate limiting); replaced with Codex/Claude CLI dual-engine config; fixed KnowledgeBase from SQLite to PostgreSQL; replaced DB schema section with correct PostgreSQL table listing"
+    }
   },
-  "open_questions": []
+  "open_questions": [],
+  "anti_bloat_notes": "README at 773 lines (threshold: 500). Issue #221 created for v3.x Highlights migration. CLAUDE.md at ~210 lines — within threshold."
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,12 @@
 shadowops-bot/
 ├── src/
 │   ├── bot.py                    # Haupt-Bot
-│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring)
+│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring, customer_setup_commands, cron_heartbeat, phase_5e_health_aggregator)
 │   ├── integrations/             # Externe Systeme (siehe unten)
-│   └── utils/                    # config, logging, embeds, state
+│   ├── patch_notes/              # 5-Stufen Patch-Notes Pipeline (pipeline, grouping, versioning, stages/, templates/)
+│   ├── schemas/                  # JSON Schemas fuer Structured Output (fix_strategy, patch_notes, incident_analysis, jules_review, coordinated_plan)
+│   ├── commands/                 # Admin-Commands (ai_learning_admin, knowledge_stats)
+│   └── utils/                    # config, logging, embeds, state, health_server, process_lock
 ├── tests/
 │   ├── unit/                     # 161+ Unit-Tests
 │   ├── integration/              # End-to-End-Workflows
@@ -72,20 +75,27 @@ shadowops-bot/
 
 ### Module unter `src/integrations/`
 
+Flache Module:
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
 - `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
 - `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
+
+Pakete (Unterverzeichnisse):
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (core, batch_mixin, executor_mixin, planner_mixin, recovery_mixin, discord_mixin)
+- `github_integration/` — Webhooks mit HMAC-SHA256 Verification + Jules SecOps Workflow + Multi-Agent Review Pipeline (core, webhook_mixin, jules_workflow_mixin, event_handlers_mixin, agent_review/)
+- `security_engine/` — Autonomer SecurityScanAgent: taeglich + weekly-deep (scan_agent, engine, db, executor, fixer_adapters, learning_bridge, activity_monitor, prompts, providers, models)
+- `fixers/` — Spezialisierte Fixer-Klassen (aide_fixer, crowdsec_fixer, fail2ban_fixer, trivy_fixer, walg_fixer)
+- `analyst/` — Legacy Security Analyst (security_analyst, analyst_db, activity_monitor, prompts) — nicht mehr von Engine gestartet
+- `ai_learning/` — Cross-Agent Lernschicht (continuous_learning_agent, knowledge_db, knowledge_synthesizer)
 
 ## Coding-Conventions
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ projects:
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letzte Docker Scan Ergebnisse (Trivy)
 
 #### Auto-Remediation
 - `/remediation-stats` - Auto-Remediation Statistiken
@@ -257,12 +258,16 @@ projects:
 - `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
 
 #### AI & Learning System
-- `/get-ai-stats` - AI-Provider Status und Fallback-Chain
+- `/get-ai-stats` - AI-Provider Status und Fallback-Chain (Codex/Claude CLI)
 - `/reload-context` - Lade Project-Context neu
+- `/agent-stats` - Agent-Learning Statistiken (Knowledge Base, Feedback, Session-History)
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+
+#### Security Engine
+- `/security-engine` - Security Engine v6 Status, Statistiken und aktive Findings
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -442,6 +447,7 @@ Security Commands:
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
   /aide                - AIDE Check-Status
+  /docker              - Letzte Docker Scan Ergebnisse
 
 Auto-Remediation:
   /remediation-stats             - Statistiken
@@ -449,12 +455,16 @@ Auto-Remediation:
   /set-approval-mode [mode]      - Approval Mode ändern
 
 AI System:
-  /get-ai-stats                  - AI Provider Status
+  /get-ai-stats                  - AI Provider Status (Codex/Claude CLI)
   /reload-context                - Context neu laden
+  /agent-stats                   - Agent-Learning Statistiken
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+
+Security Engine:
+  /security-engine               - Security Engine v6 Status + Stats
 ```
 
 ### GitHub Webhook Setup
@@ -498,20 +508,25 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
-│   │   ├── admin.py
-│   │   ├── inspector.py
-│   │   └── monitoring.py
+│   ├── cogs/                           # Modulare Slash Commands
+│   │   ├── admin.py                    # scan, stop-all-fixes, remediation-stats, set-approval-mode, reload-context, release-notes, pending-notes, mark-duplicate
+│   │   ├── inspector.py                # get-ai-stats, projekt-status, alle-projekte, agent-stats, security-engine
+│   │   ├── monitoring.py               # status, bans, threats, docker, aide
+│   │   ├── customer_setup_commands.py  # setup-customer-server
+│   │   ├── cron_heartbeat.py           # Scheduled heartbeat tasks
+│   │   └── phase_5e_health_aggregator.py  # Health aggregation (Phase 5e)
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (package)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules SecOps + Agent Review (package)
+│   │   ├── security_engine/            # Autonomous SecurityScanAgent (package)
+│   │   ├── fixers/                     # Specialized fixer classes (package)
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
@@ -520,12 +535,16 @@ shadowops-bot/
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
+│   ├── patch_notes/                    # 5-stage Patch Notes Pipeline
+│   ├── schemas/                        # JSON Schemas for Structured Output
+│   ├── commands/                       # Admin commands (ai_learning_admin, knowledge_stats)
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
-│       └── discord_logger.py           # Discord Channel Logger
+│       ├── discord_logger.py           # Discord Channel Logger
+│       └── health_server.py            # Health-Check HTTP endpoint
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
 │   ├── unit/                           # Unit Tests (161)
@@ -541,17 +560,14 @@ shadowops-bot/
 │   └── integration/
 │       └── test_learning_workflow.py   # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
-│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
+│   ├── config.example.yaml             # Template (commited)
+│   ├── config.yaml                     # Real config (gitignored)
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
+│   ├── logrotate.conf                  # Log-Rotation
+│   ├── DO-NOT-TOUCH.md                 # Critical files protection
+│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
+│   └── PROJECT_*.md                    # Per-Projekt-Notizen
 ├── deploy/                             # Deployment
 │   └── shadowops-bot.service           # systemd Unit
 ├── scripts/                            # Utility-Skripte
@@ -562,8 +578,9 @@ shadowops-bot/
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
 ├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+│   ├── reference/api.md                # API-Referenz
+│   ├── SECURITY_ANALYST.md
+│   ├── SETUP_GUIDE.md
 │   ├── adr/                            # Architecture Decision Records
 │   ├── plans/                          # Design-Dokumente
 │   └── archive/                        # Historische Doku

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -164,10 +164,9 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
-- Active fallback chain
+- Codex CLI status (primary engine, configured models)
+- Claude CLI status (fallback engine, configured models)
+- Active routing configuration (critical/high/low/verify)
 - Request counts per provider
 
 **Example:**
@@ -268,23 +267,26 @@ channels:
 # AI CONFIGURATION
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true                             # Global toggle (disables all AI features when false)
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  codex:                                    # Primary engine — Codex CLI (OpenAI)
+    cli_path: "codex"                       # CLI path (must be in PATH)
+    models:
+      fast: "gpt-5.3-codex"               # Fast analyses
+      standard: "gpt-5.3-codex"           # Standard analyses + structured output
+      thinking: "o3"                       # Complex planning tasks
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  claude:                                   # Fallback engine — Claude CLI (Anthropic)
+    cli_path: "/home/user/.local/bin/claude"
+    models:
+      fast: "claude-sonnet-4-6"
+      standard: "claude-sonnet-4-6"
+      thinking: "claude-opus-4-6"          # Security Analyst sessions
+
+  timeouts:
+    codex_seconds: 300                      # 5 min for Codex CLI
+    claude_seconds: 300                     # 5 min for Claude CLI
+    analyst_seconds: 1800                   # 30 min for Security Analyst sessions
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -582,8 +584,8 @@ Fallback auf das jeweils andere Modell bei Timeout oder leerer Response.
 ```python
 from src.integrations.knowledge_base import KnowledgeBase
 
-# Initialize
-kb = KnowledgeBase(db_path="data/knowledge_base.db")
+# Initialize (DSN from config.yaml: security_analyst.database_dsn or SECURITY_ANALYST_DB_URL env var)
+kb = KnowledgeBase(config=config)
 
 # Record a fix
 kb.record_fix(
@@ -791,29 +793,20 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+### Knowledge Base (PostgreSQL — `security_analyst` DB)
 
-#### fixes table
-```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
-    severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
-    duration_seconds REAL,
-    error_message TEXT,
-    retry_count INTEGER DEFAULT 0
-);
+Key tables in the `security_analyst` database (asyncpg pool, min 2 / max 5 connections):
 
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
-```
+| Table | Purpose |
+|-------|---------|
+| `fix_attempts_v2` | All fix results (success, failed, no_op, skipped_duplicate) |
+| `fix_verifications` | Post-fix verification outcomes |
+| `finding_quality` | Per-finding confidence scores and false-positive tracking |
+| `scan_coverage` | Coverage gaps, hotspots, recheck schedules |
+| `remediation_status` | Cross-mode lock: claim_event / release_event |
+| `jules_pr_reviews` | Jules workflow PR state, iteration counter |
+
+Full schema: see `src/integrations/security_engine/db.py` and `src/integrations/analyst/analyst_db.py`.
 
 ### Project Monitor State (JSON)
 
@@ -894,9 +887,9 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI**: Timeout controlled by `ai.timeouts.codex_seconds` (default: 300s); no built-in request delay
+- **Claude CLI**: Timeout controlled by `ai.timeouts.claude_seconds` (default: 300s); no built-in request delay
+- Both engines use exponential backoff on subprocess failures (1s, 2s, 4s)
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)
@@ -951,12 +944,12 @@ debug_mode: true
 
 ### Common API Issues
 
-**Knowledge Base locked:**
+**Knowledge Base issues (PostgreSQL):**
 ```bash
-# Check if database is locked
-sqlite3 data/knowledge_base.db "PRAGMA busy_timeout=5000;"
+# Check DB connectivity
+python3 -c "from src.integrations.knowledge_base import KnowledgeBase; print('OK')"
 
-# If still locked, restart bot
+# Restart bot to reset connection pool
 sudo systemctl restart shadowops-bot
 ```
 


### PR DESCRIPTION
Routine doku-worker run 2026-05-08. Zwei thematische Commits in einem PR.

---

## Commit 1 — Drift-Korrekturen

### docs/reference/api.md
- **Ollama komplett entfernt**: `ai.ollama`-Block aus Configuration Reference geloescht; Ollama-Zeilen aus `/get-ai-stats`-Beschreibung und Rate-Limiting-Sektion entfernt. Grund: Ollama wurde in v4.0 vollstaendig aus dem Code entfernt (1364 Zeilen Dead Code, steht in CLAUDE.md).
- **AI-Config-Block aktualisiert**: Zeigt jetzt die tatsaechliche Dual-Engine-Struktur (`ai.codex` + `ai.claude` + `ai.timeouts`) aus `config.example.yaml` statt der alten `ai.ollama/anthropic/openai`-Struktur.
- **KnowledgeBase-API**: `db_path="data/knowledge_base.db"` (SQLite) ersetzt durch korrekten PostgreSQL-Hinweis (`security_analyst` DB via DSN aus config). Troubleshooting-Kommando `sqlite3 ...` entfernt.
- **Database Schema Section**: SQLite-`CREATE TABLE`-Block ersetzt durch korrekte PostgreSQL-Tabellenliste (`fix_attempts_v2`, `remediation_status`, `jules_pr_reviews`, etc.) mit Verweis auf Quellcode.

### CLAUDE.md
- **Integrations-Liste**: `orchestrator.py` und `github_integration.py` als Packages markiert (nicht mehr flat files). Fehlende Packages ergaenzt: `security_engine/`, `fixers/`, `analyst/`, `ai_learning/` — jeweils mit kurzem Zweck.
- **Verzeichnisstruktur**: `patch_notes/`, `schemas/`, `commands/` zu `src/` ergaenzt. `utils/` um `health_server.py` und `process_lock.py` ergaenzt. `cogs/`-Beschreibung listet jetzt alle 6 Cog-Dateien.

---

## Commit 2 — Luecken gefuellt

### README.md — Slash Commands
- `/docker` ergaenzt (in `monitoring.py`, war nicht dokumentiert)
- `/agent-stats` ergaenzt (in `inspector.py`, war nicht dokumentiert)
- `/security-engine` ergaenzt (in `inspector.py`, war nicht dokumentiert)
- Beide Command-Listen (Features-Sektion + Verwendung-Sektion) aktualisiert.

### README.md — Projektstruktur
- Cog-Liste von 3 auf 6 Dateien erweitert (`customer_setup_commands.py`, `cron_heartbeat.py`, `phase_5e_health_aggregator.py` ergaenzt), jeweils mit Commands-Uebersicht.
- `orchestrator/`, `github_integration/`, `security_engine/`, `fixers/` als Packages dargestellt.
- `patch_notes/`, `schemas/`, `commands/` ergaenzt.
- Doppelter `config/`-Block zusammengefuehrt.
- `docs/API.md` → `docs/reference/api.md` korrigiert.

### .routines/state/doku.json
- Run-Timestamp, sync-Timestamps pro Datei, offenes Issue #221 eingetragen.

---

## Nicht in diesem PR (bewusst ausgelassen)

- **Anti-Bloat README**: v3.x Highlights-Sektionen → Issue #221 eroeffnet, da Content-Deletion solo-dev Entscheidung.
- **`/release-notes`, `/pending-notes`, `/mark-duplicate`**: In `admin.py` vorhanden, aber Beschreibung und Parameter unklar ohne vollstaendige Cog-Analyse — bei naechstem Lauf oder via Issue klaeren.

https://claude.ai/code/session_01UYPbqPjtBeVrnGxr1DMbK3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYPbqPjtBeVrnGxr1DMbK3)_