### PR TITLE
fix(scan-agent): Host-OS-Routing + Jules-Dedup (#249 Phase 2+3)

### DIFF
--- a/src/integrations/github_integration/agent_review/queue.py
+++ b/src/integrations/github_integration/agent_review/queue.py
@@ -151,6 +151,43 @@ class TaskQueue:
             )
         return int(row["cnt"] or 0)
 
+    async def find_open_task_by_signature(
+        self, finding_signature: str,
+    ) -> Optional[QueuedTask]:
+        """Issue #249: Idempotenz fuer Jules-Tasks.
+
+        Sucht eine noch nicht abgeschlossene Task (status in {'queued',
+        'released'}) mit identischer `payload.finding_signature`. Wird
+        beim PR-Cleanup 2026-05-17 gefunden, weil drei aufeinanderfolgende
+        `_enqueue_jules_fix`-Aufrufe identische N+1-Optimierungs-Tasks
+        erzeugten → 3 PRs fuer dieselbe Sache (#195, #196, #197).
+
+        Returnt None wenn keine passende Task existiert oder wenn die
+        Signature leer ist. Bei DB-Fehler ebenfalls None (Caller faellt
+        auf den alten Pfad zurueck, kein Schaden).
+        """
+        if not finding_signature:
+            return None
+        assert self._pool is not None
+        try:
+            async with self._pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """SELECT id, source, priority, payload, project, retry_count
+                       FROM agent_task_queue
+                       WHERE status IN ('queued', 'released')
+                         AND payload->>'finding_signature' = $1
+                       ORDER BY created_at ASC
+                       LIMIT 1""",
+                    finding_signature,
+                )
+        except Exception as exc:
+            logger.warning(
+                "find_open_task_by_signature: DB-Fehler — fahre ohne Dedupe fort: %s",
+                exc,
+            )
+            return None
+        return self._row_to_task(row) if row else None
+
     async def cancel(self, task_id: int, reason: str = "") -> None:
         """Cancelt einen Task (z.B. weil bereits anders erledigt)."""
         assert self._pool is not None

--- a/src/integrations/security_engine/scan_agent.py
+++ b/src/integrations/security_engine/scan_agent.py
@@ -101,6 +101,22 @@ PROJECT_REPO_MAP = {
 DEFAULT_REPO = 'Commandershadow9/shadowops-bot'
 SKIP_ISSUE_PROJECTS = {'openclaw', 'agents', 'blogger', 'content-pipeline'}
 
+# Issue #249 (PR-Cleanup 2026-05-17): Host-OS- und externe Container-Image-Findings
+# duerfen NICHT als GitHub-Issue im shadowops-bot Repo landen — sie betreffen
+# den Bot nicht, gehoeren in Server-Ops oder externes Repo. Stattdessen nur Log.
+# Kategorien sind lower-case und werden case-insensitiv gematcht.
+HOST_OS_CATEGORIES = {
+    'kernel_update', 'kernel_patch', 'kernel',
+    'system_package', 'apt_update', 'apt_security',
+    'imagemagick', 'chrome', 'google_chrome',
+    'aide_drift', 'aide_failure',
+    'ownership_drift', 'setuid_drift', 'root_ownership',
+    'env_perms', 'env_world_readable',
+    'claude_settings_perms', 'backup_perms',
+    'container_image_cve',  # externe Docker-Images (blogger-mcp, leitstelle-osrm)
+    'host_docker_update',
+}
+
 # === Jules SecOps Workflow — Fix-Mode-Klassifizierung ===
 # Siehe docs/plans/2026-04-11-jules-secops-workflow-design.md §9.1
 
@@ -2122,6 +2138,17 @@ von der ShadowOps Review-Pipeline reviewt — halte den Scope eng."""
         for skip in SKIP_ISSUE_PROJECTS:
             if skip in ap.lower():
                 return None
+
+        # Issue #249: Host-OS- und externe Container-Image-Findings nicht als
+        # GitHub-Issue ablegen (gehoeren nicht ins shadowops-bot Repo).
+        category = (finding.get('category') or '').lower().strip()
+        if category in HOST_OS_CATEGORIES:
+            logger.info(
+                "[scan-agent] Finding '%s' (category=%s) ist Host-OS-Thema — "
+                "kein GitHub-Issue (Routing via HOST_OS_CATEGORIES).",
+                title[:60], category,
+            )
+            return None
 
         repo = self._resolve_repo(ap)
         fp, existing = await self._find_similar_open_finding_by_fingerprint(

--- a/src/integrations/security_engine/scan_agent.py
+++ b/src/integrations/security_engine/scan_agent.py
@@ -2057,11 +2057,27 @@ class SecurityScanAgent:
             return False
         return True
 
+    @staticmethod
+    def _compute_finding_signature(
+        repo_name: str, category: str, affected_files: List[str],
+    ) -> str:
+        """Issue #249: stabile Signatur fuer Dedup-Check vor Jules-Enqueue.
+
+        Hash ueber (repo, category, sortierte affected_files). Identische
+        Findings (z.B. drei Re-Trigger fuer dieselbe N+1-Optimierung)
+        ergeben dieselbe Signatur.
+        """
+        import hashlib
+        files_norm = sorted(str(f).strip().lower() for f in (affected_files or []) if f)
+        raw = f"{repo_name.lower()}|{category.lower()}|{','.join(files_norm)}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
     async def _enqueue_jules_fix(self, finding: Dict) -> Optional[int]:
         """Baut Jules-Prompt aus Finding und queued in agent_task_queue.
 
         Returns:
-            task_id bei Erfolg, None bei Fehler.
+            task_id bei Erfolg (auch wenn Dedup-Treffer, dann existing id),
+            None bei Fehler.
         """
         queue = getattr(self, 'agent_task_queue', None)
         if queue is None:
@@ -2084,6 +2100,30 @@ class SecurityScanAgent:
         if isinstance(affected_files, str):
             affected_files = [affected_files]
         files_list = "\n".join(f"- {f}" for f in affected_files[:10])
+
+        # Issue #249: Dedup-Check vor enqueue. Identische Findings (gleiche
+        # Repo + Category + Files) duerfen nicht erneut an Jules delegiert
+        # werden, sonst entstehen Doppel-PRs wie #195/#196/#197.
+        category = finding.get('category', '') or ''
+        finding_signature = self._compute_finding_signature(
+            repo_name=repo_name, category=category, affected_files=affected_files,
+        )
+        if hasattr(queue, "find_open_task_by_signature"):
+            try:
+                existing = await queue.find_open_task_by_signature(finding_signature)
+            except Exception as exc:
+                logger.warning(
+                    "[scan-agent] find_open_task_by_signature schlug fehl, "
+                    "fahre ohne Dedupe fort: %s", exc,
+                )
+                existing = None
+            if existing is not None:
+                logger.info(
+                    "[scan-agent] Dedupe-Treffer: Task %s ist bereits offen fuer "
+                    "Signature %s (repo=%s, category=%s) — kein neuer Enqueue.",
+                    existing.id, finding_signature, repo_name, category,
+                )
+                return int(existing.id)
 
         prompt = f"""Security-Fix fuer {project} ({severity} severity).
 
@@ -2117,6 +2157,8 @@ von der ShadowOps Review-Pipeline reviewt — halte den Scope eng."""
                     'branch': 'main',
                     'finding_category': finding.get('category', ''),
                     'finding_severity': severity,
+                    # Issue #249: Signatur fuer Dedup beim naechsten Enqueue
+                    'finding_signature': finding_signature,
                 },
                 project=project,
             )

--- a/tests/unit/test_scan_agent_jules_delegation.py
+++ b/tests/unit/test_scan_agent_jules_delegation.py
@@ -16,13 +16,18 @@ from src.integrations.security_engine.scan_agent import SecurityScanAgent
 pytestmark = pytest.mark.asyncio
 
 
-def _make_agent(*, enabled=True, queue_enqueue=None):
-    """Fabrik: SecurityScanAgent mit gestubtem Bot + Queue."""
+def _make_agent(*, enabled=True, queue_enqueue=None, existing_task=None):
+    """Fabrik: SecurityScanAgent mit gestubtem Bot + Queue.
+
+    Issue #249: Dedupe-Lookup wird per Default auf None gestubbed → kein Dedup-Hit.
+    Mit `existing_task=<QueuedTask>` simuliert man einen Dedup-Hit.
+    """
     agent = SecurityScanAgent.__new__(SecurityScanAgent)
     agent.bot = SimpleNamespace()
 
     queue = MagicMock()
     queue.enqueue = queue_enqueue or AsyncMock(return_value=42)
+    queue.find_open_task_by_signature = AsyncMock(return_value=existing_task)
     agent.bot.github_integration = SimpleNamespace(
         agent_task_queue=queue,
         _agent_review_enabled=enabled,
@@ -166,6 +171,9 @@ class TestEnqueueJulesFix:
         assert 'web/src/auth.ts' in payload['prompt']
         assert payload['finding_category'] == 'code_security'
         assert payload['finding_severity'] == 'high'
+        # Issue #249: Signature ist im payload fuer naechsten Dedup-Lookup
+        assert 'finding_signature' in payload
+        assert len(payload['finding_signature']) == 16  # sha256[:16]
 
     async def test_no_queue_returns_none(self):
         agent = SecurityScanAgent.__new__(SecurityScanAgent)
@@ -197,6 +205,81 @@ class TestEnqueueJulesFix:
         await agent._enqueue_jules_fix(f)
         payload = queue.enqueue.await_args.kwargs['payload']
         assert 'single/file.py' in payload['prompt']
+
+    # ───── Issue #249: Dedup-Pfad ─────
+
+    async def test_dedupe_hit_returns_existing_task_id_no_enqueue(self):
+        """Wenn find_open_task_by_signature einen Treffer liefert, darf
+        queue.enqueue NICHT mehr gerufen werden — die existierende Task
+        wird zurueckgegeben."""
+        existing = SimpleNamespace(id=99, source='scan_agent', priority=1,
+                                   payload={}, project='zerodox', retry_count=0)
+        agent, queue = _make_agent(enabled=True, existing_task=existing)
+        agent._repo_for_finding = lambda f: 'Commandershadow9/ZERODOX'
+
+        result = await agent._enqueue_jules_fix(self._finding())
+
+        assert result == 99
+        queue.find_open_task_by_signature.assert_awaited_once()
+        queue.enqueue.assert_not_called()
+
+    async def test_dedupe_miss_proceeds_to_enqueue(self):
+        """Wenn find_open_task_by_signature None liefert (kein Treffer),
+        laeuft enqueue normal durch."""
+        agent, queue = _make_agent(enabled=True, existing_task=None)
+        agent._repo_for_finding = lambda f: 'Commandershadow9/ZERODOX'
+
+        result = await agent._enqueue_jules_fix(self._finding())
+
+        assert result == 42  # _make_agent default
+        queue.find_open_task_by_signature.assert_awaited_once()
+        queue.enqueue.assert_awaited_once()
+
+    async def test_dedupe_db_error_falls_back_to_enqueue(self):
+        """DB-Fehler in find_open_task_by_signature darf NICHT den Enqueue
+        blockieren — graceful Fallback auf alten Pfad."""
+        agent, queue = _make_agent(enabled=True)
+        queue.find_open_task_by_signature = AsyncMock(
+            side_effect=RuntimeError("connection lost")
+        )
+        agent._repo_for_finding = lambda f: 'Commandershadow9/ZERODOX'
+
+        result = await agent._enqueue_jules_fix(self._finding())
+
+        assert result == 42
+        queue.enqueue.assert_awaited_once()
+
+    async def test_signature_is_stable_for_same_inputs(self):
+        """Drei aufeinanderfolgende Calls fuer dieselbe Sache erzeugen
+        dieselbe Signature — das ist die Grundlage des Dedupes."""
+        sig1 = SecurityScanAgent._compute_finding_signature(
+            'ZERODOX', 'code_security', ['web/src/auth.ts'],
+        )
+        sig2 = SecurityScanAgent._compute_finding_signature(
+            'ZERODOX', 'code_security', ['web/src/auth.ts'],
+        )
+        assert sig1 == sig2
+        assert len(sig1) == 16
+
+    async def test_signature_changes_with_files(self):
+        """Andere Files → andere Signature → kein Dedupe-Treffer."""
+        sig1 = SecurityScanAgent._compute_finding_signature(
+            'ZERODOX', 'code_security', ['web/src/auth.ts'],
+        )
+        sig2 = SecurityScanAgent._compute_finding_signature(
+            'ZERODOX', 'code_security', ['web/src/login.tsx'],
+        )
+        assert sig1 != sig2
+
+    async def test_signature_normalizes_file_order(self):
+        """File-Reihenfolge darf nicht zu unterschiedlichen Signaturen fuehren."""
+        sig1 = SecurityScanAgent._compute_finding_signature(
+            'ZERODOX', 'code_security', ['a.ts', 'b.ts'],
+        )
+        sig2 = SecurityScanAgent._compute_finding_signature(
+            'ZERODOX', 'code_security', ['b.ts', 'a.ts'],
+        )
+        assert sig1 == sig2
 
 
 # ─────────── Constants ───────────

--- a/tests/unit/test_scan_agent_routing_249.py
+++ b/tests/unit/test_scan_agent_routing_249.py
@@ -1,0 +1,158 @@
+"""Tests fuer Issue #249 — SecurityScanAgent Routing:
+
+- Host-OS-Findings (Kernel, ImageMagick, Ownership-Drift, etc.) duerfen
+  KEIN GitHub-Issue im shadowops-bot Repo erzeugen.
+- Bot-Code-Findings (npm_audit, code_security, etc.) gehen weiter normal durch.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.integrations.security_engine.scan_agent import (
+    HOST_OS_CATEGORIES,
+    SecurityScanAgent,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_minimal_agent():
+    """Minimal-Agent fuer _create_github_issue-Routing-Tests."""
+    agent = SecurityScanAgent.__new__(SecurityScanAgent)
+    agent.bot = SimpleNamespace()
+    # Fingerprint-Check umgehen — Test fokussiert nur auf Host-OS-Routing
+    agent._find_similar_open_finding_by_fingerprint = AsyncMock(
+        return_value=(None, None)
+    )
+    return agent
+
+
+class TestHostOsCategoriesShortCircuit:
+    """Issue #249: Host-OS-Kategorien fuehren zu return None ohne subprocess."""
+
+    async def test_kernel_update_returns_none(self):
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'kernel_update',
+            'affected_project': 'infrastructure',
+            'title': 'Kernel security update verfuegbar',
+            'description': 'Neue CVEs im linux-image-cloud-amd64 verfuegbar.',
+            'severity': 'medium',
+        }
+        result = await agent._create_github_issue(finding)
+        assert result is None
+        # Fingerprint-Dedupe darf NICHT gerufen worden sein (early-return davor)
+        agent._find_similar_open_finding_by_fingerprint.assert_not_called()
+
+    async def test_imagemagick_returns_none(self):
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'imagemagick',
+            'affected_project': 'infrastructure',
+            'title': 'ImageMagick deb12u9',
+            'description': 'Security-Backlog auf Debian 12 schliessen.',
+            'severity': 'medium',
+        }
+        assert await agent._create_github_issue(finding) is None
+
+    async def test_ownership_drift_returns_none(self):
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'ownership_drift',
+            'affected_project': 'infrastructure',
+            'title': 'Ownership-Drift auf Root-Pfaden',
+            'description': 'setuid-Binaries gehoeren nobody statt root.',
+            'severity': 'critical',
+        }
+        assert await agent._create_github_issue(finding) is None
+
+    async def test_container_image_cve_returns_none(self):
+        """blogger-mcp / leitstelle-osrm CVEs gehoeren in externes Repo, nicht hier."""
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'container_image_cve',
+            'affected_project': 'infrastructure',
+            'title': 'blogger-mcp HIGH-CVE-Last gestiegen',
+            'description': '+43 HIGH-CVEs seit 2026-04-24 im public Container.',
+            'severity': 'high',
+        }
+        assert await agent._create_github_issue(finding) is None
+
+    async def test_category_case_insensitive(self):
+        """KERNEL_UPDATE oder Kernel_Update werden gleich behandelt."""
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'KERNEL_UPDATE',
+            'affected_project': 'infrastructure',
+            'title': 'Kernel-Update',
+            'description': 'Sicherheits-Updates ausstehend auf Host.',
+            'severity': 'medium',
+        }
+        assert await agent._create_github_issue(finding) is None
+
+
+class TestNonHostOsContinuesNormally:
+    """Bot-Code-Findings (npm_audit, code_security) fallen NICHT auf den
+    Early-Return — sie laufen weiter in den Fingerprint-Check und ggf.
+    gh issue create."""
+
+    async def test_npm_audit_continues_past_routing(self):
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'npm_audit',
+            'affected_project': 'zerodox',
+            'title': 'npm-Package mit CVE',
+            'description': 'Dependency XYZ hat CVE-2026-1234.',
+            'severity': 'high',
+        }
+        # _find_similar_open_finding_by_fingerprint MUSS gerufen werden
+        # (= wir sind ueber den Host-OS-Check hinaus). Wir mocken die
+        # naechste subprocess-Stufe weg, indem `gh issue list` einfach
+        # nichts findet → Funktion versucht gh issue create, aber der
+        # subprocess-Call ist nicht gemockt → Exception, return None.
+        # Der Test prueft: Fingerprint-Check WURDE gerufen.
+        try:
+            await agent._create_github_issue(finding)
+        except Exception:
+            pass  # subprocess-Calls sind nicht gemockt, das ist hier OK
+        agent._find_similar_open_finding_by_fingerprint.assert_called_once()
+
+    async def test_code_security_continues_past_routing(self):
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'code_security',
+            'affected_project': 'zerodox',
+            'title': 'XSS in user input',
+            'description': 'User-Input wird ohne Sanitizer als HTML gerendert.',
+            'severity': 'high',
+            'affected_files': ['web/src/auth.ts'],
+        }
+        try:
+            await agent._create_github_issue(finding)
+        except Exception:
+            pass
+        agent._find_similar_open_finding_by_fingerprint.assert_called_once()
+
+
+class TestHostOsCategoriesConstant:
+    """Konstante selbst testen."""
+
+    def test_contains_kernel_categories(self):
+        assert 'kernel_update' in HOST_OS_CATEGORIES
+        assert 'kernel_patch' in HOST_OS_CATEGORIES
+
+    def test_contains_imagemagick(self):
+        assert 'imagemagick' in HOST_OS_CATEGORIES
+
+    def test_contains_ownership_drift(self):
+        assert 'ownership_drift' in HOST_OS_CATEGORIES
+        assert 'setuid_drift' in HOST_OS_CATEGORIES
+
+    def test_contains_external_container_cve(self):
+        assert 'container_image_cve' in HOST_OS_CATEGORIES
+
+    def test_all_entries_lowercase(self):
+        """Pflicht-Eigenschaft fuer den case-insensitiven Lookup."""
+        for cat in HOST_OS_CATEGORIES:
+            assert cat == cat.lower(), f"Eintrag {cat!r} ist nicht lower-case"


### PR DESCRIPTION
## Summary

Schließt **Phase 2 (Jules-Dedup)** und **Phase 3 (Host-OS-Routing)** aus Tracking-Issue #249. Beide Probleme stammen aus dem PR-Cleanup vom 17.05.: 15 Host-OS-Findings landeten im falschen Repo, 3 Jules-PRs entstanden für dieselbe Optimierung.

### Commit 1 — Host-OS-Routing (Phase 3)
- Neue Konstante `HOST_OS_CATEGORIES` (20 Kategorien: kernel, imagemagick, ownership_drift, container_image_cve, …)
- `_create_github_issue()` early-return bei Host-OS-Kategorien → kein Issue im shadowops-bot Repo
- 12 neue Tests in `tests/unit/test_scan_agent_routing_249.py`

### Commit 2 — Jules-Dedup (Phase 2)
- Neue Methode `TaskQueue.find_open_task_by_signature()` mit graceful DB-Fehler-Fallback
- Neue Staticmethod `SecurityScanAgent._compute_finding_signature()` (sha256[:16] über repo+category+sortierte files)
- `_enqueue_jules_fix()` prüft Signatur vor enqueue → existing.id returnen wenn Treffer
- `payload['finding_signature']` wird beim Enqueue gespeichert für künftige Lookups
- 6 neue + 1 erweiterter Test in `tests/unit/test_scan_agent_jules_delegation.py`

## Risiko-Analyse

Beide Änderungen sind **rein additiv** und haben graceful Fallback:
- Host-OS-Routing: wenn die Konstante unvollständig ist → wie bisher Issue im Bot-Repo (= alter Zustand)
- Jules-Dedup: bei DB-Fehler oder fehlender `find_open_task_by_signature` Methode → wie bisher direkt enqueue (= alter Zustand)
- Keine DB-Migration nötig (JSONB-Lookup auf `payload->>'finding_signature'`)

## Test plan

- [x] `pytest tests/unit/test_scan_agent_jules_delegation.py tests/unit/test_scan_agent_routing_249.py` → 41 passed
- [ ] Smoke nach Bot-Restart: Host-OS-Finding (z.B. kernel_update) wird im journalctl als "Routing via HOST_OS_CATEGORIES" geloggt, kein neues Issue
- [ ] Smoke: zweimaliger `_enqueue_jules_fix` für selbes Finding → 2. Call returnt existing.id ohne neue Jules-Session

Refs #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)