### PR TITLE
fix(deploy): rollback-rsync excludes logs/+uploads/ (Issue #236)

### DIFF
--- a/src/integrations/deployment_manager.py
+++ b/src/integrations/deployment_manager.py
@@ -616,9 +616,18 @@ class DeploymentManager:
             # Restore from backup using rsync
             # --no-perms --no-group --no-owner: Avoid chgrp/chown errors when
             # files were originally owned by Docker container user
+            #
             # WICHTIG: Gleiche Excludes wie beim Backup + .env/.venv!
             # Ohne --exclude=.git würde --delete das Git-Repo löschen,
             # weil .git NICHT im Backup enthalten ist (Vorfall 2026-03-20).
+            #
+            # 2026-05-14 (ZERODOX #236): --exclude=logs, --exclude=uploads
+            # ergänzt. Vorher: ZERODOX-Backup hat logs/uploads exclude-d
+            # (Backup-rsync line 372-373), Rollback aber NICHT → --delete
+            # versuchte logs/contact-requests/*.jsonl + uploads/invoices/*.pdf
+            # zu unlink-en. Diese Dateien gehören Docker-Container-User (UID
+            # 1001), Bot läuft als cmdshadow (UID 1000) → Permission denied.
+            # 2-Tage-Auto-Deploy-Blockade nach ZERODOX-PRs #705, #707, #708.
             cmd = [
                 'rsync', '-rlptD', '--delete',
                 '--exclude=.git',
@@ -627,6 +636,8 @@ class DeploymentManager:
                 '--exclude=node_modules',
                 '--exclude=__pycache__',
                 '--exclude=backups',
+                '--exclude=logs',
+                '--exclude=uploads',
                 '--no-perms', '--no-group', '--no-owner',
                 str(backup_path) + '/',
                 str(project['path']) + '/'


### PR DESCRIPTION
## Fixes #236

\`_create_backup\` exkludiert seit jeher \`logs/\` und \`uploads/\` (line 372-373) — diese Pfade sind persistente Production-Daten (Customer-PDFs, Audit-Logs) die der Docker-Container-User (UID 1001) schreibt, nicht der Bot-User (cmdshadow UID 1000).

\`_rollback\` hatte diese Excludes **NICHT**. Mit \`--delete\` versuchte rsync dann, diese Files zu löschen → \`Permission denied (13)\`.

## Vorfall

ZERODOX 2026-05-12/13: Bot-Log:
\`\`\`
🚀 Starting deployment: ZERODOX@c483c85
❌ Deployment failed: Post-deploy command failed:
  File "deployment_manager.py", line 644, in _rollback
DeploymentError: Post-deploy command failed:
rsync: [generator] delete_file: unlink(uploads/invoices/.../<id>.pdf) failed: Permission denied (13)
rsync: [generator] delete_file: rmdir(uploads/invoices/<id>) failed: Permission denied (13)
rsync: [generator] opendir "/home/cmdshadow/ZERODOX/logs/client-errors" failed: Permission denied (13)
rsync error: some files/attrs were not transferred (code 23)
\`\`\`

→ 2 Tage Auto-Deploy-Blockade. ZERODOX-PRs #705, #707, #708 wurden NICHT automatisch deployed.

## Fix

Identisch zur Backup-rsync-Konfig (\`_create_backup\`, line 372-373):

\`\`\`python
cmd = [
    'rsync', '-rlptD', '--delete',
    '--exclude=.git',
    '--exclude=.env',
    '--exclude=.venv',
    '--exclude=node_modules',
    '--exclude=__pycache__',
    '--exclude=backups',
+   '--exclude=logs',
+   '--exclude=uploads',
    '--no-perms', '--no-group', '--no-owner',
    str(backup_path) + '/',
    str(project['path']) + '/'
]
\`\`\`

## Test Plan

- [x] Python syntax-check OK
- [ ] Merge + \`systemctl --user restart shadowops-bot\`
- [ ] Manueller Trigger eines ZERODOX-Deploys (oder warten auf nächsten PR-Merge auf main)
- [ ] Verifikation: Rollback rsync exit 0 statt 23

## Note

Der **eigentliche** post-deploy-Fail-Grund (warum \`scripts/deploy.sh --skip-e2e\` failed beim Bot-Aufruf) ist noch unklar — die rsync-Errors aus dem Rollback überschreiben den echten stderr im Bot-Log. Nach diesem Fix wird beim nächsten Deploy-Versuch der **wahre** Fail-Grund sichtbar (falls deploy.sh trotzdem failed), bzw. Auto-Deploy klappt komplett (falls die deploy.sh-Issues parallel gelöst sind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)