### PR TITLE
fix(deploy): UnboundLocalError 'deploy_success' bei leeren jobs blockt Auto-Deploy

### DIFF
--- a/src/integrations/github_integration/event_handlers_mixin.py
+++ b/src/integrations/github_integration/event_handlers_mixin.py
@@ -258,6 +258,13 @@ class EventHandlersMixin:
                 if jobs_response and isinstance(jobs_response, dict):
                     jobs = jobs_response.get('jobs') or []
 
+            # Defensives Default damit Line 532 (`if is_completed and deploy_success`)
+            # nicht crashed wenn `jobs` leer ist (z.B. workflow_run in_progress oder
+            # API-Hiccup). Bug 2026-05-15: 15× _trigger_deployment für admin-merged
+            # PRs hingen weil UnboundLocalError exception path verschluckt wurde.
+            deploy_success = False
+            deploy_job_name = None
+
             if jobs:
                 jobs_total = len(jobs)
                 counts = {


### PR DESCRIPTION
Critical bug fix: Bot crashed bei workflow_run-Events ohne Jobs (in_progress oder API-Race) → 4+ Stunden gestaute Auto-Deploys für 12 ZERODOX-PRs. Defensives Default für deploy_success+deploy_job_name außerhalb if jobs:-Scope.

Vorfall: ZERODOX SEO-Session 2026-05-15 — 15× _trigger_deployment in Bot-Logs, 0 echte Deploys, Container blieb auf altem Image trotz 12 PR-Merges danach.

Auch Update für Issue #243 (admin-merge deploy-drift) — Auto-Deploy funktional nach Fix.

🤖 Generated with Claude Code