### PR TITLE
docs: CLAUDE.md Verzeichnisstruktur-Update

### DIFF
--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,13 +2,39 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": null,
-  "last_drift_check": null,
-  "open_prs": [],
+  "last_run": "2026-05-10",
+  "last_drift_check": "2026-05-10",
+  "open_prs": [
+    {
+      "branch": "claude/doku/readme-api-drift",
+      "pr": 226,
+      "title": "docs: README + api.md Drift-Korrekturen",
+      "opened": "2026-05-10",
+      "status": "open"
+    },
+    {
+      "branch": "claude/doku/claude-md-structure-gaps",
+      "title": "docs: CLAUDE.md Verzeichnisstruktur-Update",
+      "opened": "2026-05-10",
+      "status": "open"
+    }
+  ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": null },
-    "CLAUDE.md": { "last_synced_with_code_at": null },
-    "docs/reference/api.md": { "last_synced_with_code_at": null }
+    "README.md": { "last_synced_with_code_at": "2026-05-10" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-10" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-10" }
   },
-  "open_questions": []
+  "open_questions": [
+    {
+      "issue": 225,
+      "file": "config/DO-NOT-TOUCH.md",
+      "question": "Datei fehlt im Repo — Maintainer muss Inhalt liefern",
+      "opened": "2026-05-10"
+    }
+  ],
+  "notes": [
+    "PR #226: README anti-bloat (174 Zeilen Highlights v3.1-v3.4 entfernt, README 773→617), 7 fehlende Slash Commands, Verzeichnisstruktur, Discord Commands 15→19, api.md Ollama-Drift behoben.",
+    "PR #227 (dieses PR): CLAUDE.md orchestrator.py→orchestrator/, github_integration.py→github_integration/, security_engine/ ergaenzt, patch_notes/ ergaenzt, Statistiken 150→161 Tests / 15→19 Commands, DO-NOT-TOUCH.md Broken-Link bereinigt (Issue #225).",
+    "Naechster Lauf: Pruefen ob Issue #225 beantwortet und config/DO-NOT-TOUCH.md erstellt wurde. Dann Link in CLAUDE.md wiederherstellen."
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 | AI Fallback | Claude CLI | claude-sonnet-4-6 / claude-opus-4-6 |
 | Container | Docker | mit Trivy fuer Scans |
 | Service | systemd | `/etc/systemd/system/shadowops-bot.service` |
-| Tests | pytest | 150+ Tests, unit + integration |
+| Tests | pytest | 161+ Tests, unit + integration |
 | Webhook | GitHub Webhooks | HMAC-SHA256 verifiziert |
 
 ## Architektur-Prinzipien
@@ -42,7 +42,8 @@
 shadowops-bot/
 ├── src/
 │   ├── bot.py                    # Haupt-Bot
-│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring)
+│   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring, customer_setup, cron, health)
+│   ├── patch_notes/              # Patch Notes Pipeline v6 (5-Stufen State Machine)
 │   ├── integrations/             # Externe Systeme (siehe unten)
 │   └── utils/                    # config, logging, embeds, state
 ├── tests/
@@ -75,16 +76,17 @@ shadowops-bot/
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (Package: core, planner, executor, discord, recovery, batch Mixins)
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
 - `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
-- `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
+- `context_manager.py` — RAG: Project-Context + Infra
+- `github_integration/` — Webhooks mit HMAC-SHA256 Verification + Multi-Agent Review Pipeline (Package: ci, ai_patch_notes, agent_review/)
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
+- `security_engine/` — SecurityScanAgent v6 (autonome Scans, Fixer-Adapters, Activity-Monitor, Prompts)
 - `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
 
 ## Coding-Conventions
@@ -181,7 +183,7 @@ Worker-Konventionen:
 
 ## Statistik (Stand v5.1)
 
-20.000+ LoC, 150+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
+20.000+ LoC, 161+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 19 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
 
 ## Aktuelle Doku
 
@@ -190,8 +192,9 @@ Worker-Konventionen:
 - [docs/SETUP_GUIDE.md](./docs/SETUP_GUIDE.md)
 - [docs/reference/api.md](./docs/reference/api.md)
 - [DOCS_OVERVIEW.md](./DOCS_OVERVIEW.md)
-- [config/DO-NOT-TOUCH.md](./config/DO-NOT-TOUCH.md)
+- `config/DO-NOT-TOUCH.md` — fehlt im Repo (Issue #225, Maintainer liefert Inhalt)
 
 ## Letztes Update dieser Datei
 
 2026-04-26 — initiales Setup, generiert aus Worker-Bundle.
+2026-05-10 — Doku-Kurator: Verzeichnisstruktur korrigiert (orchestrator/, github_integration/, security_engine/, patch_notes/), Statistiken aktualisiert.


### PR DESCRIPTION
## Was wurde geaendert

### CLAUDE.md

**Verzeichnis-Struktur korrigiert:**
- `src/patch_notes/` ergaenzt — Patch Notes Pipeline v6 (5-Stufen State Machine, ~2100 LoC, in `src/patch_notes/` — fehlte komplett in der KI-Wissensbasis)
- `cogs/`-Kommentar um alle aktiven Cogs erweitert: `cron_heartbeat`, `customer_setup_commands`, `phase_5e_health_aggregator` fehlten

**Module-Liste `src/integrations/` korrigiert:**
- `orchestrator.py` → `orchestrator/` (ist ein Python-Package mit 6 Mixins: `core`, `planner`, `executor`, `discord`, `recovery`, `batch`)
- `github_integration.py` → `github_integration/` (ist ein Package: `ci_mixin`, `ai_patch_notes_mixin`, `agent_review/` Sub-Package)
- `security_engine/` ergaenzt — SecurityScanAgent v6 mit Fixer-Adapters, Activity-Monitor und Prompts (war in safety.md dokumentiert aber fehlte im Modul-Listing)
- `context_manager.py` Kommentar: "DO-NOT-TOUCH + Infra" → "Infra" (DO-NOT-TOUCH.md existiert nicht, Issue #225)

**Statistiken aktualisiert:**
- Tech-Stack Tabelle + Statistik-Sektion: `150+ Tests` → `161+` (verifiziert: 161 Dateien in `tests/unit/`)
- `15 Discord-Commands` → `19` (verifiziert in Cog-Dateien)

**Broken Link behoben:**
- `config/DO-NOT-TOUCH.md` in "Aktuelle Doku" war ein toter Link (Datei existiert nicht im Repo). Ersetzt durch Hinweis auf Issue #225.

---

## Begruendung

Ohne korrekte Verzeichnisstruktur in CLAUDE.md navigieren KI-Tools zu falschen Pfaden (z.B. `src/integrations/orchestrator.py` statt `src/integrations/orchestrator/`). Das fuehrt zu "File not found"-Fehlern in Codex- und Claude-Sessions.

Gefunden durch Doku-Kurator Worker (Drift-Check 2026-05-10). Alle Aenderungen direkt durch `ls` im Repo verifiziert.

---
Labels: `status:routine-generated`, `worker:doku`, `type:docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01152Qq9ZW6ihwCk22fKvhAN)_