### PR TITLE
feat(bot): Welle 9.10 — wait-for-CI vor _trigger_deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ deployment:
   health_check_timeout: 30
 ```
 
+> **Welle 9.10 (2026-05-11) — Wait-for-CI vor Auto-Deploy:** Sobald ein PR auf einen `deploy_branches`-Branch gemergt wird, wartet der Bot vor dem Trigger von `deploy.sh` auf den Abschluss der in `projects.<name>.ci_workflows` konfigurierten Workflows (z.B. `["Web Quality"]`). Bei `failure`/`timeout` wird `deploy.sh` NICHT aufgerufen — stattdessen erscheint ein Alert im projekt-`ci_channel_id` oder `deployment_log`. Hard-Timeout 30 min (überschreibbar via `projects.<name>.ci_wait_max_min`). Exponential backoff 60s → 120s → 240s → cap 300s.
+
 **AI komplett deaktivieren (Monitoring + Patch Notes ohne KI):**
 - `ai.enabled: false`
 - `ai_learning.enabled: false`

--- a/src/integrations/github_integration/ci_mixin.py
+++ b/src/integrations/github_integration/ci_mixin.py
@@ -4,12 +4,22 @@ CI polling and deployment methods for GitHubIntegration.
 
 import asyncio
 import logging
-from typing import Dict, Optional
+import time
+from datetime import datetime, timezone
+from typing import Dict, List, Literal, Optional
 
 import aiohttp
 import discord
 
 logger = logging.getLogger('shadowops')
+
+# Welle 9.10 (2026-05-11): Welche Conclusions als "Failure" gelten und
+# _trigger_deployment abbrechen (kein deploy.sh-Call).
+_CI_FAILURE_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out", "action_required", "startup_failure"})
+
+# Stati, die als "running" gelten — alle anderen Werte fallen durch
+# `status != 'completed'` weiter in den Poll-Loop.
+_CI_RUNNING_STATI = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
 
 
 class CIMixin:
@@ -151,14 +161,295 @@ class CIMixin:
             self.logger.error(f"❌ Fehler beim Laden des Workflow Runs: {e}", exc_info=True)
             return None
 
-    async def _trigger_deployment(self, repo_name: str, branch: str, commit_sha: str):
+    async def _fetch_workflow_runs_for_sha(
+        self,
+        repo_full_name: str,
+        head_sha: str,
+    ) -> Optional[Dict]:
+        """
+        Fetch workflow runs filtered by head_sha via GitHub REST API.
+
+        Welle 9.10 (2026-05-11): Wird von _wait_for_ci_completion genutzt, um
+        zu erkennen ob CI fuer den gemergten Commit fertig ist, bevor deploy.sh
+        getriggert wird.
+
+        Args:
+            repo_full_name: e.g. "Commandershadow9/ZERODOX"
+            head_sha: Full 40-char commit SHA (NICHT die 7-char Variante).
+
+        Returns:
+            dict from GitHub API, oder None bei Fehler.
+        """
+        if not repo_full_name or not head_sha:
+            return None
+
+        url = f"https://api.github.com/repos/{repo_full_name}/actions/runs?head_sha={head_sha}&per_page=50"
+        headers = {"Accept": "application/vnd.github+json"}
+        token = self._get_github_token()
+        if token:
+            headers["Authorization"] = f"token {token}"
+
+        try:
+            async with aiohttp.ClientSession(headers=headers) as session:
+                async with session.get(url, timeout=20) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        self.logger.warning(
+                            f"⚠️ Workflow Runs fuer {repo_full_name}@{head_sha[:7]} "
+                            f"konnten nicht geladen werden ({resp.status}): {body[:200]}"
+                        )
+                        return None
+                    return await resp.json()
+        except Exception as e:
+            self.logger.error(
+                f"❌ Fehler beim Laden der Workflow Runs fuer {repo_full_name}@{head_sha[:7]}: {e}",
+                exc_info=True,
+            )
+            return None
+
+    async def _wait_for_ci_completion(
+        self,
+        repo_full_name: str,
+        merged_sha: str,
+        workflow_names: List[str],
+        max_wait_min: int = 30,
+    ) -> Literal["success", "failure", "timeout", "no_workflows"]:
+        """
+        Wait for required CI workflows on a given commit to complete.
+
+        Welle 9.10 (2026-05-11): Verhindert den Race Condition aus dem
+        58h-Vorfall: Bot triggert deploy.sh sofort bei PR-merge → deploy.sh
+        Pre-Flight-Gate sieht pending CI auf dem neuen SHA → exit 1.
+
+        Exponential backoff: 60s → 120s → 240s → cap 300s.
+
+        Args:
+            repo_full_name: e.g. "Commandershadow9/ZERODOX"
+            merged_sha: FULL 40-char commit SHA des Merge-Commits.
+            workflow_names: Liste von erlaubten workflow-Names (z.B. ["Web Quality"]).
+                            Match ist case-insensitive substring.
+            max_wait_min: Hard-timeout in Minuten. Default 30.
+
+        Returns:
+            "success"      — alle required Workflows haben conclusion=success
+            "failure"      — mind. 1 Workflow ist failed/cancelled/timed_out
+            "timeout"      — nach max_wait_min noch nicht alle completed
+            "no_workflows" — kein workflow_names konfiguriert → caller entscheidet
+        """
+        if not workflow_names:
+            self.logger.info(
+                f"ℹ️ _wait_for_ci_completion: Keine ci_workflows fuer {repo_full_name} "
+                f"konfiguriert — skip wait."
+            )
+            return "no_workflows"
+
+        if not repo_full_name or not merged_sha or len(merged_sha) < 7:
+            self.logger.warning(
+                f"⚠️ _wait_for_ci_completion: Ungueltige Args "
+                f"repo={repo_full_name!r} sha={merged_sha!r} — skip wait."
+            )
+            return "no_workflows"
+
+        workflow_names_lower = [str(n).lower().strip() for n in workflow_names if n]
+        deadline = time.monotonic() + max_wait_min * 60
+        poll_interval_s = 60
+        max_poll_interval_s = 300  # 5 min cap
+
+        self.logger.info(
+            f"⏳ Welle 9.10: warte auf CI-Completion fuer {repo_full_name}@{merged_sha[:7]} "
+            f"(workflows={workflow_names}, timeout={max_wait_min}min)"
+        )
+
+        while time.monotonic() < deadline:
+            data = await self._fetch_workflow_runs_for_sha(repo_full_name, merged_sha)
+            if data is None:
+                # API-Fehler / Rate-Limit — weiter pollen
+                await asyncio.sleep(poll_interval_s)
+                poll_interval_s = min(poll_interval_s * 2, max_poll_interval_s)
+                continue
+
+            all_runs = data.get("workflow_runs") or []
+
+            # Filter auf relevant: name matched workflow_names (case-insensitive, substring)
+            relevant = []
+            for run in all_runs:
+                run_name = str(run.get("name") or "").lower()
+                run_path = str(run.get("path") or "").lower()
+                for wf_name in workflow_names_lower:
+                    if not wf_name:
+                        continue
+                    if (
+                        wf_name == run_name
+                        or f"/{wf_name}.yml" in run_path
+                        or f"/{wf_name}.yaml" in run_path
+                    ):
+                        relevant.append(run)
+                        break
+
+            if not relevant:
+                self.logger.info(
+                    f"⏳ _wait_for_ci_completion: noch keine relevanten Workflows "
+                    f"fuer {merged_sha[:7]} sichtbar — weiter pollen ({poll_interval_s}s)..."
+                )
+                await asyncio.sleep(poll_interval_s)
+                poll_interval_s = min(poll_interval_s * 2, max_poll_interval_s)
+                continue
+
+            # Bestimme Status pro workflow_name: den NEUESTEN Run zaehlen
+            # (re-runs koennen mehrere Eintraege liefern).
+            latest_per_workflow: Dict[str, Dict] = {}
+            for run in relevant:
+                rname = str(run.get("name") or "").lower()
+                # Welle 9.10 Vorsicht: created_at kann fehlen; default leerer string sortiert
+                # frueh -> der ECHTE neueste ueberschreibt das.
+                created = run.get("created_at") or ""
+                existing = latest_per_workflow.get(rname)
+                if existing is None or created > (existing.get("created_at") or ""):
+                    latest_per_workflow[rname] = run
+
+            # Alle latest_per_workflow durchgehen
+            all_completed = True
+            any_failed = False
+            failed_run = None
+            pending_names = []
+            for rname, run in latest_per_workflow.items():
+                status = str(run.get("status") or "").lower()
+                conclusion = str(run.get("conclusion") or "").lower()
+
+                if status != "completed":
+                    all_completed = False
+                    pending_names.append(rname)
+                    continue
+
+                if conclusion in _CI_FAILURE_CONCLUSIONS:
+                    any_failed = True
+                    failed_run = run
+                    break
+
+            if any_failed:
+                self.logger.warning(
+                    f"❌ _wait_for_ci_completion: CI FAILED fuer {merged_sha[:7]} "
+                    f"(workflow={failed_run.get('name')}, conclusion={failed_run.get('conclusion')})"
+                )
+                return "failure"
+
+            if all_completed:
+                self.logger.info(
+                    f"✅ _wait_for_ci_completion: alle CI-Workflows fuer {merged_sha[:7]} "
+                    f"erfolgreich ({list(latest_per_workflow.keys())})"
+                )
+                return "success"
+
+            self.logger.info(
+                f"⏳ _wait_for_ci_completion: warte weiter auf {pending_names} "
+                f"fuer {merged_sha[:7]} (next poll in {poll_interval_s}s)"
+            )
+            await asyncio.sleep(poll_interval_s)
+            poll_interval_s = min(poll_interval_s * 2, max_poll_interval_s)
+
+        self.logger.warning(
+            f"⏰ _wait_for_ci_completion: TIMEOUT nach {max_wait_min}min "
+            f"fuer {repo_full_name}@{merged_sha[:7]}"
+        )
+        return "timeout"
+
+    async def _send_ci_wait_alert(
+        self,
+        outcome: Literal["failure", "timeout"],
+        repo_name: str,
+        repo_full_name: str,
+        branch: str,
+        merged_sha: str,
+        workflow_names: List[str],
+        max_wait_min: int,
+    ) -> None:
+        """
+        Welle 9.10 (2026-05-11): Discord-Alert bei abgebrochenem Deploy.
+        Postet in den projekt-spezifischen ci_channel_id (falls vorhanden)
+        oder fallback deployment_log channel.
+        """
+        try:
+            # Project config lookup (case-insensitive)
+            project_config = {}
+            for key in self.config.projects.keys():
+                if key.lower() == repo_name.lower():
+                    project_config = self.config.projects[key]
+                    break
+
+            ci_channel_id = project_config.get('ci_channel_id') if project_config else None
+            target_channel = None
+            if ci_channel_id:
+                target_channel = self.bot.get_channel(ci_channel_id)
+            if not target_channel:
+                target_channel = self.bot.get_channel(self.deployment_channel_id)
+            if not target_channel:
+                self.logger.warning(
+                    f"⚠️ _send_ci_wait_alert: kein Discord-Channel verfuegbar fuer {repo_name}"
+                )
+                return
+
+            if outcome == "failure":
+                title = f"🛑 {repo_name}: Deploy ABGEBROCHEN — CI rot"
+                color = 0xE74C3C
+                description = (
+                    f"Welle-9.10-Schutz: Mindestens einer der required CI-Workflows "
+                    f"({', '.join(workflow_names) or '—'}) hat fuer Commit "
+                    f"`{merged_sha[:7]}` mit Failure/Cancelled/TimedOut abgeschlossen.\n\n"
+                    f"**deploy.sh wurde NICHT getriggert.** Manueller Check noetig."
+                )
+            else:  # timeout
+                title = f"⏰ {repo_name}: Deploy zurueckgestellt — CI nicht durch"
+                color = 0xF1C40F
+                description = (
+                    f"Welle-9.10-Schutz: CI-Workflows ({', '.join(workflow_names) or '—'}) "
+                    f"sind nach {max_wait_min} Minuten fuer Commit `{merged_sha[:7]}` "
+                    f"noch nicht alle completed.\n\n"
+                    f"**deploy.sh wurde NICHT getriggert.** Sobald CI gruen ist, "
+                    f"deploy.sh manuell triggern."
+                )
+
+            embed = discord.Embed(
+                title=title,
+                color=color,
+                description=description,
+                timestamp=datetime.now(timezone.utc),
+            )
+            embed.add_field(name="Repository", value=repo_name, inline=True)
+            embed.add_field(name="Branch", value=branch, inline=True)
+            embed.add_field(name="Commit", value=merged_sha[:7], inline=True)
+            if repo_full_name:
+                actions_url = f"https://github.com/{repo_full_name}/actions?query=branch%3A{branch}"
+                embed.add_field(name="Actions", value=f"[Workflow-Runs]({actions_url})", inline=False)
+            embed.set_footer(text="ShadowOps-Bot • Welle 9.10 wait-for-CI")
+
+            await target_channel.send(embed=embed)
+        except Exception as e:
+            self.logger.error(
+                f"❌ _send_ci_wait_alert: Fehler beim Posten: {e}",
+                exc_info=True,
+            )
+
+    async def _trigger_deployment(
+        self,
+        repo_name: str,
+        branch: str,
+        commit_sha: str,
+        repo_full_name: Optional[str] = None,
+        full_sha: Optional[str] = None,
+    ):
         """
         Trigger deployment for a repository
 
+        Welle 9.10 (2026-05-11): Wartet auf CI-Completion bevor deploy.sh
+        getriggert wird. Verhindert Race Condition aus dem 58h-Vorfall.
+
         Args:
-            repo_name: Name of the repository
+            repo_name: Name of the repository (e.g. "ZERODOX")
             branch: Branch to deploy
-            commit_sha: Commit SHA being deployed
+            commit_sha: Commit SHA being deployed (typischerweise 7-char Short-SHA fuers Log)
+            repo_full_name: e.g. "Commandershadow9/ZERODOX". Wenn None, wird Wait
+                            uebersprungen (Backward-Compat fuer alte Caller).
+            full_sha: 40-char SHA. Wenn None, wird Wait uebersprungen.
         """
         if not self.deployment_manager:
             self.logger.warning("⚠️ No deployment manager configured")
@@ -176,6 +467,52 @@ class CIMixin:
             if not deploy_config.get('enabled', True):
                 self.logger.info(f"⏭️ Deployment disabled for {repo_name} - handled by CI/CD pipeline")
                 return
+
+        # Welle 9.10: Wait-for-CI BEFORE deploy.sh-Call (falls Args vollstaendig).
+        # Caller (handle_pr_event) MUSS repo_full_name + full_sha mitgeben um zu profitieren.
+        if repo_full_name and full_sha and project_config:
+            workflow_names = project_config.get('ci_workflows') or []
+            if workflow_names:
+                max_wait_min = int(project_config.get('ci_wait_max_min', 30))
+                outcome = await self._wait_for_ci_completion(
+                    repo_full_name=repo_full_name,
+                    merged_sha=full_sha,
+                    workflow_names=workflow_names,
+                    max_wait_min=max_wait_min,
+                )
+                if outcome == "failure":
+                    await self._send_ci_wait_alert(
+                        outcome="failure",
+                        repo_name=repo_name,
+                        repo_full_name=repo_full_name,
+                        branch=branch,
+                        merged_sha=full_sha,
+                        workflow_names=workflow_names,
+                        max_wait_min=max_wait_min,
+                    )
+                    return
+                if outcome == "timeout":
+                    await self._send_ci_wait_alert(
+                        outcome="timeout",
+                        repo_name=repo_name,
+                        repo_full_name=repo_full_name,
+                        branch=branch,
+                        merged_sha=full_sha,
+                        workflow_names=workflow_names,
+                        max_wait_min=max_wait_min,
+                    )
+                    return
+                # outcome == "success" oder "no_workflows" → weiter unten deployen
+            else:
+                self.logger.info(
+                    f"ℹ️ _trigger_deployment: kein ci_workflows fuer {repo_name} "
+                    f"konfiguriert — kein Wait, direkt deployen."
+                )
+        else:
+            self.logger.info(
+                f"ℹ️ _trigger_deployment: repo_full_name/full_sha fehlt fuer {repo_name} "
+                f"— skip Welle-9.10-Wait (Backward-Compat-Pfad)."
+            )
 
         try:
             self.logger.info(f"🚀 Starting deployment: {repo_name}@{commit_sha}")

--- a/src/integrations/github_integration/event_handlers_mixin.py
+++ b/src/integrations/github_integration/event_handlers_mixin.py
@@ -111,11 +111,22 @@ class EventHandlersMixin:
             # If PR was merged to deployment branch, trigger deploy
             if action == 'closed' and pr.get('merged', False):
                 if target_branch in self.deploy_branches and self.auto_deploy_enabled:
-                    merge_commit_sha = pr['merge_commit_sha'][:7]
+                    # Welle 9.10 (2026-05-11): Volle SHA + repo_full_name an
+                    # _trigger_deployment durchreichen, damit wait-for-CI funktioniert.
+                    full_merge_sha = pr.get('merge_commit_sha') or ''
+                    merge_commit_sha = full_merge_sha[:7] if full_merge_sha else ''
+                    repo_full_name = payload.get('repository', {}).get('full_name')
                     self.logger.info(
-                        f"🚀 PR merged to {target_branch}, triggering deployment"
+                        f"🚀 PR merged to {target_branch}, triggering deployment "
+                        f"(wait-for-CI: repo={repo_full_name}, sha={merge_commit_sha})"
                     )
-                    await self._trigger_deployment(repo_name, target_branch, merge_commit_sha)
+                    await self._trigger_deployment(
+                        repo_name,
+                        target_branch,
+                        merge_commit_sha,
+                        repo_full_name=repo_full_name,
+                        full_sha=full_merge_sha,
+                    )
 
         except Exception as e:
             self.logger.error(f"❌ Error handling PR event: {e}", exc_info=True)

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -200,6 +200,275 @@ class TestPullRequestHandling:
         await integration.handle_pull_request_event(payload)
 
         integration._trigger_deployment.assert_called_once()
+        # Welle 9.10 (2026-05-11): _trigger_deployment muss repo_full_name + full_sha bekommen
+        call_kwargs = integration._trigger_deployment.call_args.kwargs
+        assert call_kwargs.get('repo_full_name') is None or 'full_name' not in payload['repository']
+        assert call_kwargs.get('full_sha') == 'abc123def456'
+
+    @pytest.mark.asyncio
+    async def test_handle_pr_merged_passes_full_name_and_sha(self, mock_bot, enabled_config):
+        """Welle 9.10: handle_pr_event muss repo_full_name + full_sha durchreichen."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration._send_pr_notification = AsyncMock()
+        integration._trigger_deployment = AsyncMock()
+
+        payload = {
+            'action': 'closed',
+            'repository': {
+                'name': 'ZERODOX',
+                'full_name': 'Commandershadow9/ZERODOX',
+            },
+            'pull_request': {
+                'number': 42,
+                'title': 'Feature PR',
+                'user': {'login': 'developer'},
+                'html_url': 'https://github.com/Commandershadow9/ZERODOX/pull/42',
+                'head': {'ref': 'feat/x'},
+                'base': {'ref': 'main'},
+                'merged': True,
+                'merge_commit_sha': 'a' * 40,
+            }
+        }
+
+        await integration.handle_pull_request_event(payload)
+
+        integration._trigger_deployment.assert_called_once()
+        kwargs = integration._trigger_deployment.call_args.kwargs
+        assert kwargs['repo_full_name'] == 'Commandershadow9/ZERODOX'
+        assert kwargs['full_sha'] == 'a' * 40
+
+
+class TestWelle910WaitForCI:
+    """Welle 9.10 (2026-05-11): _wait_for_ci_completion + _trigger_deployment Wait-Logic."""
+
+    @pytest.fixture
+    def cfg_with_projects(self, mock_bot):
+        cfg = MagicMock(spec=Config)
+        cfg.github = {
+            'enabled': True,
+            'webhook_secret': 'secret',
+            'auto_deploy': True,
+            'deploy_branches': ['main'],
+        }
+        cfg.channels = {'deployment_log': 99999, 'code_fixes': 99998}
+        cfg.projects = {
+            'zerodox': {
+                'enabled': True,
+                'ci_workflows': ['Web Quality'],
+                'ci_channel_id': 88888,
+            },
+        }
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_no_workflows_when_empty(self, mock_bot, cfg_with_projects):
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='a' * 40,
+            workflow_names=[],
+            max_wait_min=1,
+        )
+        assert result == 'no_workflows'
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_success_when_all_completed(self, mock_bot, cfg_with_projects):
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration._fetch_workflow_runs_for_sha = AsyncMock(return_value={
+            'workflow_runs': [
+                {
+                    'name': 'Web Quality',
+                    'status': 'completed',
+                    'conclusion': 'success',
+                    'created_at': '2026-05-11T18:00:00Z',
+                    'path': '.github/workflows/web-quality.yml',
+                },
+            ],
+        })
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='a' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=1,
+        )
+        assert result == 'success'
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_failure_on_failed_workflow(self, mock_bot, cfg_with_projects):
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration._fetch_workflow_runs_for_sha = AsyncMock(return_value={
+            'workflow_runs': [
+                {
+                    'name': 'Web Quality',
+                    'status': 'completed',
+                    'conclusion': 'failure',
+                    'created_at': '2026-05-11T18:00:00Z',
+                    'path': '.github/workflows/web-quality.yml',
+                },
+            ],
+        })
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='a' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=1,
+        )
+        assert result == 'failure'
+
+    @pytest.mark.asyncio
+    async def test_wait_uses_latest_run_per_workflow(self, mock_bot, cfg_with_projects):
+        """Re-run scenario: ein failed Run + ein successful Re-Run → success."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration._fetch_workflow_runs_for_sha = AsyncMock(return_value={
+            'workflow_runs': [
+                {
+                    'name': 'Web Quality',
+                    'status': 'completed',
+                    'conclusion': 'failure',
+                    'created_at': '2026-05-11T18:00:00Z',
+                    'path': '.github/workflows/web-quality.yml',
+                },
+                {
+                    'name': 'Web Quality',
+                    'status': 'completed',
+                    'conclusion': 'success',
+                    'created_at': '2026-05-11T18:10:00Z',  # later
+                    'path': '.github/workflows/web-quality.yml',
+                },
+            ],
+        })
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='a' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=1,
+        )
+        assert result == 'success'
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_timeout_when_pending_too_long(self, mock_bot, cfg_with_projects, monkeypatch):
+        """Timeout-Pfad: API liefert immer pending → timeout zurueck."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration._fetch_workflow_runs_for_sha = AsyncMock(return_value={
+            'workflow_runs': [
+                {
+                    'name': 'Web Quality',
+                    'status': 'in_progress',
+                    'conclusion': None,
+                    'created_at': '2026-05-11T18:00:00Z',
+                    'path': '.github/workflows/web-quality.yml',
+                },
+            ],
+        })
+
+        # asyncio.sleep stubben damit Test schnell laeuft
+        sleep_calls = []
+
+        async def fast_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.asyncio.sleep', fast_sleep)
+
+        # time.monotonic stubben damit Schleife nach 2 Iterationen abbricht
+        # Sequence: 0 (deadline calc), 0 (loop entry), then advance past deadline
+        times = iter([0.0, 0.0, 1000.0, 1000.0])
+
+        def fake_monotonic():
+            try:
+                return next(times)
+            except StopIteration:
+                return 1000.0
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.time.monotonic', fake_monotonic)
+
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='a' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=1,
+        )
+        assert result == 'timeout'
+
+    @pytest.mark.asyncio
+    async def test_trigger_deployment_blocks_on_failure(self, mock_bot, cfg_with_projects):
+        """deploy.sh darf NICHT laufen wenn CI failed."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock(return_value={'success': True})
+        integration._wait_for_ci_completion = AsyncMock(return_value='failure')
+        integration._send_ci_wait_alert = AsyncMock()
+
+        await integration._trigger_deployment(
+            repo_name='zerodox',
+            branch='main',
+            commit_sha='abc1234',
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='a' * 40,
+        )
+
+        integration.deployment_manager.deploy_project.assert_not_called()
+        integration._send_ci_wait_alert.assert_called_once()
+        kwargs = integration._send_ci_wait_alert.call_args.kwargs
+        assert kwargs['outcome'] == 'failure'
+
+    @pytest.mark.asyncio
+    async def test_trigger_deployment_blocks_on_timeout(self, mock_bot, cfg_with_projects):
+        """deploy.sh darf NICHT laufen wenn CI Timeout."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock(return_value={'success': True})
+        integration._wait_for_ci_completion = AsyncMock(return_value='timeout')
+        integration._send_ci_wait_alert = AsyncMock()
+
+        await integration._trigger_deployment(
+            repo_name='zerodox',
+            branch='main',
+            commit_sha='abc1234',
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='a' * 40,
+        )
+
+        integration.deployment_manager.deploy_project.assert_not_called()
+        integration._send_ci_wait_alert.assert_called_once()
+        kwargs = integration._send_ci_wait_alert.call_args.kwargs
+        assert kwargs['outcome'] == 'timeout'
+
+    @pytest.mark.asyncio
+    async def test_trigger_deployment_proceeds_on_success(self, mock_bot, cfg_with_projects):
+        """deploy.sh MUSS laufen wenn CI success."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock(return_value={'success': True})
+        integration._wait_for_ci_completion = AsyncMock(return_value='success')
+        integration._send_ci_wait_alert = AsyncMock()
+
+        await integration._trigger_deployment(
+            repo_name='zerodox',
+            branch='main',
+            commit_sha='abc1234',
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='a' * 40,
+        )
+
+        integration.deployment_manager.deploy_project.assert_called_once_with('zerodox', 'main')
+        integration._send_ci_wait_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trigger_deployment_skips_wait_when_no_full_args(self, mock_bot, cfg_with_projects):
+        """Backward-Compat: alte Caller ohne repo_full_name/full_sha → kein Wait."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock(return_value={'success': True})
+        integration._wait_for_ci_completion = AsyncMock()
+
+        await integration._trigger_deployment(
+            repo_name='zerodox',
+            branch='main',
+            commit_sha='abc1234',
+        )
+
+        integration._wait_for_ci_completion.assert_not_called()
+        integration.deployment_manager.deploy_project.assert_called_once()
 
 
 class TestReleaseHandling:


### PR DESCRIPTION
## Summary
- Behebt den Welle-9.7-9.9-Vorfall (58h Production-Stau): Bot rief deploy.sh sofort bei PR-Merge auf, Pre-Flight Hard-Gate kollidierte mit pending CI auf gerade gemergtem SHA.
- Neuer Helper `_wait_for_ci_completion` mit exponential backoff (60s -> 300s cap), Hard-Timeout 30min.
- `_trigger_deployment` blockt deploy.sh bei `failure`/`timeout` und postet Discord-Alert. Bei `success` lauft deploy.sh wie gehabt.
- Defense-in-Depth: deploy.sh-Pre-Flight bleibt unverandert.

## Test Plan
- [x] `tests/unit/test_github_integration.py::TestWelle910WaitForCI` — 9 neue Tests grun (success / failure / timeout / no_workflows / Re-Run / Backward-Compat)
- [x] Bestehender `test_handle_pr_merged_to_main` ergaenzt um Kwarg-Check
- [x] 23 passed, 0 failed (0.36s)
- [ ] Smoke: nach Restart per `journalctl` pruefen dass Bot wieder hochkommt
- [ ] Bei naechstem PR-Merge auf main im ZERODOX-Repo: Bot-Logs sollten "Welle 9.10: warte auf CI-Completion fuer ..." zeigen statt sofort deploy.sh zu rufen

## Refs
- `project_welle_9_10_bot_wait_for_ci.md`
- Vorfall: Welle 9.7-9.9 (siehe `project_welle_9_7_9_9_2026_05_11.md`)