### PR TITLE
fix(deploy): _run_post_deploy_command capturet stdout + stderr

### DIFF
--- a/src/integrations/deployment_manager.py
+++ b/src/integrations/deployment_manager.py
@@ -534,7 +534,23 @@ class DeploymentManager:
         stdout, stderr = await process.communicate()
 
         if process.returncode != 0:
-            raise DeploymentError(f"Post-deploy command failed: {stderr.decode()}")
+            # Bash-Scripts (z.B. deploy.sh) schreiben Errors oft nach stdout
+            # (via echo/print_fail) statt stderr. Plus: `gh api ... 2>&1` in
+            # deploy.sh redirects stderr-zu-stdout — bei set -e ist stderr leer.
+            # Wenn wir nur stderr loggen, geht die Diagnose verloren.
+            # Vorfall 2026-05-14: "Post-deploy command failed: " ohne Reason.
+            stdout_text = stdout.decode(errors='replace').strip() if stdout else ''
+            stderr_text = stderr.decode(errors='replace').strip() if stderr else ''
+            parts = [
+                f"Post-deploy command failed (exit={process.returncode}):",
+            ]
+            if stdout_text:
+                parts.append(f"stdout: {stdout_text}")
+            if stderr_text:
+                parts.append(f"stderr: {stderr_text}")
+            if not stdout_text and not stderr_text:
+                parts.append("(both streams empty — subprocess silent fail)")
+            raise DeploymentError("\n".join(parts))
 
     async def _restart_service(self, project: Dict):
         """

--- a/tests/unit/test_deployment_manager_error_capture.py
+++ b/tests/unit/test_deployment_manager_error_capture.py
@@ -1,0 +1,129 @@
+"""
+Tests fuer Bot's Subprocess-Error-Capture im _run_post_deploy_command.
+
+Hintergrund:
+Bash-Scripts schreiben Errors typischerweise nach stdout (via echo/print_fail),
+nicht nach stderr. Plus: `gh api ... 2>&1` redirects stderr-zu-stdout. Wenn
+deploy.sh failt, ist stderr leer und der echte Fehler-Reason landet in stdout.
+
+Original Bug (2026-05-14):
+ZERODOX-Auto-Deploy failed 2x in 11s mit Bot-Log:
+  "Post-deploy command failed:"
+(mit Doppelpunkt, ohne Reason — weil stderr leer und Bot nur stderr captured)
+
+Fix: Error-Message inkludiert stdout + stderr fuer vollstaendige Diagnose.
+"""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.integrations.deployment_manager import DeploymentManager, DeploymentError
+
+
+class _MockProcess:
+    """Mock fuer asyncio.subprocess.Process."""
+
+    def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+@pytest.fixture
+def mgr():
+    """
+    Stub-Instance ohne __init__ — `_run_post_deploy_command` nutzt nur das
+    project-Argument, keinen Instanz-State. Bypass spart komplexes Bot/Config-Setup.
+    """
+    return DeploymentManager.__new__(DeploymentManager)
+
+
+@pytest.mark.asyncio
+async def test_post_deploy_failure_with_stdout_only_includes_stdout_in_error(mgr):
+    """
+    Wenn deploy.sh nach stdout schreibt (typisch fuer Bash mit print_fail / set -e
+    nach gh api 2>&1) und stderr leer ist, MUSS die Error-Message den stdout-
+    Inhalt enthalten — sonst geht die Diagnose verloren (Original-Bug).
+    """
+    project = {
+        'post_deploy_command': 'bash /tmp/fake-deploy.sh',
+        'path': '/tmp/fake-project',
+    }
+
+    fake_process = _MockProcess(
+        returncode=1,
+        stdout=b"\xe2\x9c\x97 Keine Required-Checks fuer Commit abc123 gefunden\n",
+        stderr=b"",
+    )
+
+    with patch('asyncio.create_subprocess_exec', AsyncMock(return_value=fake_process)):
+        with pytest.raises(DeploymentError) as exc_info:
+            await mgr._run_post_deploy_command(project)
+
+    msg = str(exc_info.value)
+    assert "Keine Required-Checks" in msg, (
+        f"Stdout-Diagnose muss in Error-Message sein, aber: {msg!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_deploy_failure_with_stderr_only_includes_stderr_in_error(mgr):
+    """Standard-Fall: stderr-Output muss weiterhin sichtbar sein."""
+    project = {
+        'post_deploy_command': 'bash /tmp/fake-deploy.sh',
+        'path': '/tmp/fake-project',
+    }
+
+    fake_process = _MockProcess(
+        returncode=1,
+        stdout=b"",
+        stderr=b"npm ERR! ENOENT package.json\n",
+    )
+
+    with patch('asyncio.create_subprocess_exec', AsyncMock(return_value=fake_process)):
+        with pytest.raises(DeploymentError) as exc_info:
+            await mgr._run_post_deploy_command(project)
+
+    msg = str(exc_info.value)
+    assert "npm ERR" in msg, f"Stderr muss erhalten bleiben, aber: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_post_deploy_failure_with_both_includes_both(mgr):
+    """Wenn beides da ist: beide Streams in Error-Message."""
+    project = {
+        'post_deploy_command': 'bash /tmp/fake-deploy.sh',
+        'path': '/tmp/fake-project',
+    }
+
+    fake_process = _MockProcess(
+        returncode=2,
+        stdout=b"\xe2\x9c\x97 GitHub-CI rot: 1 Check(s) failed\n",
+        stderr=b"warning: gh api rate-limit hit\n",
+    )
+
+    with patch('asyncio.create_subprocess_exec', AsyncMock(return_value=fake_process)):
+        with pytest.raises(DeploymentError) as exc_info:
+            await mgr._run_post_deploy_command(project)
+
+    msg = str(exc_info.value)
+    assert "GitHub-CI rot" in msg, f"Stdout-Diagnose fehlt: {msg!r}"
+    assert "rate-limit" in msg, f"Stderr-Diagnose fehlt: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_post_deploy_success_does_not_raise(mgr):
+    """Regression-Schutz: Erfolgsfall darf KEINE Exception werfen."""
+    project = {
+        'post_deploy_command': 'bash /tmp/fake-deploy.sh',
+        'path': '/tmp/fake-project',
+    }
+
+    fake_process = _MockProcess(returncode=0, stdout=b"Deploy OK", stderr=b"")
+
+    with patch('asyncio.create_subprocess_exec', AsyncMock(return_value=fake_process)):
+        # Darf NICHT throw'n
+        await mgr._run_post_deploy_command(project)


### PR DESCRIPTION
## Summary

Bot's Auto-Deploy verlor heute (2026-05-14) zweimal die Diagnose von deploy.sh-Failures: Log zeigte nur `Post-deploy command failed:` mit leerem Reason — 11s nach Start, dann automatischer Rollback. Ohne Output war keine Root-Cause-Analyse möglich.

Bei der dritten Bot-Auto-Deploy-Welle (272b962) musste manuell mit `--emergency-bypass-ci-gate` deployed werden, weil die Bot-Diagnose fehlte.

## Root-Cause

Bash-Scripts schreiben Errors typischerweise nach **stdout** (über `echo`/`print_fail`), nicht nach stderr. ZERODOX' `deploy.sh` verstärkt das: `gh api ... 2>&1` redirects alle gh-Output nach stdout. Bei `set -euo pipefail`-Exit ist stderr leer und alle Diagnose in stdout.

`_run_post_deploy_command` capturet beides via `process.communicate()`, nutzt aber **nur** `stderr.decode()` in der Error-Message:

```python
# vorher
raise DeploymentError(f"Post-deploy command failed: {stderr.decode()}")
```

→ Bei leerem stderr: `Post-deploy command failed:` (Doppelpunkt ohne Reason)

## Fix

Error-Message kombiniert exit-code + beide Streams, mit Labels:

```python
# nachher
raise DeploymentError(
    f"Post-deploy command failed (exit={returncode}):\n"
    f"stdout: {stdout_text}\n"
    f"stderr: {stderr_text}"
)
```

`errors='replace'` beim decode verhindert UnicodeDecodeError-Crashes bei nicht-UTF-8-Output. Fallback bei doppel-leeren Streams.

## TDD

4 neue Unit-Tests in `tests/unit/test_deployment_manager_error_capture.py`:

| Test | Was |
|---|---|
| stdout-only | Stdout-Diagnose muss in Error-Message (Original-Bug-Pattern) |
| stderr-only | Bestehendes Verhalten erhalten (Backwards-Compat) |
| beide | Kombiniert in Error-Message |
| success | Regression: Erfolgsfall throw't nicht |

Alle 4/4 grün lokal:
\`\`\`
$ pytest tests/unit/test_deployment_manager_error_capture.py -v --no-cov
4 passed, 1 warning in 0.12s
\`\`\`

## Erwartung beim nächsten Bot-Auto-Deploy-Fail

**Vorher:**
\`\`\`
Post-deploy command failed:
\`\`\`

**Nachher:**
\`\`\`
Post-deploy command failed (exit=1):
stdout: ✗ Keine Required-Checks (^(Quality Gate|Build|E2E Shard [1-4]/4)$)
        für Commit abc1234 gefunden
stderr: (leer)
\`\`\`

→ Echter Root-Cause des ZERODOX-Deploy-Issues wird sichtbar, sodass eine zielgerichtete Fix-Welle möglich wird.

## Test plan

- [x] Lokal: 4/4 Unit-Tests grün
- [x] Stub-Instance-Pattern (`DeploymentManager.__new__`) bypasst komplexen Init
- [ ] CI grün (pytest + ruff + mypy)
- [ ] Nach Merge: Bot deployt sich selbst per Auto-Deploy
- [ ] Bei nächstem ZERODOX-PR-Merge: vollständige deploy.sh-Diagnose im Bot-Log sichtbar

## Cross-Refs

- Vorfall heute: ZERODOX-PR #710 + #713 Auto-Deploys gescheitert mit leerer Diagnose
- ZERODOX Welle 10.3: musste manuell mit --emergency-bypass-ci-gate deployed werden
- shadowops-bot #236 (rsync Permission denied) — gleicher Bug-Klasse (subprocess-Diagnose-Loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)