### PR TITLE
docs: drift-Korrekturen README, CLAUDE.md, api.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,12 @@ shadowops-bot/
 - `ai_engine.py` — Dual-Engine Router (Codex Primary, Claude Fallback)
 - `smart_queue.py` — Analyse-Pool (Semaphore=3) + serieller Fix-Lock + Circuit Breaker
 - `verification.py` — Pre-Push Pipeline (Confidence ≥85% → Tests → Claude-Verify → KB-Check)
-- `orchestrator.py` — Multi-Event-Batching (10s Fenster) + Approval-Flow
+- `orchestrator/` — Multi-Event-Batching (10s Fenster) + Approval-Flow (Package: core, batch_mixin, planner_mixin, executor_mixin, recovery_mixin, discord_mixin, models)
 - `event_watcher.py` — Lauscht auf Fail2ban/CrowdSec/AIDE/Docker-Events
 - `knowledge_base.py` — SQL Learning (fix_attempts, fix_verifications, finding_quality, scan_coverage)
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
-- `github_integration.py` — Webhooks mit HMAC-SHA256 Verification
+- `github_integration/` — Webhooks mit HMAC-SHA256 Verification + Jules Workflow (Package: core, webhook_mixin, event_handlers_mixin, jules_workflow_mixin, notifications_mixin, ci_mixin, agent_review/)
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback
 - `incident_manager.py` — Incident Threads in Discord

--- a/README.md
+++ b/README.md
@@ -246,19 +246,27 @@ projects:
 
 #### Security & Monitoring
 - `/status` - Gesamt-Sicherheitsstatus
-- `/scan` - Manuellen Docker-Scan triggern
+- `/scan` - Manuellen Docker-Scan triggern (Admin)
 - `/threats` - Letzte erkannte Bedrohungen
 - `/bans` - Aktuell gebannte IPs (Fail2ban + CrowdSec)
+- `/docker` - Letzte Docker Scan Ergebnisse
 - `/aide` - AIDE Integrity Check Status
 
 #### Auto-Remediation
-- `/remediation-stats` - Auto-Remediation Statistiken
-- `/stop-all-fixes` - 🛑 EMERGENCY: Stoppt alle laufenden Fixes
-- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run)
+- `/remediation-stats` - Auto-Remediation Statistiken (Admin)
+- `/stop-all-fixes` - EMERGENCY: Stoppt alle laufenden Fixes (Admin)
+- `/set-approval-mode [mode]` - Ändere Approval Mode (paranoid/auto/dry-run) (Admin)
+
+#### Patch Notes
+- `/release-notes [project]` - Commits als Patch Notes veröffentlichen (Admin)
+- `/pending-notes` - Übersicht ausstehender Commit-Batches (Admin)
+- `/mark-duplicate` - Finding als Duplikat markieren (Learning-Feedback)
 
 #### AI & Learning System
 - `/get-ai-stats` - AI-Provider Status und Fallback-Chain
-- `/reload-context` - Lade Project-Context neu
+- `/reload-context` - Lade Project-Context neu (Admin)
+- `/agent-stats` - Agent-Learning Statistiken
+- `/security-engine` - Security Engine v6 Status und Statistiken
 
 #### Multi-Project Management
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
@@ -500,24 +508,30 @@ sudo systemctl restart shadowops-bot
 shadowops-bot/
 ├── src/
 │   ├── bot.py                          # Haupt-Bot-Logik
-│   ├── cogs/                           # NEU: Modulare Slash Commands
-│   │   ├── admin.py
-│   │   ├── inspector.py
-│   │   └── monitoring.py
+│   ├── cogs/                           # Modulare Slash Commands
+│   │   ├── admin.py                    # /scan, /stop-all-fixes, /remediation-stats, ...
+│   │   ├── inspector.py                # /get-ai-stats, /projekt-status, /agent-stats, ...
+│   │   ├── monitoring.py               # /status, /bans, /threats, /docker, /aide
+│   │   ├── customer_setup_commands.py  # /setup-customer-server
+│   │   ├── cron_heartbeat.py           # Cron-Heartbeat
+│   │   └── phase_5e_health_aggregator.py  # Health-Aggregation
 │   ├── integrations/
 │   │   ├── ai_engine.py                # Dual-Engine AI (Codex + Claude CLI)
 │   │   ├── smart_queue.py              # SmartQueue (Analyse-Pool + Fix-Lock)
 │   │   ├── verification.py             # Pre-Push Verification Pipeline
-│   │   ├── orchestrator.py             # Remediation Orchestrator
+│   │   ├── orchestrator/               # Remediation Orchestrator (Package)
 │   │   ├── event_watcher.py            # Security Event Watcher
 │   │   ├── knowledge_base.py           # SQL Learning System
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
-│   │   ├── github_integration.py       # GitHub Webhooks
+│   │   ├── github_integration/         # GitHub Webhooks + Jules Workflow (Package)
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
+│   │   ├── fixers/                     # Security Fixers (fail2ban, crowdsec, aide, wal-g)
+│   │   ├── analyst/                    # Security Analyst (Legacy-Referenz)
+│   │   ├── ai_learning/                # Continuous Learning Agent
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
@@ -543,14 +557,8 @@ shadowops-bot/
 │   └── integration/
 │       └── test_learning_workflow.py   # End-to-End Tests
 ├── config/
-│   ├── config.example.yaml             # Example Config
-│   ├── config.yaml                     # Your Config (gitignored)
-│   ├── DO-NOT-TOUCH.md                 # Safety Rules
-│   ├── INFRASTRUCTURE.md               # Infrastructure Knowledge
-│   └── PROJECT_*.md                    # Project Documentation
-├── config/                             # Konfiguration
-│   ├── config.yaml                     # Hauptconfig (gitignored)
-│   ├── config.example.yaml             # Template
+│   ├── config.example.yaml             # Template (commited)
+│   ├── config.yaml                     # Real Config (gitignored)
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
 │   └── logrotate.conf                  # Log-Rotation
@@ -564,8 +572,7 @@ shadowops-bot/
 ├── data/                               # Runtime-Daten (gitignored)
 ├── logs/                               # Log-Dateien (gitignored)
 ├── docs/                               # Dokumentation
-│   ├── API.md                          # API-Referenz
-│   ├── guides/                         # Benutzer-Anleitungen
+│   ├── reference/api.md                # API-Referenz
 │   ├── adr/                            # Architecture Decision Records
 │   ├── plans/                          # Design-Dokumente
 │   └── archive/                        # Historische Doku

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -164,11 +164,9 @@ Shows AI provider status, fallback chain, and usage statistics.
 **Permissions:** None
 **Parameters:** None
 **Returns:** Embed with:
-- Ollama status (enabled/disabled, model, URL)
-- Claude status (enabled/disabled, model)
-- OpenAI status (enabled/disabled, model)
-- Active fallback chain
-- Request counts per provider
+- Codex CLI status (Primary engine, models)
+- Claude CLI status (Fallback engine, models, cli_path)
+- Engine stats (calls, successes per provider)
 
 **Example:**
 ```
@@ -265,26 +263,35 @@ channels:
   deployment_log: 0
 
 # ========================================
-# AI CONFIGURATION
+# AI CONFIGURATION (Dual-Engine: Codex CLI Primary, Claude CLI Fallback)
+# Ollama wurde vollstaendig entfernt (v4.0).
+# Keys DISCORD_BOT_TOKEN, OPENAI_API_KEY, ANTHROPIC_API_KEY kommen aus Env-Vars, NICHT aus config.yaml.
 # ========================================
 ai:
-  ollama:
-    enabled: true                           # Enable Ollama (local AI)
-    url: http://localhost:11434             # Ollama API URL
-    model: phi3:mini                        # Model for regular analysis
-    model_critical: llama3.1                # Model for CRITICAL events
-    hybrid_models: true                     # Use different models by severity
-    request_delay_seconds: 4.0              # Rate limiting (seconds between requests)
+  enabled: true
 
-  anthropic:
-    enabled: false                          # Enable Claude
-    api_key: null                           # Anthropic API key
-    model: claude-3-5-sonnet-20241022       # Claude model
+  primary:
+    engine: codex
+    models:
+      fast: gpt-4o
+      standard: gpt-5.3-codex
+      thinking: o3
+    timeout: 300
 
-  openai:
-    enabled: false                          # Enable OpenAI
-    api_key: null                           # OpenAI API key
-    model: gpt-4o                           # OpenAI model
+  fallback:
+    engine: claude
+    cli_path: /home/user/.local/bin/claude
+    models:
+      fast: claude-sonnet-4-6
+      standard: claude-sonnet-4-6
+      thinking: claude-opus-4-6
+    timeout: 300
+
+  routing:
+    critical_analysis: { engine: codex, model: thinking }
+    high_analysis: { engine: codex, model: standard }
+    low_analysis: { engine: codex, model: fast }
+    critical_verify: { engine: claude, model: thinking }
 
 # ========================================
 # AUTO-REMEDIATION CONFIGURATION
@@ -791,29 +798,20 @@ event = SecurityEvent(
 
 ## Database Schema
 
-### Knowledge Base (SQLite)
+### Knowledge Base (PostgreSQL — `security_analyst` DB)
 
-#### fixes table
-```sql
-CREATE TABLE fixes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp TEXT NOT NULL,
-    event_signature TEXT NOT NULL,  -- Unique event identifier
-    event_type TEXT NOT NULL,  -- vulnerability, intrusion, etc.
-    severity TEXT,
-    event_details TEXT,  -- JSON
-    strategy TEXT NOT NULL,  -- JSON: Full fix strategy
-    result TEXT NOT NULL,  -- 'success' or 'failed'
-    duration_seconds REAL,
-    error_message TEXT,
-    retry_count INTEGER DEFAULT 0
-);
+Die Knowledge Base nutzt PostgreSQL, nicht SQLite. Haupttabellen:
 
-CREATE INDEX idx_event_signature ON fixes(event_signature);
-CREATE INDEX idx_event_type ON fixes(event_type);
-CREATE INDEX idx_result ON fixes(result);
-CREATE INDEX idx_timestamp ON fixes(timestamp);
-```
+| Tabelle | Zweck |
+|---------|-------|
+| `fix_attempts_v2` | Fix-Ergebnisse (success, failed, no_op, skipped_duplicate) |
+| `fix_verifications` | Post-Fix Verifikations-Ergebnisse |
+| `finding_quality` | Qualitaetsbewertung von Findings |
+| `scan_coverage` | Coverage-Tracking pro Scan-Area und Projekt |
+| `remediation_status` | Cross-Mode Lock fuer laufende Fixes |
+| `jules_pr_reviews` | PR-State, Lock-Claim, Iteration-Counter fuer Jules Workflow |
+
+DSN kommt aus `config.security_analyst_dsn` (Env: `SECURITY_ANALYST_DB_URL`).
 
 ### Project Monitor State (JSON)
 
@@ -894,9 +892,8 @@ CREATE INDEX idx_timestamp ON fixes(timestamp);
 ## Rate Limiting
 
 ### AI Requests
-- **Ollama**: Configurable delay (`ai.ollama.request_delay_seconds`, default: 4.0s)
-- **Anthropic**: Built-in retry with exponential backoff (1s, 2s, 4s)
-- **OpenAI**: Built-in retry with exponential backoff (1s, 2s, 4s)
+- **Codex CLI (Primary)**: Timeout 300s, kein internes Rate Limiting (CLI-seitig gesteuert)
+- **Claude CLI (Fallback)**: Timeout 300s, Fallback greift bei Fehler oder Quota-Limit
 
 ### Discord Commands
 - **Global**: No built-in rate limiting (Discord handles this)
@@ -951,12 +948,15 @@ debug_mode: true
 
 ### Common API Issues
 
-**Knowledge Base locked:**
+**Knowledge Base-Verbindungsfehler:**
 ```bash
-# Check if database is locked
-sqlite3 data/knowledge_base.db "PRAGMA busy_timeout=5000;"
+# PostgreSQL-Status pruefen
+sudo systemctl status postgresql
 
-# If still locked, restart bot
+# DSN korrekt gesetzt?
+echo $SECURITY_ANALYST_DB_URL
+
+# Bot neu starten
 sudo systemctl restart shadowops-bot
 ```
 


### PR DESCRIPTION
## Doku-Kurator Lauf 2026-05-16 — Drift-Korrekturen

Falsche oder veraltete Aussagen in README, CLAUDE.md und api.md behoben.

### README.md

- **Fehlende Slash-Commands ergaenzt:** `/docker`, `/release-notes [project]`, `/pending-notes`, `/mark-duplicate` (Admin), `/agent-stats`, `/security-engine` waren im Code vorhanden aber nicht gelistet.
- **Doppelter `config/`-Block entfernt:** Projektstruktur hatte `config/` zweimal — ein Relikt aus einem alten Merge.
- **`docs/API.md` korrigiert auf `docs/reference/api.md`:** Pfad existierte nicht.
- **Cog-Liste aktualisiert:** `orchestrator.py`/`github_integration.py` als Packages eingetragen; neue Cogs (`customer_setup_commands`, `cron_heartbeat`, `phase_5e_health_aggregator`) und Sub-Packages (`fixers/`, `analyst/`, `ai_learning/`) eingetragen.

### CLAUDE.md

- **`orchestrator.py` → `orchestrator/`:** Ist ein Package (core, batch_mixin, planner_mixin, executor_mixin, recovery_mixin, discord_mixin, models). Die Falschaussage liess KI-Tools glauben, es sei eine Flat-File.
- **`github_integration.py` → `github_integration/`:** Ebenso ein Package mit Jules-Workflow-Modulen. Beides wurde prominent in "Module unter src/integrations/" gelistet.

### docs/reference/api.md

- **Ollama-Konfiguration entfernt** (Ollama wurde in v4.0 mit 1364 Zeilen vollstaendig geloescht; die alten `ai.ollama`, `ai.anthropic`, `ai.openai` Keys sind nicht mehr gueltig).
- **AI-Config auf Codex/Claude Dual-Engine-Stand gebracht** (Primär: Codex mit gpt-4o/gpt-5.3-codex/o3; Fallback: Claude CLI mit sonnet/opus).
- **`/get-ai-stats` Returns-Beschreibung korrigiert** (zeigte noch Ollama/Claude/OpenAI statt Codex/Claude).
- **Knowledge Base SQLite → PostgreSQL** (`security_analyst` DB mit asyncpg Pool); Tabellenliste aktualisiert auf `fix_attempts_v2`, `fix_verifications`, `finding_quality`, `scan_coverage`, `remediation_status`, `jules_pr_reviews`.
- **Rate Limiting Abschnitt** auf Codex/Claude CLI aktualisiert.
- **Troubleshooting** SQLite-Befehl durch PostgreSQL-Check ersetzt.

### Begruendung pro Item

Alle Korrekturen basieren auf direkter Code-Inspektion (`find`, `grep` auf Cog-Dekoratoren; `ls integrations/`). Keine spekulativen Aenderungen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWgZHWmnUU1w6i5D4YPJLf)_