### PR TITLE
docs: fehlende Slash-Commands in api.md + discord-bot.md Cog-Tabelle

### DIFF
--- a/.claude/rules/discord-bot.md
+++ b/.claude/rules/discord-bot.md
@@ -18,9 +18,11 @@ paths:
 | Datei | Cog | Commands |
 |-------|-----|----------|
 | `monitoring.py` | MonitoringCog | `/status`, `/bans`, `/threats`, `/docker`, `/aide` |
-| `admin.py` | AdminCog | `/scan`, `/stop-all-fixes`, `/remediation-stats`, `/set-approval-mode`, `/reload-context` |
-| `inspector.py` | InspectorCog | `/get-ai-stats`, `/projekt-status`, `/alle-projekte` |
+| `admin.py` | AdminCog | `/scan`, `/stop-all-fixes`, `/remediation-stats`, `/set-approval-mode`, `/reload-context`, `/release-notes`, `/pending-notes`, `/mark-duplicate` |
+| `inspector.py` | InspectorCog | `/get-ai-stats`, `/projekt-status`, `/alle-projekte`, `/agent-stats`, `/security-engine` |
 | `customer_setup_commands.py` | CustomerSetupCommands | `/setup-customer-server` |
+| `cron_heartbeat.py` | CronHeartbeatCog | (intern, keine Slash Commands) |
+| `phase_5e_health_aggregator.py` | Phase5eHealthAggregator | (intern, kein Slash Command — pollt 3 Hosts) |
 
 ## Patterns
 - Alle async: `await` fuer Discord API Calls

--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,13 +2,34 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": null,
-  "last_drift_check": null,
-  "open_prs": [],
+  "last_run": "2026-05-16T00:00:00Z",
+  "last_drift_check": "2026-05-16T00:00:00Z",
+  "open_prs": [
+    {
+      "branch": "claude/doku/drift-2026-05-16",
+      "title": "docs: drift-Korrekturen README, CLAUDE.md, api.md",
+      "scope": "drift",
+      "created": "2026-05-16"
+    },
+    {
+      "branch": "claude/doku/gaps-2026-05-16",
+      "title": "docs: fehlende Slash-Commands in api.md + discord-bot.md Cog-Tabelle",
+      "scope": "gaps",
+      "created": "2026-05-16"
+    }
+  ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": null },
-    "CLAUDE.md": { "last_synced_with_code_at": null },
-    "docs/reference/api.md": { "last_synced_with_code_at": null }
+    "README.md": { "last_synced_with_code_at": "2026-05-16" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-16" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-16" },
+    ".claude/rules/discord-bot.md": { "last_synced_with_code_at": "2026-05-16" }
   },
-  "open_questions": []
+  "open_questions": [
+    {
+      "id": "q1",
+      "created": "2026-05-16",
+      "file": "README.md",
+      "note": "README ist 775 Zeilen (Limit: 500). Highlights v3.1-v3.4 sind mehr als 2 Versionen alt und koennten in CHANGELOG.md migriert werden. Kein PR erstellt — Entscheidung beim Maintainer."
+    }
+  ]
 }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -97,6 +97,63 @@ Shows AIDE File Integrity Check status.
 /aide
 ```
 
+#### `/docker`
+Shows results of the last Docker security scan (Trivy).
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Vulnerability summary by severity for scanned images
+
+**Example:**
+```
+/docker
+```
+
+---
+
+### Patch Notes Commands
+
+#### `/release-notes [project]`
+Publishes accumulated commits as patch notes for a project (v6 Pipeline or v5 Batcher).
+
+**Permissions:** Administrator
+**Parameters:**
+- `project` (required): Project name (case-insensitive, e.g., guildscout, zerodox)
+
+**Returns:** Confirmation with version, commit count, and group count; patch notes posted to update channel
+
+**Example:**
+```
+/release-notes guildscout
+```
+
+#### `/pending-notes`
+Shows all pending commit batches waiting for release.
+
+**Permissions:** Administrator
+**Parameters:** None
+**Returns:** Embed with per-project commit count and date range
+
+**Example:**
+```
+/pending-notes
+```
+
+#### `/mark-duplicate`
+Marks a security finding as a duplicate of another for Learning-Feedback.
+
+**Permissions:** None (Security Engine must be active)
+**Parameters:**
+- `parent_id` (required): ID of the finding to keep
+- `child_id` (required): ID of the finding to mark as duplicate
+
+**Returns:** Confirmation of the duplicate marking
+
+**Example:**
+```
+/mark-duplicate 42 57
+```
+
 ---
 
 ### Auto-Remediation Commands
@@ -191,6 +248,32 @@ Reloads all project context files (DO-NOT-TOUCH, INFRASTRUCTURE, PROJECT_*.md).
 - After updating DO-NOT-TOUCH.md
 - After modifying project documentation
 - After adding new infrastructure knowledge
+
+#### `/agent-stats`
+Shows Agent-Learning statistics from the `agent_learning` database.
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Embed with learning metrics, recent fix outcomes, and knowledge-base state
+
+**Example:**
+```
+/agent-stats
+```
+
+#### `/security-engine`
+Shows Security Engine v6 status and statistics.
+
+**Permissions:** None
+**Parameters:** None
+**Returns:** Embed with:
+- Circuit Breaker state (open/closed, which sources are tripped)
+- Events processed and skipped counts
+
+**Example:**
+```
+/security-engine
+```
 
 ---
 


### PR DESCRIPTION
## Doku-Kurator Lauf 2026-05-16 — Luecken-Fuellung

Fehlende Eintraege in internen AI-Regeln und API-Referenz ergaenzt.

### docs/reference/api.md — fehlende Commands

Folgende Commands existierten im Code, hatten aber keinen Eintrag in der API-Referenz:

| Command | Cog | Neu dokumentiert |
|---------|-----|-----------------|
| `/docker` | MonitoringCog | Ja |
| `/release-notes [project]` | AdminCog | Ja |
| `/pending-notes` | AdminCog | Ja |
| `/mark-duplicate` | AdminCog | Ja |
| `/agent-stats` | InspectorCog | Ja |
| `/security-engine` | InspectorCog | Ja |

Quelle: direktes Lesen der `@app_commands.command(name=...)` Dekoratoren in allen Cog-Dateien sowie der Command-Handler-Implementierungen.

### .claude/rules/discord-bot.md — Cog-Tabelle

Die Tabelle war unvollstaendig:

- **AdminCog:** `/release-notes`, `/pending-notes`, `/mark-duplicate` fehlten.
- **InspectorCog:** `/agent-stats`, `/security-engine` fehlten.
- **Neue Cogs:** `cron_heartbeat.py` (Cron-Heartbeat, keine Slash Commands) und `phase_5e_health_aggregator.py` (Health-Aggregation fuer 3 Hosts, keine Slash Commands) waren nicht eingetragen.

Diese Datei ist die primaere Referenz fuer KI-Tools die an Cogs arbeiten — Luecken hier fuehren direkt zu falschen Annahmen beim Schreiben neuer Commands.

### .routines/state/doku.json

State-File initialisiert (erster Lauf). Offene Frage zu README Anti-Bloat festgehalten (README ist 775 Zeilen; Highlights v3.1-v3.4 sind mehr als 2 Versionen alt). Kein PR dafuer erstellt — Entscheidung beim Maintainer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWgZHWmnUU1w6i5D4YPJLf)_