### PR TITLE
docs: korrigiere Drift in api.md und README (AI-Config, Commands, Struktur)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,23 +246,36 @@ projects:
 
 #### Security & Monitoring
 - `/status` - Gesamt-Sicherheitsstatus
-- `/scan` - Manuellen Docker-Scan triggern
-- `/threats` - Letzte erkannte Bedrohungen
-- `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
+- `/threats [hours]` - Letzte erkannte Bedrohungen
+- `/bans [limit]` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letzte Docker Scan Ergebnisse
 
-#### Auto-Remediation
+#### Auto-Remediation (Administrator)
+- `/scan` - Manuellen Docker-Scan triggern
 - `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes
 - `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/reload-context` - Lade Project-Context neu
+
+#### Patch Notes (Administrator)
+- `/release-notes [project]` - Gesammelte Commits als Patch Notes veröffentlichen
+- `/pending-notes` - Zeige ausstehende Commit-Batches
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
-- `/reload-context` - Lade Project-Context neu
+- `/agent-stats` - Agent-Learning Statistiken (few-shot, quality scores)
+- `/security-engine` - Security Engine v6 Status und Statistiken
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+
+#### Learning Feedback (Administrator)
+- `/mark-duplicate [parent_id] [child_id]` - Finding als Duplikat markieren
+
+#### Customer Setup (Administrator)
+- `/setup-customer-server` - Monitoring-Channels auf Kunden-Discord einrichten
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -438,23 +451,36 @@ deployment:
 ```
 Security Commands:
   /status              - Gesamt-Sicherheitsstatus
-  /scan                - Docker Security Scan
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
   /aide                - AIDE Check-Status
+  /docker              - Letzte Docker Scan Ergebnisse
 
-Auto-Remediation:
+Auto-Remediation (Admin):
+  /scan                          - Docker Security Scan
   /remediation-stats             - Statistiken
   /stop-all-fixes                - Emergency Stop
   /set-approval-mode [mode]      - Approval Mode ändern
-
-AI System:
-  /get-ai-stats                  - AI Provider Status
   /reload-context                - Context neu laden
+
+Patch Notes (Admin):
+  /release-notes [project]       - Patch Notes veröffentlichen
+  /pending-notes                 - Ausstehende Batches anzeigen
+
+AI & Learning:
+  /get-ai-stats                  - AI Provider Status
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+
+Learning Feedback (Admin):
+  /mark-duplicate [parent] [child] - Finding als Duplikat markieren
+
+Customer Setup (Admin):
+  /setup-customer-server         - Monitoring-Channels einrichten
 ```
 
 ### GitHub Webhook Setup
@@ -498,84 +524,69 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
+│   ├── cogs/                           # Modulare Slash Commands
 │   │   ├── admin.py
 │   │   ├── inspector.py
-│   │   └── monitoring.py
+│   │   ├── monitoring.py
+│   │   ├── customer_setup_commands.py
+│   │   ├── cron_heartbeat.py
+│   │   └── phase_5e_health_aggregator.py
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (package)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules Workflow (package)
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
-│   │   ├── incident_manager.py         # Incident Tracking
+│   │   ├── incident_manager.py         # Incident Threads in Discord
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
+│   │   ├── security_engine/            # SecurityScanAgent v6 (package)
+│   │   ├── analyst/                    # Legacy Security Analyst (package)
+│   │   ├── fixers/                     # Fix-Adapter (aide, crowdsec, fail2ban, trivy, walg)
+│   │   ├── ai_learning/                # Continuous Learning Agent (package)
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
+│   ├── patch_notes/                    # Patch Notes Pipeline v6 (5-stage state machine)
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       └── discord_logger.py           # Discord Channel Logger
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (161)
-│   │   ├── test_config.py
-│   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
-│   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
-│   │   ├── test_orchestrator.py
-│   │   ├── test_knowledge_base.py
-│   │   ├── test_event_watcher.py
-│   │   ├── test_github_integration.py
-│   │   ├── test_project_monitor.py
-│   │   └── test_incident_manager.py
-│   └── integration/
-│       └── test_learning_workflow.py   # End-to-End Tests
+│   ├── unit/                           # Unit Tests
+│   └── integration/                    # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
+│   ├── config.example.yaml             # Template (committed)
+│   ├── config.yaml                     # Real config (gitignored)
+│   ├── DO-NOT-TOUCH.md                 # Critical files protection
 │   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
-│   ├── config.recommended.yaml         # Empfehlungen
-│   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
-├── deploy/                             # Deployment
+│   └── PROJECT_*.md                    # Per-Projekt-Notizen
+├── deploy/
 │   └── shadowops-bot.service           # systemd Unit
 ├── scripts/                            # Utility-Skripte
-│   ├── restart.sh                      # Bot neustarten (--pull, --logs)
-│   ├── diagnose-bot.sh                 # Diagnose
-│   ├── setup.sh                        # Erstinstallation
-│   └── ...
 ├── data/                               # Runtime-Daten (gitignored)
-├── logs/                               # Log-Dateien (gitignored)
-├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+├── logs/                               # Logs (gitignored)
+├── docs/
+│   ├── SECURITY_ANALYST.md
+│   ├── SETUP_GUIDE.md
+│   ├── reference/api.md                # API-Referenz
 │   ├── adr/                            # Architecture Decision Records
-│   ├── plans/                          # Design-Dokumente
-│   └── archive/                        # Historische Doku
-├── .claude/                            # KI-Konfiguration
-│   ├── rules/                          # Pfad-gefilterte Rules
-│   ├── skills/                         # Workflow-Skills
-│   └── agents/                         # Spezialisierte Agents
-├── requirements.txt                    # Python Dependencies
-├── pyproject.toml                      # Projekt-Definition
+│   └── plans/                          # Design-Dokumente
+├── .claude/                            # KI-spezifische Configs
+├── .routines/                          # Worker State + Prompts
+├── requirements.txt
 ├── CLAUDE.md                           # KI-Projektinstruktionen
-├── CHANGELOG.md                        # Version History
-└── README.md                           # This file
+├── CHANGELOG.md
+└── README.md
 ```
 
 ## 🛡️ Security

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -164,9 +164,8 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
+- Codex CLI status (enabled/disabled, model, availability)
+- Claude CLI status (enabled/disabled, model, availability)
 - Active fallback chain
 - Request counts per provider
 
@@ -268,23 +267,36 @@ channels:
 # AI CONFIGURATION
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true                             # Global AI toggle
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  # === CODEX CLI (PRIMARY) ===
+  codex:
+    cli_path: "codex"                       # Path to Codex CLI binary
+    models:
+      fast: "gpt-5.3-codex"                # Fast analyses
+      standard: "gpt-5.3-codex"            # Standard analyses + Structured Output
+      thinking: "o3"                        # Complex planning tasks
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  # === CLAUDE CLI (FALLBACK + VERIFY) ===
+  claude:
+    cli_path: "/home/user/.local/bin/claude"  # Path to Claude CLI binary
+    models:
+      fast: "claude-sonnet-4-6"            # Fast analyses
+      standard: "claude-sonnet-4-6"        # Standard analyses
+      thinking: "claude-opus-4-6"          # Security Analyst sessions
+
+  # === TIMEOUTS ===
+  timeouts:
+    codex_seconds: 300                      # 5 min for Codex CLI
+    claude_seconds: 300                     # 5 min for Claude CLI
+    analyst_seconds: 1800                   # 30 min for Security Analyst sessions
+
+  # === ROUTING (optional overrides) ===
+  routing:
+    critical_analysis: { engine: codex, model: thinking }
+    high_analysis: { engine: codex, model: standard }
+    low_analysis: { engine: codex, model: fast }
+    critical_verify: { engine: claude, model: thinking }
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -791,28 +803,31 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+### PostgreSQL Databases
 
-#### fixes table
+ShadowOps uses three PostgreSQL databases. Connection strings come from environment variables or `config.yaml` (never hardcoded):
+
+| Database | Env var | Config key | Purpose |
+|----------|---------|------------|---------|
+| `security_analyst` | `SECURITY_ANALYST_DB_URL` | `security_analyst.database_dsn` | Fix attempts, findings, Jules reviews |
+| `agent_learning` | `AGENT_LEARNING_DB_URL` | `agent_learning.database_dsn` | Few-shot examples, quality scores, knowledge |
+| `seo_agent` | — | — | SEO-specific tables (managed by seo-agent project) |
+
+#### fix_attempts_v2 table (security_analyst)
 ```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
+CREATE TABLE fix_attempts_v2 (
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    event_signature TEXT NOT NULL,
+    event_type TEXT NOT NULL,
     severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
+    event_details JSONB,
+    strategy JSONB NOT NULL,
+    result TEXT NOT NULL,  -- 'success', 'failed', 'no_op', 'skipped_duplicate'
     duration_seconds REAL,
     error_message TEXT,
     retry_count INTEGER DEFAULT 0
 );
-
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
 ```
 
 ### Project Monitor State (JSON)
@@ -894,9 +909,8 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI**: Controlled by process-level concurrency (SmartQueue Semaphore=3)
+- **Claude CLI**: Controlled by process-level concurrency; falls back to Codex on timeout
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)
@@ -951,12 +965,15 @@ debug_mode: true
 
 ### Common API Issues
 
-**Knowledge Base locked:**
+**Knowledge Base issues:**
 ```bash
-# Check if database is locked
-sqlite3 data/knowledge_base.db "PRAGMA busy_timeout=5000;"
+# Check PostgreSQL connection
+psql "$SECURITY_ANALYST_DB_URL" -c "SELECT 1;"
 
-# If still locked, restart bot
+# Check asyncpg pool (bot logs)
+sudo journalctl -u shadowops-bot -f | grep -i "pool\|pg\|asyncpg"
+
+# If pool exhausted, restart bot
 sudo systemctl restart shadowops-bot
 ```
 


### PR DESCRIPTION
## Aenderungen

### docs/reference/api.md
- **AI-Config-Block**: Ollama/Anthropic API/OpenAI-Konfiguration durch aktuelle Codex CLI + Claude CLI Konfiguration ersetzt. Der Bot nutzt seit v4.0 keine direkte Anthropic API mehr, sondern ausschliesslich CLI-Tools.
- **`/get-ai-stats` Returns**: "Ollama status"-Eintrag entfernt (Ollama wurde in v4.0 vollstaendig entfernt, 1364 Zeilen Dead Code geloescht).
- **Datenbank-Schema-Sektion**: SQLite-Schema (`CREATE TABLE fixes`) durch PostgreSQL-Uebersichtstabelle ersetzt. Das System nutzt seit v5.0 asyncpg mit drei PostgreSQL-Datenbanken, keine SQLite mehr.
- **Rate-Limiting-Sektion**: Ollama-Zeile entfernt, durch korrekte SmartQueue-Semaphore-Beschreibung ersetzt.
- **Troubleshooting "KB locked"**: `sqlite3`-Befehl durch PostgreSQL/asyncpg-Diagnose ersetzt.

### README.md
- **Slash-Commands-Sektion**: 7 fehlende Commands ergaenzt (`/docker`, `/agent-stats`, `/security-engine`, `/release-notes`, `/pending-notes`, `/mark-duplicate`, `/setup-customer-server`). Admin-Permissions pro Command korrekt markiert.
- **Doppelter `config/`-Block**: Entfernt (war zweimal im Projekt-Struktur-Abschnitt vorhanden).
- **Projekt-Struktur**: Auf aktuelle Paket-Struktur aktualisiert (`orchestrator/`, `github_integration/`, `security_engine/`, `analyst/`, `fixers/`, `ai_learning/`, `patch_notes/` als Pakete eingetragen).
- **`docs/API.md`-Pfad**: Korrigiert auf `docs/reference/api.md`.

## Begruendung

Alle Aenderungen sind reine Drift-Korrekturen — kein Code, keine Verhaltensaenderung. Die Doku beschrieb den Stand von v3.x, der Bot laeuft auf v5.1.

https://claude.ai/code/session_012si1XAcu1cfpuDeoeK3XJF

---
_Generated by [Claude Code](https://claude.ai/code/session_012si1XAcu1cfpuDeoeK3XJF)_