### PR TITLE
docs: fix slash command list, broken links, and api.md drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,18 +52,18 @@ shadowops-bot/
 ├── config/
 │   ├── config.example.yaml       # Template (commited)
 │   ├── config.yaml               # Real config (gitignored)
-│   ├── DO-NOT-TOUCH.md           # Critical files protection
-│   ├── INFRASTRUCTURE.md
-│   └── PROJECT_*.md              # Per-projekt-Notizen
+│   ├── config.recommended.yaml   # Empfehlungen
+│   └── logrotate.conf            # Log-Rotation
 ├── deploy/
 │   └── shadowops-bot.service     # systemd Unit
 ├── scripts/                      # Wartungs-Skripte
 ├── docs/
-│   ├── SECURITY_ANALYST.md
-│   ├── SETUP_GUIDE.md
 │   ├── reference/api.md
 │   ├── adr/                      # Architecture Decision Records
-│   └── plans/                    # Design-Dokumente
+│   ├── design/                   # Design-Dokumente
+│   ├── operations/               # Setup + Runbooks
+│   ├── plans/                    # Design-Plaene
+│   └── runbooks/                 # Betriebs-Handbuecher
 ├── data/                         # Runtime-Daten (gitignored)
 ├── logs/                         # Logs (gitignored)
 ├── .claude/                      # KI-spezifische Configs
@@ -75,12 +75,12 @@ shadowops-bot/
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (Package: core, batch_mixin, executor_mixin, planner_mixin, recovery_mixin, discord_mixin, models)
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
 - `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
+- `github_integration/` — Webhooks mit HMAC-SHA256 Verification + Jules SecOps Workflow + Multi-Agent Review Pipeline (Package: core, webhook_mixin, jules_workflow_mixin, agent_review/)
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord
@@ -181,17 +181,16 @@ Worker-Konventionen:
 
 ## Statistik (Stand v5.1)
 
-20.000+ LoC, 150+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
+20.000+ LoC, 150+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 19 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
 
 ## Aktuelle Doku
 
 - [README.md](./README.md)
-- [docs/SECURITY_ANALYST.md](./docs/SECURITY_ANALYST.md)
-- [docs/SETUP_GUIDE.md](./docs/SETUP_GUIDE.md)
 - [docs/reference/api.md](./docs/reference/api.md)
-- [DOCS_OVERVIEW.md](./DOCS_OVERVIEW.md)
-- [config/DO-NOT-TOUCH.md](./config/DO-NOT-TOUCH.md)
+- [docs/operations/setup.md](./docs/operations/setup.md)
+- [docs/adr/](./docs/adr/) — Architecture Decision Records
+- [docs/runbooks/](./docs/runbooks/) — Betriebs-Handbuecher
 
 ## Letztes Update dieser Datei
 
-2026-04-26 — initiales Setup, generiert aus Worker-Bundle.
+2026-05-12 — Doku-Kurator: Modul-Pfade korrigiert (orchestrator/, github_integration/), config-Dir bereinigt, Doku-Links auf existierende Dateien korrigiert, Discord-Commands auf 19 aktualisiert.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 **ShadowOps** ist ein **vollständig autonomer Security Guardian** mit lernfähigem AI Security Analyst, KI-gesteuerter Auto-Remediation, adaptiver Session-Steuerung und wachsender Knowledge-DB — kein statischer Scanner, sondern ein **System das aus seinen Erfahrungen lernt und immer besser wird**.
 
-> 📖 **Security Analyst Doku:** [docs/SECURITY_ANALYST.md](./docs/SECURITY_ANALYST.md)
-> 📚 **Dokumentations-Übersicht:** [DOCS_OVERVIEW.md](./DOCS_OVERVIEW.md)
-> 🔧 **API Dokumentation:** [docs/reference/api.md](./docs/reference/api.md)
-> 🚀 **Setup Guide:** [docs/SETUP_GUIDE.md](./docs/SETUP_GUIDE.md)
-> 📐 **Learning Pipeline Design:** [docs/plans/2026-03-18-analyst-learning-pipeline-design.md](./docs/plans/2026-03-18-analyst-learning-pipeline-design.md)
+> **API Dokumentation:** [docs/reference/api.md](./docs/reference/api.md)
+> **Setup Guide:** [docs/operations/setup.md](./docs/operations/setup.md)
+> **Architecture Decisions:** [docs/adr/](./docs/adr/)
+> **Runbooks:** [docs/runbooks/](./docs/runbooks/)
 
 ## ⚡ Highlights v5.1
 
@@ -250,19 +249,30 @@ projects:
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
 - `/aide` - AIDE Integrity Check Status
+- `/docker` - Letzte Docker-Scan-Ergebnisse (Trivy)
 
 #### Auto-Remediation
 - `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
-- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes
+- `/set-approval-mode [mode]` - Approval Mode aendern (paranoid/auto/dry-run)
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
-- `/reload-context` - Lade Project-Context neu
+- `/reload-context` - Project-Context neu laden
+- `/agent-stats` - Agent-Learning Statistiken (agent_learning DB)
+- `/security-engine` - Security Engine v6 Status und Statistiken
 
 #### Multi-Project Management
-- `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
-- `/alle-projekte` - Übersicht aller überwachten Projekte
+- `/projekt-status [name]` - Status fuer spezifisches Projekt (Uptime, Response Time, Health)
+- `/alle-projekte` - Uebersicht aller ueberwachten Projekte
+
+#### Patch Notes
+- `/release-notes [project]` - Gesammelte Commits als Patch Notes veroeffentlichen (Admin)
+- `/pending-notes` - Ausstehende Commits anzeigen, die auf Release warten (Admin)
+
+#### Administration
+- `/setup-customer-server` - Customer-Server einrichten (Channels + Rollen)
+- `/mark-duplicate` - Finding als Duplikat markieren (Learning-Feedback)
 
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
@@ -444,19 +454,30 @@ Security Commands:
   /threats [hours]     - Bedrohungen der letzten X Stunden
   /bans [limit]        - Gebannte IPs
   /aide                - AIDE Check-Status
+  /docker              - Letzte Docker-Scan-Ergebnisse
 
 Auto-Remediation:
   /remediation-stats             - Statistiken
   /stop-all-fixes                - Emergency Stop
-  /set-approval-mode [mode]      - Approval Mode ändern
+  /set-approval-mode [mode]      - Approval Mode aendern
 
 AI System:
   /get-ai-stats                  - AI Provider Status
   /reload-context                - Context neu laden
+  /agent-stats                   - Agent-Learning Statistiken
+  /security-engine               - Security Engine v6 Status
 
 Multi-Project:
   /projekt-status [name]         - Detaillierter Projekt-Status
-  /alle-projekte                 - Übersicht aller Projekte
+  /alle-projekte                 - Uebersicht aller Projekte
+
+Patch Notes:
+  /release-notes [project]       - Patch Notes veroeffentlichen (Admin)
+  /pending-notes                 - Ausstehende Commits anzeigen (Admin)
+
+Administration:
+  /setup-customer-server         - Customer-Server einrichten
+  /mark-duplicate                - Finding als Duplikat markieren
 ```
 
 ### GitHub Webhook Setup
@@ -500,10 +521,13 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
+│   ├── cogs/                           # Modulare Slash Commands
 │   │   ├── admin.py
 │   │   ├── inspector.py
-│   │   └── monitoring.py
+│   │   ├── monitoring.py
+│   │   ├── customer_setup_commands.py
+│   │   ├── cron_heartbeat.py
+│   │   └── phase_5e_health_aggregator.py
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
@@ -513,7 +537,7 @@ shadowops-bot/
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules + Multi-Agent Review
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
@@ -543,14 +567,8 @@ shadowops-bot/
 │   └── integration/
 │       └── test_learning_workflow.py   # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
-│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
+│   ├── config.example.yaml             # Template (commited)
 │   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
 │   └── logrotate.conf                  # Log-Rotation
@@ -564,11 +582,12 @@ shadowops-bot/
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
 ├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+│   ├── reference/api.md                # API-Referenz
 │   ├── adr/                            # Architecture Decision Records
-│   ├── plans/                          # Design-Dokumente
-│   └── archive/                        # Historische Doku
+│   ├── design/                         # Design-Dokumente
+│   ├── operations/                     # Setup + Runbooks
+│   ├── plans/                          # Design-Plaene
+│   └── runbooks/                       # Betriebs-Handbuecher
 ├── .claude/                            # KI-Konfiguration
 │   ├── rules/                          # Pfad-gefilterte Rules
 │   ├── skills/                         # Workflow-Skills
@@ -756,9 +775,9 @@ tail -f logs/shadowops.log | grep deployment
 
 ### Vollständige Dokumentation
 
-- 📖 [Setup Guide](./docs/SETUP_GUIDE.md) - Schritt-für-Schritt Installation
-- 🔧 [API Documentation](./docs/reference/api.md) - Vollständige API-Referenz
-- 📚 [Docs Overview](./DOCS_OVERVIEW.md) - Dokumentations-Index
+- [Setup Guide](./docs/operations/setup.md) - Schritt-fuer-Schritt Installation
+- [API Documentation](./docs/reference/api.md) - Vollstaendige API-Referenz
+- [Architecture Decisions](./docs/adr/) - ADR-Index
 
 ### Bei Problemen
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -164,10 +164,9 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
-- Active fallback chain
+- Codex CLI status (primary engine: model, timeout)
+- Claude CLI status (fallback engine: model, timeout)
+- Active routing configuration
 - Request counts per provider
 
 **Example:**
@@ -243,7 +242,7 @@ Shows overview of all monitored projects.
 # DISCORD CONFIGURATION
 # ========================================
 discord:
-  token: "YOUR_BOT_TOKEN_HERE"  # Discord bot token (REQUIRED)
+  # token: set via DISCORD_BOT_TOKEN env var (REQUIRED, never in config.yaml)
   guild_id: 123456789            # Discord server ID (REQUIRED)
 
 # ========================================
@@ -268,23 +267,30 @@ channels:
 # AI CONFIGURATION
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  primary:
+    engine: codex
+    models:
+      fast: gpt-4o
+      standard: gpt-5.3-codex
+      thinking: o3
+    timeout: 300
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  fallback:
+    engine: claude
+    cli_path: /home/user/.local/bin/claude
+    models:
+      fast: claude-sonnet-4-6
+      standard: claude-sonnet-4-6
+      thinking: claude-opus-4-6
+    timeout: 300
+
+  routing:
+    critical_analysis: { engine: codex, model: thinking }
+    high_analysis: { engine: codex, model: standard }
+    low_analysis: { engine: codex, model: fast }
+    critical_verify: { engine: claude, model: thinking }
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -346,7 +352,7 @@ github:
   enabled: false                            # Enable GitHub webhooks
   webhook_secret: "your_webhook_secret_here"  # HMAC secret for verification
   webhook_port: 8080                        # Webhook server port
-  auto_deploy: false                        # Auto-deploy on push (RECOMENDED: false for security)
+  auto_deploy: false                        # Auto-deploy on push (false — direct-push blocked by event_handlers_mixin)
   deploy_branches:                          # Branches that trigger deployments
     - main
     - master
@@ -582,8 +588,8 @@ Fallback auf das jeweils andere Modell bei Timeout oder leerer Response.
 ```python
 from src.integrations.knowledge_base import KnowledgeBase
 
-# Initialize
-kb = KnowledgeBase(db_path="data/knowledge_base.db")
+# Initialize (DSN from config.security_analyst_dsn or SECURITY_ANALYST_DB_URL env var)
+kb = KnowledgeBase(dsn=config.security_analyst_dsn)
 
 # Record a fix
 kb.record_fix(
@@ -791,29 +797,17 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+### Datenbanken
 
-#### fixes table
-```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
-    severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
-    duration_seconds REAL,
-    error_message TEXT,
-    retry_count INTEGER DEFAULT 0
-);
+Der Bot nutzt drei PostgreSQL-Datenbanken (kein SQLite):
 
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
-```
+| Datenbank | Env-Var / Config-Key | Zweck |
+|-----------|---------------------|-------|
+| `security_analyst` | `SECURITY_ANALYST_DB_URL` / `security_analyst.database_dsn` | Fix-Attempts, Security-Findings, Jules PR Reviews |
+| `agent_learning` | `AGENT_LEARNING_DB_URL` / `agent_learning.database_dsn` | Few-Shot Examples, Quality Scores, Patch-Notes Training |
+| `seo_agent` | — | SEO-Audit-Daten (extern verwaltet) |
+
+Die Tabellen sind in `src/integrations/security_engine/db.py`, `src/integrations/knowledge_base.py` und `src/integrations/github_integration/jules_state.py` definiert. Fuer das vollstaendige Schema siehe die jeweiligen Modul-Dateien.
 
 ### Project Monitor State (JSON)
 
@@ -894,9 +888,8 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI (primary)**: subprocess call with `ai.primary.timeout` (default: 300s); SmartQueue Semaphore limits to 3 concurrent analysis tasks
+- **Claude CLI (fallback)**: subprocess call with `ai.fallback.timeout` (default: 300s); Circuit Breaker (5 failures → 1h pause)
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)
@@ -951,12 +944,12 @@ debug_mode: true
 
 ### Common API Issues
 
-**Knowledge Base locked:**
+**Knowledge Base not connecting:**
 ```bash
-# Check if database is locked
-sqlite3 data/knowledge_base.db "PRAGMA busy_timeout=5000;"
+# Check PostgreSQL connection
+psql $SECURITY_ANALYST_DB_URL -c "SELECT 1"
 
-# If still locked, restart bot
+# Restart bot
 sudo systemctl restart shadowops-bot
 ```
 


### PR DESCRIPTION
## Zusammenfassung

Drift-Korrekturen aus dem Doku-Kurator-Lauf (2026-05-12). Alle Aenderungen sind Korrekturen von Fakten — kein neuer Inhalt erfunden.

## Aenderungen

### README.md — Slash Commands
- **Hinzugefuegt:** `/docker`, `/agent-stats`, `/security-engine`, `/release-notes`, `/pending-notes`, `/mark-duplicate`, `/setup-customer-server` (alle in Code vorhanden, fehlten in Doku)
- **Umstrukturiert:** Neue Sektionen "Patch Notes" und "Administration" fuer bessere Orientierung
- **Verwendungs-Sektion** mit identischer Liste synchronisiert

### README.md — Broken Links
- `docs/SECURITY_ANALYST.md` → existiert nicht → ersetzt durch `docs/operations/setup.md`
- `DOCS_OVERVIEW.md` → existiert nicht → entfernt
- `docs/SETUP_GUIDE.md` → existiert nicht → ersetzt durch `docs/operations/setup.md`
- `docs/plans/2026-03-18-analyst-learning-pipeline-design.md` → existiert nicht → entfernt

### README.md — Projektstruktur-Baum
- `src/cogs/` zeigte 3 Dateien, tatsaechlich 7: `cron_heartbeat.py`, `customer_setup_commands.py`, `phase_5e_health_aggregator.py` ergaenzt
- Doppelter `config/`-Block entfernt (war zweimal vorhanden)
- `github_integration.py` → `github_integration/` (ist ein Package, keine einzelne Datei)
- `docs/`-Baum spiegelt jetzt die tatsaechliche Verzeichnisstruktur wider

### docs/reference/api.md — Ollama-Entfernung
- `/get-ai-stats` beschrieb Ollama-Return-Felder (Ollama wurde in v4.0 entfernt, ~1364 LoC geloescht) → auf Codex/Claude aktualisiert
- AI-Konfigurations-Block zeigte altes `ollama`/`anthropic`/`openai`-Schema → ersetzt durch aktuellen Dual-Engine-Block aus `config.example.yaml`
- Rate-Limiting-Sektion erwaehnte Ollama → auf Codex CLI + Claude CLI aktualisiert

### docs/reference/api.md — Knowledge Base
- Python-API-Beispiel zeigte `KnowledgeBase(db_path="data/knowledge_base.db")` (SQLite) → Datenbank ist PostgreSQL, DSN kommt aus Config/Env-Var
- Database-Schema-Sektion zeigte SQLite CREATE TABLE → ersetzt durch Uebersicht der drei PostgreSQL-Datenbanken
- Troubleshooting-Snippet fuer `sqlite3`-Befehl → `psql`-Befehl

### docs/reference/api.md — Sonstiges
- `discord.token` im Konfig-Beispiel war Klartext → jetzt Hinweis auf `DISCORD_BOT_TOKEN` Env-Var
- Tippfehler `RECOMENDED` → behoben

### CLAUDE.md
- `orchestrator.py` → `orchestrator/` (Package mit 7 Modulen)
- `github_integration.py` → `github_integration/` (Package inkl. Jules + Multi-Agent Review)
- `config/`-Verzeichnisbaum: `DO-NOT-TOUCH.md`, `INFRASTRUCTURE.md`, `PROJECT_*.md` entfernt (Dateien existieren nicht); tatsaechliche Dateien eingetragen
- `docs/`-Baum: `SECURITY_ANALYST.md`, `SETUP_GUIDE.md` entfernt; tatsaechliche Unterverzeichnisse eingetragen
- "Aktuelle Doku"-Sektion: Alle 4 broken Links entfernt/korrigiert
- Discord-Commands-Count: 15 → 19

## Geprueft
Alle Aenderungen basieren auf `find`/`grep` gegen den tatsaechlichen Code-Stand. Kein Inhalt erfunden.

## Labels
`status:routine-generated`, `worker:doku`, `type:docs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCP7ySQQy7pNBDcgBMAcrh)_