### PR TITLE
fix(deploy): admin-merged PRs ohne CI-Trigger erkennen (#243)

### DIFF
--- a/src/integrations/github_integration/ci_mixin.py
+++ b/src/integrations/github_integration/ci_mixin.py
@@ -213,6 +213,7 @@ class CIMixin:
         merged_sha: str,
         workflow_names: List[str],
         max_wait_min: int = 30,
+        admin_merge_grace_min: int = 5,
     ) -> Literal["success", "failure", "timeout", "no_workflows"]:
         """
         Wait for required CI workflows on a given commit to complete.
@@ -220,6 +221,13 @@ class CIMixin:
         Welle 9.10 (2026-05-11): Verhindert den Race Condition aus dem
         58h-Vorfall: Bot triggert deploy.sh sofort bei PR-merge → deploy.sh
         Pre-Flight-Gate sieht pending CI auf dem neuen SHA → exit 1.
+
+        Welle 9.16 (Issue #243): Admin-merged PRs triggern oft keinen CI-Run
+        (Required-Checks bleiben leer). Wenn nach `admin_merge_grace_min`
+        Minuten KEIN relevanter Workflow fuer den SHA gesichtet wurde,
+        gilt das als "kein CI vorhanden" → return "no_workflows" (Caller
+        deployt direkt). Sobald aber EIN Workflow gesehen wurde, gilt der
+        normale Timeout-Pfad (max_wait_min).
 
         Exponential backoff: 60s → 120s → 240s → cap 300s.
 
@@ -229,12 +237,15 @@ class CIMixin:
             workflow_names: Liste von erlaubten workflow-Names (z.B. ["Web Quality"]).
                             Match ist case-insensitive substring.
             max_wait_min: Hard-timeout in Minuten. Default 30.
+            admin_merge_grace_min: Grace-Period in Minuten, in der NOCH KEIN
+                Workflow fuer den SHA erkannt sein muss. Default 5.
 
         Returns:
             "success"      — alle required Workflows haben conclusion=success
             "failure"      — mind. 1 Workflow ist failed/cancelled/timed_out
             "timeout"      — nach max_wait_min noch nicht alle completed
-            "no_workflows" — kein workflow_names konfiguriert → caller entscheidet
+            "no_workflows" — kein workflow_names konfiguriert ODER admin-merge
+                             ohne CI-Trigger erkannt → caller entscheidet
         """
         if not workflow_names:
             self.logger.info(
@@ -251,13 +262,17 @@ class CIMixin:
             return "no_workflows"
 
         workflow_names_lower = [str(n).lower().strip() for n in workflow_names if n]
-        deadline = time.monotonic() + max_wait_min * 60
+        started_at = time.monotonic()
+        deadline = started_at + max_wait_min * 60
+        admin_merge_deadline = started_at + max(0, admin_merge_grace_min) * 60
         poll_interval_s = 60
         max_poll_interval_s = 300  # 5 min cap
+        saw_any_relevant = False
 
         self.logger.info(
             f"⏳ Welle 9.10: warte auf CI-Completion fuer {repo_full_name}@{merged_sha[:7]} "
-            f"(workflows={workflow_names}, timeout={max_wait_min}min)"
+            f"(workflows={workflow_names}, timeout={max_wait_min}min, "
+            f"admin_merge_grace={admin_merge_grace_min}min)"
         )
 
         while time.monotonic() < deadline:
@@ -287,6 +302,17 @@ class CIMixin:
                         break
 
             if not relevant:
+                # Welle 9.16 (Issue #243): admin-merged Detection. Wenn nach
+                # admin_merge_grace_min weiter KEIN Workflow fuer den SHA gesichtet
+                # wurde, ist es vermutlich ein admin-merge ohne CI-Trigger →
+                # weiter deployen (Caller behandelt "no_workflows" als OK).
+                if not saw_any_relevant and time.monotonic() >= admin_merge_deadline:
+                    self.logger.info(
+                        f"ℹ️ _wait_for_ci_completion: nach {admin_merge_grace_min}min "
+                        f"keine relevanten Workflows fuer {merged_sha[:7]} sichtbar — "
+                        f"admin-merge ohne CI-Trigger vermutet, fahre fort."
+                    )
+                    return "no_workflows"
                 self.logger.info(
                     f"⏳ _wait_for_ci_completion: noch keine relevanten Workflows "
                     f"fuer {merged_sha[:7]} sichtbar — weiter pollen ({poll_interval_s}s)..."
@@ -294,6 +320,8 @@ class CIMixin:
                 await asyncio.sleep(poll_interval_s)
                 poll_interval_s = min(poll_interval_s * 2, max_poll_interval_s)
                 continue
+
+            saw_any_relevant = True
 
             # Bestimme Status pro workflow_name: den NEUESTEN Run zaehlen
             # (re-runs koennen mehrere Eintraege liefern).
@@ -474,11 +502,15 @@ class CIMixin:
             workflow_names = project_config.get('ci_workflows') or []
             if workflow_names:
                 max_wait_min = int(project_config.get('ci_wait_max_min', 30))
+                admin_merge_grace_min = int(
+                    project_config.get('ci_wait_admin_merge_grace_min', 5)
+                )
                 outcome = await self._wait_for_ci_completion(
                     repo_full_name=repo_full_name,
                     merged_sha=full_sha,
                     workflow_names=workflow_names,
                     max_wait_min=max_wait_min,
+                    admin_merge_grace_min=admin_merge_grace_min,
                 )
                 if outcome == "failure":
                     await self._send_ci_wait_alert(

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -390,6 +390,113 @@ class TestWelle910WaitForCI:
         assert result == 'timeout'
 
     @pytest.mark.asyncio
+    async def test_wait_returns_no_workflows_after_admin_merge_grace(
+        self, mock_bot, cfg_with_projects, monkeypatch,
+    ):
+        """Welle 9.16 (Issue #243): wenn nach admin_merge_grace_min weiter KEIN
+        Workflow für den SHA gesichtet wurde, gilt es als admin-merge ohne CI
+        → "no_workflows" (Caller deployt direkt) statt 30min Timeout."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        # API liefert konstant einen Workflow-Run, der NICHT zum Filter passt
+        # (anderes Repo / anderer Name). Damit bleibt `relevant` immer leer.
+        integration._fetch_workflow_runs_for_sha = AsyncMock(return_value={
+            'workflow_runs': [
+                {
+                    'name': 'Unrelated Workflow',
+                    'status': 'completed',
+                    'conclusion': 'success',
+                    'created_at': '2026-05-15T18:00:00Z',
+                    'path': '.github/workflows/unrelated.yml',
+                },
+            ],
+        })
+
+        sleep_calls = []
+
+        async def fast_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.asyncio.sleep', fast_sleep)
+
+        # time.monotonic: 0 (started_at), 0 (Loop-Eintritt) ⇒ in Grace,
+        # dann 400 (>5*60=300) ⇒ Grace abgelaufen ⇒ no_workflows
+        times = iter([0.0, 0.0, 400.0])
+
+        def fake_monotonic():
+            try:
+                return next(times)
+            except StopIteration:
+                return 400.0
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.time.monotonic', fake_monotonic)
+
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='b' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=30,
+            admin_merge_grace_min=5,
+        )
+        assert result == 'no_workflows'
+
+    @pytest.mark.asyncio
+    async def test_wait_does_not_short_circuit_when_workflow_was_seen(
+        self, mock_bot, cfg_with_projects, monkeypatch,
+    ):
+        """Negativtest: wenn schon mal ein relevanter Workflow gesehen wurde,
+        darf admin_merge_grace NICHT mehr greifen — dann gilt der normale
+        Timeout-Pfad."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        # Erst pending (relevant), dann verschwindet er aus dem Response
+        # (z.B. weil neuer Re-Run gestartet, aber API noch nicht aktuell).
+        call_count = {'n': 0}
+
+        async def fetch(*_args, **_kwargs):
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                return {
+                    'workflow_runs': [
+                        {
+                            'name': 'Web Quality',
+                            'status': 'in_progress',
+                            'conclusion': None,
+                            'created_at': '2026-05-15T18:00:00Z',
+                            'path': '.github/workflows/web-quality.yml',
+                        },
+                    ],
+                }
+            return {'workflow_runs': []}
+
+        integration._fetch_workflow_runs_for_sha = fetch
+
+        async def fast_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.asyncio.sleep', fast_sleep)
+
+        # Erste Iteration: in_progress → saw_any_relevant=True, weiter pollen
+        # Zweite Iteration: relevant leer, ABER saw_any_relevant=True → kein short-circuit
+        # Dritte Iteration: deadline überschritten → timeout
+        times = iter([0.0, 0.0, 100.0, 2000.0])
+
+        def fake_monotonic():
+            try:
+                return next(times)
+            except StopIteration:
+                return 2000.0
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.time.monotonic', fake_monotonic)
+
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='c' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=30,
+            admin_merge_grace_min=1,
+        )
+        assert result == 'timeout'
+
+    @pytest.mark.asyncio
     async def test_trigger_deployment_blocks_on_failure(self, mock_bot, cfg_with_projects):
         """deploy.sh darf NICHT laufen wenn CI failed."""
         integration = GitHubIntegration(mock_bot, cfg_with_projects)


### PR DESCRIPTION
## Summary
- Behebt Issue #243: `_wait_for_ci_completion` pollte bisher bis zum Hard-Timeout (30min) wenn für einen admin-merged Commit nie ein Workflow startete. Bei Single-Maintainer-Patterns (ZERODOX, shadowops-bot selbst) führte das zu Deploy-Drift trotz erfolgreicher Merges.
- Lösung: neuer Parameter `admin_merge_grace_min` (Default 5min). Wenn nach Grace-Period KEIN relevanter Workflow für den SHA gesichtet wurde → `no_workflows` (Caller deployt direkt). Sobald aber 1× ein Workflow gesehen wurde, bleibt der normale Timeout-Pfad aktiv.

## Konfigurierbar
```yaml
projects:
  zerodox:
    ci_workflows: ["Web Quality"]
    ci_wait_max_min: 30
    ci_wait_admin_merge_grace_min: 5   # NEU
```

## Test plan
- [x] `pytest tests/unit/test_github_integration.py::TestWelle910WaitForCI -x -q` → 11 passed
- [x] Neuer Test: `test_wait_returns_no_workflows_after_admin_merge_grace` — Short-Circuit bei admin-merge
- [x] Negativtest: `test_wait_does_not_short_circuit_when_workflow_was_seen` — normale CI-Latenz wird nicht fälschlich als admin-merge erkannt
- [ ] Smoke nach Merge: nächster admin-merged PR auf shadowops-bot triggert deploy.sh ohne 30min Wartezeit

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)