### PR TITLE
docs: README + api.md Drift-Korrekturen

### DIFF
--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,13 +2,39 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": null,
-  "last_drift_check": null,
-  "open_prs": [],
+  "last_run": "2026-05-10",
+  "last_drift_check": "2026-05-10",
+  "open_prs": [
+    {
+      "branch": "claude/doku/readme-api-drift",
+      "title": "docs: README + api.md Drift-Korrekturen",
+      "opened": "2026-05-10",
+      "status": "open"
+    },
+    {
+      "branch": "claude/doku/claude-md-structure-gaps",
+      "title": "docs: CLAUDE.md Verzeichnisstruktur-Update",
+      "opened": "2026-05-10",
+      "status": "open"
+    }
+  ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": null },
-    "CLAUDE.md": { "last_synced_with_code_at": null },
-    "docs/reference/api.md": { "last_synced_with_code_at": null }
+    "README.md": { "last_synced_with_code_at": "2026-05-10" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-10" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-10" }
   },
-  "open_questions": []
+  "open_questions": [
+    {
+      "issue": 225,
+      "file": "config/DO-NOT-TOUCH.md",
+      "question": "Datei fehlt im Repo — Maintainer muss Inhalt liefern",
+      "opened": "2026-05-10"
+    }
+  ],
+  "notes": [
+    "README anti-bloat: 174 Zeilen (Highlights v3.1-v3.4) entfernt. README jetzt 617 Zeilen (war 773). Weitere Reduktion moeglich durch Kuerzen der Quick-Start-Section, aber inhaltlich riskant ohne Maintainer-Input.",
+    "api.md: Ollama komplett entfernt aus Config-Reference, get-ai-stats, Rate Limiting, Error Codes. Codex+Claude CLI Struktur eingepflegt.",
+    "7 fehlende Slash Commands ergaenzt in README und api.md: /docker, /agent-stats, /security-engine, /release-notes, /pending-notes, /mark-duplicate, /setup-customer-server.",
+    "Verzeichnisstruktur in README: orchestrator/ und github_integration/ als Directories markiert, security_engine/ und patch_notes/ ergaenzt, cogs-Liste vervollstaendigt, doppelter config/-Block entfernt, docs/API.md -> docs/reference/api.md korrigiert."
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -56,180 +56,6 @@ Event → TaskRouter → Codex CLI (Primary)
                SmartQueue (Fix-Lock + Circuit Breaker)
 ```
 
-## ⚡ Highlights v3.4
-
-### 🧠 **Advanced AI Learning System (v3.4 - NEW)**
-- ✅ **Vollständige KI-Trainings-Pipeline**: Kontinuierliches Lernen für bessere Patch Notes
-  - CHANGELOG.md-Parsing für vollständigen Kontext
-  - Automatische Qualitätsbewertung (0-100 Skala)
-  - Few-Shot-Learning mit Top-10 Beispielen
-  - Trainingsdaten-Sammlung (≥80 Score)
-- ✅ **Discord Feedback-Sammlung**
-  - Automatische Reaktions-Buttons (👍 ❤️ 🔥 👎 😐 ❌)
-  - Benutzer-Feedback trainiert die KI
-  - Funktioniert für ALLE Projekte automatisch
-- ✅ **A/B Testing System**
-  - 3 Prompt-Varianten mit Performance-Tracking
-  - Gewichtete Auswahl basierend auf Erfolg
-  - Kombinierte Bewertung (70% Qualität + 30% Feedback)
-- ✅ **Auto-Tuning Engine**
-  - Automatische Performance-Analyse
-  - Verbesserungsvorschläge
-  - Automatische Varianten-Erstellung
-- ✅ **Fine-Tuning Export**
-  - JSONL-Format für LLM Fine-Tuning
-  - LoRA-Format (Alpaca-Style)
-  - Auto-generiertes Fine-Tuning-Script
-- ✅ **Admin-Befehle**
-  - `/ai-stats` - Trainings-Statistiken
-  - `/ai-variants` - Varianten-Übersicht
-  - `/ai-tune` - Tuning-Vorschläge
-  - `/ai-export-finetune` - Export für Training
-- ✅ **Multi-Projekt-Unterstützung**
-  - Gemeinsamer Lern-Pool (alle profitieren voneinander)
-  - Zero-Config (automatisch für `use_ai: true`)
-  - Projekt-übergreifendes Lernen
-- ✅ **Intelligentes RAM-Management**
-  - Automatische Prozess-Bereinigung
-  - System-Cache-Flush als Fallback
-  - Schützt kritische Services (PostgreSQL, Redis, etc.)
-
-## ⚡ Highlights v3.3
-
-### 🔐 **Webhook Security (v3.3 - NEW)**
-- ✅ **HMAC-SHA256 Signature Verification**: Sichere GuildScout ↔ ShadowOps Kommunikation
-  - Schützt vor gefälschten/gespooften Alerts
-  - Validiert Webhook-Authentizität mit Shared Secret
-  - Constant-time Signatur-Vergleich verhindert Timing-Attacks
-  - Konfigurierbar per Projekt: `webhook_secret` in Config
-- ✅ **Automatische Request-Validierung**
-  - Validiert `X-Webhook-Signature` Header Format
-  - Lehnt ungültige Signaturen mit HTTP 403 ab
-  - Abwärtskompatibel (Legacy-Modus ohne Secret)
-  - Detailliertes Security-Logging für Audits
-- ✅ **Erweiterte GuildScout Integration**
-  - Unterstützt alle neuen GuildScout v2.3.0 Alerts:
-    - Health Monitoring Alerts
-    - Performance Profiling Events
-    - Weekly Report Summaries
-    - Database Monitoring Warnings
-
-**Konfiguration:**
-```yaml
-projects:
-  guildscout:
-    webhook_secret: YOUR_RANDOM_SECRET_HERE  # python -c "import secrets; print(secrets.token_urlsafe(32))"
-    # Muss identisch mit GuildScout Config sein!
-```
-
-**Security Best Practices:**
-- Verwende starke, zufällige Secrets (min. 32 Zeichen)
-- Rotiere Secrets regelmäßig (alle 90 Tage)
-- Verwende HTTPS für Produktions-Webhooks
-- Überwache abgelehnte Requests (403 Errors)
-
-## ⚡ Highlights v3.2
-
-### 🌐 **Multi-Guild Customer Notifications (v3.2 - NEW)**
-- ✅ **Automatic Channel Setup**: Bot auto-creates monitoring channels on customer servers
-- ✅ **External Notifications**: Send Git updates and status alerts to customer Discord servers
-- ✅ **AI-Generated Patch Notes**: Professional, user-friendly updates via Codex/Claude
-- ✅ **Dual-Channel System**: Technical logs (internal) + friendly updates (customers)
-- ✅ **Per-Project Configuration**: Configurable language (DE/EN) and notification types
-- ✅ **Message Splitting**: Automatic handling of Discord's 4096 character limit
-- ✅ **Centralized Monitoring**: ShadowOps handles all notifications (Option B)
-- ✅ **Manual Setup Command**: `/setup-customer-server` for existing guilds
-
-### 🔧 **Security Integration Fixes (v3.2 - NEW)**
-- ✅ **CrowdSec Integration Fixed**: Corrected JSON parsing, now shows "🟢 Aktiv"
-- ✅ **Fail2ban Integration Fixed**: Resolved systemd restrictions, now shows "🟢 Aktiv"
-- ✅ **GitHub Webhook Logging**: Fixed logger connection for full webhook visibility
-- ✅ **Firewall Configuration**: Port 9090 opened with HMAC security
-
-## ⚡ Highlights v3.1
-
-### 🧠 **Persistent AI Learning System (v3.1 - NEW)**
-- ✅ **SQL Knowledge Base**: Persistent storage for fixes, strategies, and success rates
-- ✅ **Git History Analysis**: Learns from past commits to understand codebase evolution
-- ✅ **Code Structure Analyzer**: Deep understanding of project architecture
-- ✅ **Log-Based Learning**: Analyzes security logs to improve threat detection
-- ✅ **Success Rate Tracking**: Historical performance metrics guide strategy selection
-- ✅ **Best Strategy Recommendations**: AI suggests fixes based on proven success
-- ✅ **Adaptive Retry Logic**: Failed fixes inform better subsequent attempts
-
-### 🌐 **Multi-Project Management (v3.1 - NEW)**
-- ✅ **GitHub Webhook Integration**: Auto-deploy on push/PR merge events
-- ✅ **Automated Patch-Notes**: Detaillierte Change-Notifications bei Git-Push für interne und Kunden-Channels.
-- ✅ **Real-Time Health Monitoring**: Continuous uptime tracking for all projects
-- ✅ **Automated Deployment**: Complete CI/CD pipeline with safety checks
-- ✅ **Incident Management**: Auto-detection, tracking, and Discord threads
-- ✅ **Customer Notifications**: Professional, user-friendly status updates
-- ✅ **Project Dashboard**: `/projekt-status` and `/alle-projekte` commands
-- ✅ **Automatic Rollback**: Failed deployments trigger instant restoration
-
-### 🧪 **Enterprise Test Suite (v3.1 - NEW)**
-- ✅ **150+ Comprehensive Tests**: Full coverage for all critical systems
-- ✅ **Unit Tests**: Config, AI Service, Orchestrator, Knowledge Base, Event Watcher
-- ✅ **Integration Tests**: End-to-end learning workflows
-- ✅ **AI Learning Documentation**: Tests demonstrate how AI learns patterns
-- ✅ **pytest Configuration**: Professional test infrastructure
-- ✅ **Test Fixtures**: 20+ reusable fixtures for consistent testing
-
-### 🛡️ **Active Security Guardian (v3.0)**
-- ✅ **Echte Fix-Execution**: NPM audit fix, Docker rebuilds, Firewall-Updates, File Restoration
-- ✅ **Automatische Backups**: Vor JEDER Änderung mit 7-Tage Retention & Rollback
-- ✅ **Impact-Analyse**: Projekt-bewusste Entscheidungen (ShadowOps, GuildScout, Nexus, Sicherheitstool)
-- ✅ **Service Management**: Graceful Start/Stop mit Health Checks & Dependency-Ordering
-- ✅ **Koordinierte Remediation**: Multi-Event Batching mit single approval flow
-- ✅ **Safety First**: Dry-Run Mode, DO-NOT-TOUCH Validation, Circuit Breaker, Command Validation
-- ✅ **Live Discord Updates**: Echtzeit-Feedback während kompletter Execution (Backup → Fix → Verify → Restart)
-
-### 🤖 **Dual-Engine AI System (v4.0)**
-- **Codex CLI (Primary)**: gpt-4o / gpt-5.3-codex / o3 mit Structured Output (JSON-Schemas)
-- **Claude CLI (Fallback)**: claude-sonnet-4-6 / claude-opus-4-6 mit MCP-Zugriff
-- **RAG Context**: Projekt-Wissen + DO-NOT-TOUCH Regeln + Infrastructure Knowledge + Code Structure
-- **SQL Knowledge Base**: Persistent learning across sessions
-- **Event History**: Remembers ALL previous fix attempts with outcomes
-- **Confidence-Based**: <85% confidence → automatisch blockiert
-- **Batch-Processing**: Mehrere Events → 1 koordinierter Plan
-- **Adaptive Strategies**: AI learns from failures and improves over time
-- **Git History Integration**: Analyzes commit patterns for better context
-
-### 🎯 Enhanced Workflow (v3.1)
-```
-1. 🚨 Security Event erkannt
-   └─> Event Watcher → Orchestrator (10s Batch-Fenster)
-
-2. 🧠 AI Query Knowledge Base
-   ├─ Check previous fixes for similar events
-   ├─ Load best strategies based on success rate
-   └─ Analyze code structure and git history
-
-3. 🤖 KI-Analyse (ALLE Events zusammen)
-   ├─ Hybrid AI mit RAG Context + KB + Code Analysis
-   ├─ Koordinierter Multi-Phasen Plan
-   └─ Impact-Analyse (Projekte, Downtime, Risks)
-
-4. ✋ Single Approval Request
-   ├─ Kompletter Plan mit allen Phasen
-   ├─ Betroffene Projekte + Downtime-Schätzung
-   ├─ Historical success rate (if applicable)
-   └─ Rollback-Strategie
-
-5. 🔧 Autonome Execution
-   ├─ Phase 0: Backups erstellen
-   ├─ Phase 1-N: Fixes ausführen (npm audit, Docker rebuild, etc.)
-   ├─ Verification: Re-Scans prüfen Erfolg
-   ├─ Bei Fehler: Automatischer Rollback!
-   └─ Record result to Knowledge Base
-
-6. ✅ Completion & Learning
-   ├─ Discord: Status + Results + Stats
-   ├─ Save fix outcome to SQL KB
-   ├─ Update success rates
-   └─ Improve future strategies
-```
-
 ## 🎯 Features
 
 ### 🔔 Auto-Alerts
@@ -250,19 +76,28 @@ projects:
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letztes Docker-Scan-Ergebnis anzeigen
 
 #### Auto-Remediation
 - `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes
 - `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
 - `/reload-context` - Lade Project-Context neu
+- `/agent-stats` - Agent-Learning-Statistiken anzeigen
+- `/security-engine` - Security Engine v6 Status und Stats
+
+#### Patch Notes
+- `/release-notes [project]` - Patch Notes generieren und veröffentlichen
+- `/pending-notes` - Offene Commits anzeigen, die noch nicht released wurden
+- `/mark-duplicate [parent_id] [child_id]` - Finding als Duplikat markieren (Learning-Feedback)
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
+- `/setup-customer-server` - Monitoring-Channels auf Kunden-Server einrichten (Admin)
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -438,10 +273,11 @@ deployment:
 ```
 Security Commands:
   /status              - Gesamt-Sicherheitsstatus
-  /scan                - Docker Security Scan
+  /scan                - Docker Security Scan (Trivy)
   /threats [hours]     - Bedrohungen der letzten X Stunden
-  /bans [limit]        - Gebannte IPs
+  /bans [limit]        - Gebannte IPs (Fail2ban + CrowdSec)
   /aide                - AIDE Check-Status
+  /docker              - Letztes Docker-Scan-Ergebnis
 
 Auto-Remediation:
   /remediation-stats             - Statistiken
@@ -451,10 +287,18 @@ Auto-Remediation:
 AI System:
   /get-ai-stats                  - AI Provider Status
   /reload-context                - Context neu laden
+  /agent-stats                   - Agent-Learning-Statistiken
+  /security-engine               - Security Engine v6 Status
+
+Patch Notes:
+  /release-notes [project]       - Patch Notes generieren
+  /pending-notes                 - Offene Commits anzeigen
+  /mark-duplicate [p_id] [c_id]  - Finding als Duplikat markieren
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
   /alle-projekte                 - Übersicht aller Projekte
+  /setup-customer-server         - Kunden-Server einrichten
 ```
 
 ### GitHub Webhook Setup
@@ -498,31 +342,36 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
+│   ├── cogs/                           # Slash Commands (Discord)
 │   │   ├── admin.py
+│   │   ├── cron_heartbeat.py
+│   │   ├── customer_setup_commands.py
 │   │   ├── inspector.py
-│   │   └── monitoring.py
+│   │   ├── monitoring.py
+│   │   └── phase_5e_health_aggregator.py
+│   ├── patch_notes/                    # Patch Notes Pipeline v6 (5-Stufen State Machine)
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (multi-module)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Agent Review Pipeline
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
+│   │   ├── security_engine/            # SecurityScanAgent v6
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       └── discord_logger.py           # Discord Channel Logger
@@ -541,17 +390,11 @@ shadowops-bot/
 │   └── integration/
 │       └── test_learning_workflow.py   # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
+│   ├── config.example.yaml             # Template (commited)
+│   ├── config.yaml                     # Real Config (gitignored)
+│   ├── config.recommended.yaml         # Empfehlungen
 │   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
 │   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
-│   ├── config.recommended.yaml         # Empfehlungen
-│   ├── safe_upgrades.yaml              # Upgrade-Pfade
-│   └── logrotate.conf                  # Log-Rotation
 ├── deploy/                             # Deployment
 │   └── shadowops-bot.service           # systemd Unit
 ├── scripts/                            # Utility-Skripte
@@ -562,10 +405,11 @@ shadowops-bot/
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
 ├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+│   ├── reference/api.md                # API-Referenz
 │   ├── adr/                            # Architecture Decision Records
+│   ├── architecture/                   # Architektur-Dokumente
 │   ├── plans/                          # Design-Dokumente
+│   ├── operations/                     # Runbooks
 │   └── archive/                        # Historische Doku
 ├── .claude/                            # KI-Konfiguration
 │   ├── rules/                          # Pfad-gefilterte Rules
@@ -692,7 +536,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for detailed version history.
 - **PostgreSQL Databases**: 3 (security_analyst: 21 Tabellen, agent_learning: 7 Tabellen, seo_agent: 11 Tabellen)
 - **Learning Pipeline Tables**: 11 (Security: fix_attempts, fix_verifications, finding_quality, scan_coverage · Shared: agent_feedback, agent_quality_scores, agent_knowledge · Patch Notes: pn_generations, pn_variants, pn_examples · SEO: seo_fix_impact)
 - **Scan Areas**: 10 (firewall, ssh, docker, permissions, packages, services, logs, network, credentials, dependencies)
-- **Discord Commands**: 15 (inkl. /agent-stats)
+- **Discord Commands**: 19
 - **Monitored Projects**: 3 (GuildScout, ZERODOX, AI Agents)
 - **Auto Discord-Posts**: Session-Summaries, Feedback-Auswertungen, Weekly Summary, Meilensteine
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -159,16 +159,16 @@ Changes the auto-remediation approval mode.
 ### AI & Learning System Commands
 
 #### `/get-ai-stats`
-Shows AI provider status, fallback chain, and usage statistics.
+Shows AI provider status, failover chain, and usage statistics.
 
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
-- Active fallback chain
+- Codex CLI status (model, last response time)
+- Claude CLI status (model, last response time)
+- Active failover chain
 - Request counts per provider
+- Token usage (last session)
 
 **Example:**
 ```
@@ -176,7 +176,7 @@ Shows AI provider status, fallback chain, and usage statistics.
 ```
 
 #### `/reload-context`
-Reloads all project context files (DO-NOT-TOUCH, INFRASTRUCTURE, PROJECT_*.md).
+Reloads all project context files (INFRASTRUCTURE, PROJECT_*.md).
 
 **Permissions:** Administrator
 **Parameters:** None
@@ -187,10 +187,74 @@ Reloads all project context files (DO-NOT-TOUCH, INFRASTRUCTURE, PROJECT_*.md).
 /reload-context
 ```
 
-**Use Cases:**
-- After updating DO-NOT-TOUCH.md
-- After modifying project documentation
-- After adding new infrastructure knowledge
+#### `/agent-stats`
+Shows agent learning statistics from the `agent_learning` database.
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Embed with learning metrics, feedback counts, few-shot example counts
+
+**Example:**
+```
+/agent-stats
+```
+
+#### `/security-engine`
+Shows Security Engine v6 status and statistics.
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Embed with scan status, circuit breaker state, finding counts, last scan time
+
+**Example:**
+```
+/security-engine
+```
+
+---
+
+### Patch Notes Commands
+
+#### `/release-notes [project]`
+Generates and publishes patch notes for a monitored project via the Pipeline v6.
+
+**Permissions:** Administrator
+**Parameters:**
+- `project` (required): Project name (e.g., guildscout, shadowops-bot)
+
+**Returns:** Confirmation; patch notes posted to configured Discord channels
+
+**Example:**
+```
+/release-notes guildscout
+```
+
+#### `/pending-notes`
+Shows commits that have been accumulated but not yet released as patch notes.
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** List of pending commits per project with counts
+
+**Example:**
+```
+/pending-notes
+```
+
+#### `/mark-duplicate [parent_id] [child_id]`
+Marks a security finding as a duplicate of another finding (learning feedback).
+
+**Permissions:** Administrator
+**Parameters:**
+- `parent_id` (required): ID of the original finding
+- `child_id` (required): ID of the duplicate finding
+
+**Returns:** Confirmation of learning update
+
+**Example:**
+```
+/mark-duplicate 42 87
+```
 
 ---
 
@@ -232,6 +296,34 @@ Shows overview of all monitored projects.
 /alle-projekte
 ```
 
+#### `/setup-customer-server`
+Sets up monitoring channels on the current customer Discord server. Admin-only.
+
+**Permissions:** Administrator
+**Parameters:** None
+**Returns:** Confirmation with created channel IDs
+
+**Example:**
+```
+/setup-customer-server
+```
+
+---
+
+### Docker Commands
+
+#### `/docker`
+Shows the latest Docker security scan results from Trivy.
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Embed with vulnerabilities by severity (CRITICAL / HIGH / MEDIUM / LOW) and scan timestamp
+
+**Example:**
+```
+/docker
+```
+
 ---
 
 ## Configuration Reference
@@ -268,23 +360,29 @@ channels:
 # AI CONFIGURATION
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true                             # Global AI toggle
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  # Codex CLI (Primary engine — requires OpenAI Codex access)
+  codex:
+    cli_path: "codex"                       # Path to Codex CLI binary
+    models:
+      fast: "gpt-5.3-codex"                 # Fast analyses
+      standard: "gpt-5.3-codex"            # Standard analyses + Structured Output
+      thinking: "o3"                        # Complex planning tasks
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  # Claude CLI (Fallback + Verify — requires Anthropic Claude access)
+  claude:
+    cli_path: "/home/user/.local/bin/claude"
+    models:
+      fast: "claude-sonnet-4-6"             # Fast analyses
+      standard: "claude-sonnet-4-6"         # Standard analyses
+      thinking: "claude-opus-4-6"           # Security Analyst sessions
+
+  # Timeouts in seconds
+  timeouts:
+    codex_seconds: 300                      # 5 min per Codex request
+    claude_seconds: 300                     # 5 min per Claude request
+    analyst_seconds: 1800                   # 30 min for Security Analyst sessions
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -873,9 +971,10 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 - `Missing required field: discord.token` - Required config missing
 
 #### AI Service Errors
-- `No AI providers enabled` - All AI services disabled
-- `Ollama connection failed` - Cannot reach Ollama server
-- `AI request timeout` - AI provider took too long
+- `No AI providers enabled` - All AI services disabled (`ai.enabled: false`)
+- `Codex CLI not found` - `codex` binary not in PATH or wrong `ai.codex.cli_path`
+- `Claude CLI not found` - `claude` binary not found at configured `ai.claude.cli_path`
+- `AI request timeout` - Provider CLI timed out; bot retries with the other engine
 
 #### Deployment Errors
 - `Project not found in deployment config` - Unknown project
@@ -894,9 +993,9 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI**: Timeout per request (`ai.timeouts.codex_seconds`, default: 300s)
+- **Claude CLI**: Timeout per request (`ai.timeouts.claude_seconds`, default: 300s)
+- Both engines: Automatic failover to the other engine on timeout or error
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)


### PR DESCRIPTION
## Was wurde geaendert

### README.md

**Fehlende Slash Commands ergaenzt (7 Commands):**
- `/docker` — zeigt letztes Docker-Scan-Ergebnis (in `monitoring.py` vorhanden, fehlte in Doku)
- `/agent-stats` — Agent-Learning-Statistiken (`inspector.py`)
- `/security-engine` — Security Engine v6 Status (`inspector.py`)
- `/release-notes [project]` — Patch Notes generieren (`admin.py`)
- `/pending-notes` — offene Commits anzeigen (`admin.py`)
- `/mark-duplicate [p_id] [c_id]` — Learning-Feedback (`admin.py`)
- `/setup-customer-server` — Kunden-Server einrichten (`customer_setup_commands.py`)

**Verzeichnisstruktur korrigiert:**
- `orchestrator.py` → `orchestrator/` (ist ein Package, kein einzelnes Modul)
- `github_integration.py` → `github_integration/` (ist ein Package)
- `security_engine/` ergaenzt (fehlt komplett)
- `patch_notes/` ergaenzt (fehlt komplett — 2100 LOC Pipeline v6)
- `cogs/`-Liste vervollstaendigt: `cron_heartbeat.py`, `customer_setup_commands.py`, `phase_5e_health_aggregator.py`
- Doppelter `config/`-Block entfernt
- `docs/API.md` → `docs/reference/api.md` (korrekter Pfad)

**Statistiken:**
- "Discord Commands: 15" → 19 (verifiziert durch Codeanalyse)

**Anti-Bloat:**
- Highlights v3.1–v3.4 entfernt (174 Zeilen) — Inhalte sind in CHANGELOG.md dokumentiert, v5.1 ist aktuell. README: 773 → 617 Zeilen.

---

### docs/reference/api.md

**Ollama komplett entfernt** (Ollama wurde in v4.0 aus dem Code entfernt — 1364 Zeilen Dead Code):
- `/get-ai-stats` Response-Beschreibung: Ollama-Status-Zeile → Codex/Claude-Status
- Config-Reference AI-Sektion: `ai.ollama`/`ai.anthropic`/`ai.openai` → `ai.codex`/`ai.claude`/`ai.timeouts` (entspricht jetzt `config.example.yaml`)
- Rate Limiting: Ollama-Delay-Zeile → Codex/Claude-Timeouts
- Error Codes: `Ollama connection failed` → `Codex CLI not found` / `Claude CLI not found`

**Fehlende Commands ergaenzt:**
- `/docker`, `/agent-stats`, `/security-engine` mit vollstaendigen Beschreibungen
- `/release-notes`, `/pending-notes`, `/mark-duplicate` als neue Sektion "Patch Notes Commands"
- `/setup-customer-server` zur Multi-Project-Sektion

---

## Begruendung

Drift-Check am 2026-05-10 durch Doku-Kurator Worker. Alle Aenderungen sind direkt aus dem Quellcode verifiziert (Cog-Dateien, Directory-Listing, `config.example.yaml`).

Separates Issue #225 fuer fehlendes `config/DO-NOT-TOUCH.md`.

---
Labels: `status:routine-generated`, `worker:doku`, `type:docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01152Qq9ZW6ihwCk22fKvhAN)_