### PR TITLE
feat(monitoring): externer Bot-Watchdog + monatlicher Backup-Restore-Test

### DIFF
--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -1,0 +1,118 @@
+# ShadowOps Monitoring — Setup-Anleitung
+
+> Externer Watchdog für den Bot + monatlicher Backup-Restore-Test.
+> Beide alerten via Discord-Webhook **direkt** (nicht über den Bot selbst),
+> damit auch ein toter Bot Alarme schlagen kann.
+
+## Architektur
+
+```
+                ┌──────────────────────────┐
+                │ Discord (critical-Channel)│
+                └────────────▲─────────────┘
+                             │ Webhook (POST)
+                             │
+   ┌─────────────────┐       │       ┌──────────────────────┐
+   │ Bot-Watchdog    │───────┘       │ Backup-Restore-Test  │
+   │ alle 5 Minuten  │               │ am 1. jedes Monats   │
+   │ (systemd-Timer) │               │ (systemd-Timer)      │
+   └────────┬────────┘               └──────────────────────┘
+            │ pingt
+            ▼
+   http://127.0.0.1:8766/health
+```
+
+## Erst-Einrichtung (einmalig)
+
+### 1. Discord-Webhook erstellen
+
+1. In Discord: **Server-Einstellungen → Integrationen → Webhooks**
+2. **"Neuer Webhook"** klicken
+3. Name: `ShadowOps Watchdog`, Channel: `critical` (oder ein anderer dedizierter Alert-Channel)
+4. **"Webhook-URL kopieren"** — die URL sieht aus wie
+   `https://discord.com/api/webhooks/1234.../abcd...`
+
+### 2. Config-Datei anlegen
+
+```bash
+# Template kopieren (nicht editieren — die echte Config gehört NICHT ins Repo)
+cp ~/shadowops-bot/deploy/shadowops-watchdog.env.example \
+   ~/.config/shadowops-watchdog.env
+
+# Webhook-URL eintragen
+nano ~/.config/shadowops-watchdog.env
+# → SHADOWOPS_WATCHDOG_WEBHOOK=https://discord.com/api/webhooks/...
+
+# Rechte: nur du darfst lesen (enthält Token!)
+chmod 600 ~/.config/shadowops-watchdog.env
+```
+
+### 3. systemd-Reload
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart shadowops-watchdog.timer
+```
+
+### 4. Funktionstest
+
+```bash
+# Manueller Watchdog-Run (sollte "OK — Bot healthy" loggen)
+systemctl --user start shadowops-watchdog.service
+journalctl --user -u shadowops-watchdog.service --no-pager -n 5
+
+# Test-Alert auslösen (mit absichtlich falschem Endpoint)
+SHADOWOPS_HEALTH_URL="http://127.0.0.1:9999/health" \
+  ~/shadowops-bot/scripts/bot-watchdog.sh
+
+# State zurücksetzen
+echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
+  > ~/shadowops-bot/data/watchdog_state.json
+```
+
+## Was wird wann alertiert?
+
+### Bot-Watchdog (alle 5 Minuten)
+
+- **🔴 Bot DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
+  Verhindert false-positives bei Bot-Restart oder kurzem Netzwerk-Hiccup.
+- **✅ Bot wieder UP** — sobald der Bot nach einem Down-Alert wieder antwortet.
+- **Keine Wiederholungs-Alerts** — wenn der Bot Stunden down ist, kommt nur EIN
+  Initial-Alert, kein Spam.
+
+### Backup-Restore-Test (1. jedes Monats, 04:50 lokal)
+
+- **🔴 Backup FAILED** — wenn `~/ZERODOX/scripts/backup-test.sh` exit-code != 0
+  liefert (mindestens 1 der 10 Test-Stufen ist FAIL). Embed enthält die letzten
+  40 Log-Zeilen + Pfad zum vollen Log.
+- **Keine Success-Alerts** — monatlich grün ist langweilig. Falls gewünscht:
+  `BACKUP_TEST_NOTIFY_ON_SUCCESS=1` in `~/.config/shadowops-watchdog.env`.
+
+## Wartung / Inspektion
+
+```bash
+# Beide Timer auf einen Blick
+systemctl --user list-timers shadowops-watchdog.timer shadowops-backup-test.timer
+
+# Letzten 50 Watchdog-Läufe
+journalctl --user -u shadowops-watchdog.service --no-pager -n 50
+
+# Backup-Test-Logs (lokal)
+ls -la ~/.local/state/shadowops-bot/backup-test/
+
+# Manueller Sofort-Run (Backup-Test — Achtung: dauert ~5-20 Min)
+systemctl --user start shadowops-backup-test.service
+journalctl --user -u shadowops-backup-test.service -f
+```
+
+## Pause/Disable
+
+```bash
+# Watchdog kurz aussetzen (z.B. während geplantem Wartungs-Restart)
+systemctl --user stop shadowops-watchdog.timer
+# … nach der Wartung wieder an:
+systemctl --user start shadowops-watchdog.timer
+
+# Permanent disable (nicht empfohlen)
+systemctl --user disable --now shadowops-watchdog.timer
+```

--- a/deploy/shadowops-backup-test.service
+++ b/deploy/shadowops-backup-test.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ShadowOps Backup-Restore-Test (monatlich)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+# Webhook-URL aus EnvironmentFile (gleiche Datei wie Bot-Watchdog)
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/backup-restore-test.sh
+# Timeout 30min — backup-test prüft S3, WAL-G, mehrere DBs
+TimeoutStartSec=1800
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/shadowops-backup-test.timer
+++ b/deploy/shadowops-backup-test.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=ShadowOps Backup-Restore-Test Timer (1. jedes Monats)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Tag jedes Monats, 04:23 Uhr lokal (off-peak, Jitter 30min)
+OnCalendar=*-*-01 04:23:00
+RandomizedDelaySec=30min
+AccuracySec=5min
+# Bei verpasstem Lauf (Server war off) trotzdem nachholen
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/shadowops-watchdog.env.example
+++ b/deploy/shadowops-watchdog.env.example
@@ -1,0 +1,18 @@
+# ShadowOps Watchdog — Konfigurations-Template
+#
+# Setup:
+#   1. In Discord: Server-Einstellungen → Integrationen → Webhooks → "Neuer Webhook"
+#      Name: "ShadowOps Watchdog", Channel: dein critical-Channel
+#   2. URL kopieren und HIER eintragen (NICHT in Git committen!)
+#   3. Datei kopieren nach ~/.config/shadowops-watchdog.env (chmod 600)
+#   4. systemd reloaden: systemctl --user daemon-reload
+#
+# Datei wird vom systemd-Service als EnvironmentFile gelesen (Schluessel=Wert).
+
+# === PFLICHT — sonst keine Alerts ===
+SHADOWOPS_WATCHDOG_WEBHOOK=https://discord.com/api/webhooks/CHANNEL_ID/WEBHOOK_TOKEN
+
+# === OPTIONAL — Defaults sind sinnvoll ===
+# SHADOWOPS_HEALTH_URL=http://127.0.0.1:8766/health
+# SHADOWOPS_WATCHDOG_TIMEOUT=10
+# SHADOWOPS_WATCHDOG_STATE=/home/cmdshadow/shadowops-bot/data/watchdog_state.json

--- a/deploy/shadowops-watchdog.service
+++ b/deploy/shadowops-watchdog.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShadowOps Bot Watchdog — Health-Check + Discord-Alert
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+# Webhook-URL aus EnvironmentFile (siehe deploy/shadowops-watchdog.env.example)
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/bot-watchdog.sh
+# Bei Fail: weiter — Timer feuert wieder. Wir wollen NIE in einen failed-State
+# der die nächsten Läufe blockiert.
+SuccessExitStatus=0 1
+# Kein Restart — der Timer ist die Schedule, nicht systemd-Restart.
+StandardOutput=journal
+StandardError=journal

--- a/deploy/shadowops-watchdog.timer
+++ b/deploy/shadowops-watchdog.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=ShadowOps Bot Watchdog Timer — alle 5 Minuten
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 2 Minuten nach Boot, danach alle 5 Minuten
+OnBootSec=2min
+OnUnitActiveSec=5min
+# Etwas Jitter damit alle Timer auf dem Server nicht gleichzeitig feuern
+RandomizedDelaySec=30s
+AccuracySec=15s
+# Bei systemd-Restart nicht das Schedule neu starten
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/scripts/backup-restore-test.sh
+++ b/scripts/backup-restore-test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# backup-restore-test.sh — Monatlicher Wrapper um ~/ZERODOX/scripts/backup-test.sh.
+#
+# Ruft das bestehende End-to-End-Backup-Testskript auf und alerted via
+# Discord-Webhook bei Failure. Das eigentliche Backup-System bleibt
+# unverändert (~/ZERODOX/scripts/backup-test.sh ist die Quelle der Wahrheit).
+#
+# Solo-Dev-Wert: erfährt monatlich automatisch, ob WAL-G, S3-Sync und
+# Secrets-Backup tatsächlich funktionieren — bevor ein echter Disaster
+# zeigt, dass die Restore-Kette seit Monaten kaputt ist.
+#
+# Konfiguration:
+#   SHADOWOPS_WATCHDOG_WEBHOOK — Discord-Webhook (gleicher wie Bot-Watchdog)
+#   BACKUP_TEST_LOG_DIR        — wo Output gespeichert wird (Default: ~/.local/state/shadowops-bot/backup-test/)
+#
+# Exit-Codes:
+#   0 = Backup-Test erfolgreich (oder Alert wegen Fail erfolgreich gesendet)
+#   1 = Backup-Test failed UND Webhook-Call fehlgeschlagen
+#   2 = Konfigurationsfehler
+
+set -euo pipefail
+
+# ─── Konfiguration ─────────────────────────────────────────────────────
+BACKUP_TEST_SCRIPT="${BACKUP_TEST_SCRIPT:-/home/cmdshadow/ZERODOX/scripts/backup-test.sh}"
+WEBHOOK_URL="${SHADOWOPS_WATCHDOG_WEBHOOK:-}"
+LOG_DIR="${BACKUP_TEST_LOG_DIR:-/home/cmdshadow/.local/state/shadowops-bot/backup-test}"
+HOSTNAME_SHORT="$(hostname -s 2>/dev/null || echo vServer)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TS_LOCAL="$(date '+%Y-%m-%d %H:%M:%S')"
+
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/$(date +%Y-%m-%d)_backup-test.log"
+
+# ─── Discord-Alert ─────────────────────────────────────────────────────
+send_discord_alert() {
+    local title="$1"
+    local description="$2"
+    local color="$3"
+
+    if [[ -z "$WEBHOOK_URL" ]]; then
+        echo "[backup-test] WARN: SHADOWOPS_WATCHDOG_WEBHOOK nicht gesetzt — kein Discord-Alert"
+        return 1
+    fi
+
+    # Description auf 1800 Chars cappen (Discord-Embed-Limit ~4096, aber wir wollen lesbar bleiben)
+    local desc_short
+    desc_short=$(echo "$description" | head -c 1800)
+
+    local payload
+    payload=$(cat <<EOF
+{
+  "username": "ShadowOps Backup-Monitor",
+  "embeds": [{
+    "title": "$title",
+    "description": "$desc_short",
+    "color": $color,
+    "footer": {"text": "Host: $HOSTNAME_SHORT — $TS — Log: $LOG_FILE"}
+  }]
+}
+EOF
+)
+
+    local http_code
+    http_code=$(curl -s -o /tmp/backup_alert_resp.json -w "%{http_code}" \
+        --max-time 15 \
+        -H "Content-Type: application/json" \
+        -X POST -d "$payload" \
+        "$WEBHOOK_URL" || echo "000")
+
+    if [[ "$http_code" =~ ^2 ]]; then
+        echo "[backup-test] Discord-Alert gesendet (HTTP $http_code)"
+        return 0
+    else
+        echo "[backup-test] ERROR: Discord-Webhook fehlgeschlagen (HTTP $http_code)"
+        return 1
+    fi
+}
+
+# ─── Main ──────────────────────────────────────────────────────────────
+if [[ ! -x "$BACKUP_TEST_SCRIPT" ]]; then
+    echo "[backup-test] FEHLER: $BACKUP_TEST_SCRIPT nicht gefunden oder nicht ausfuehrbar."
+    exit 2
+fi
+
+echo "[backup-test] Starte $BACKUP_TEST_SCRIPT — Log: $LOG_FILE"
+echo "=== ShadowOps Backup-Restore-Test $TS_LOCAL ===" > "$LOG_FILE"
+
+# Backup-Test laufen lassen, Output in Log + stdout. ANSI-Escapes
+# rausstrippen, damit Discord-Embed lesbar bleibt.
+set +e
+"$BACKUP_TEST_SCRIPT" 2>&1 | tee -a "$LOG_FILE"
+test_exit=${PIPESTATUS[0]}
+set -e
+
+# Letzten Zusammenfassungs-Block aus dem Log extrahieren (Ergebnis-Zeile)
+result_summary=$(grep -E "Ergebnis:|ACHTUNG:|Hinweis:|Alle Tests bestanden" "$LOG_FILE" \
+    | tail -3 \
+    | sed -e 's/\x1b\[[0-9;]*m//g')
+
+if [[ "$test_exit" -eq 0 ]]; then
+    # Success: nur loggen, kein Discord-Spam (monatlich grün ist langweilig)
+    echo "[backup-test] OK — Backup-System gesund"
+    # Optional: kurze "alles ok" Bestaetigung — abschaltbar via Env-Var
+    if [[ "${BACKUP_TEST_NOTIFY_ON_SUCCESS:-0}" == "1" ]]; then
+        send_discord_alert \
+            "✅ Backup-Test OK" \
+            "Monatlicher Backup-Restore-Test bestanden:\n\`\`\`\n${result_summary}\n\`\`\`" \
+            3066993 || true
+    fi
+    exit 0
+fi
+
+# Failure: IMMER alerten
+echo "[backup-test] FAIL — Backup-Test exited mit $test_exit"
+
+# Letzte 40 Log-Zeilen für Context im Alert
+log_tail=$(tail -40 "$LOG_FILE" | sed -e 's/\x1b\[[0-9;]*m//g')
+
+if send_discord_alert \
+    "🔴 Backup-Test FAILED" \
+    "**$result_summary**
+
+Monatlicher Backup-Restore-Test ist fehlgeschlagen (exit=$test_exit).
+
+Tail vom Log:
+\`\`\`
+${log_tail}
+\`\`\`
+
+Komplettes Log: \`$LOG_FILE\`" \
+    15158332
+then
+    exit 0
+else
+    exit 1
+fi

--- a/scripts/bot-watchdog.sh
+++ b/scripts/bot-watchdog.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# bot-watchdog.sh — Externer Watchdog für den ShadowOps Bot.
+#
+# Pingt den Health-Endpoint (Default: http://127.0.0.1:8766/health) und
+# alertiert via Discord-Webhook wenn:
+#   - HTTP-Status != 200
+#   - JSON-Feld bot_ready != true
+#   - Curl-Timeout
+#
+# Solo-Dev-Kontext: Der Bot war am 14.-17.05.2026 für 3 Tage down, ohne
+# dass es bemerkt wurde (Issue #249-Cleanup). Dieser Watchdog schließt
+# die Lücke — direkter Discord-Webhook (nicht über den Bot selbst!), damit
+# Alerts auch bei totem Bot ankommen.
+#
+# State-File verhindert Alert-Spam: einmal "down" → einmal Alert, danach
+# nichts bis "recovery".
+#
+# Konfiguration: Env-Var SHADOWOPS_WATCHDOG_WEBHOOK muss gesetzt sein
+# (Discord-Webhook-URL). Wenn leer/unset: Script läuft trotzdem, loggt
+# nur lokal — kein Discord-Alert.
+#
+# Exit-Codes:
+#   0 = Bot healthy oder Alert erfolgreich gesendet
+#   1 = Bot down UND Webhook-Call fehlgeschlagen
+#   2 = Konfigurationsfehler
+
+set -euo pipefail
+
+# ─── Konfiguration ─────────────────────────────────────────────────────
+HEALTH_URL="${SHADOWOPS_HEALTH_URL:-http://127.0.0.1:8766/health}"
+WEBHOOK_URL="${SHADOWOPS_WATCHDOG_WEBHOOK:-}"
+STATE_FILE="${SHADOWOPS_WATCHDOG_STATE:-/home/cmdshadow/shadowops-bot/data/watchdog_state.json}"
+CURL_TIMEOUT_S="${SHADOWOPS_WATCHDOG_TIMEOUT:-10}"
+HOSTNAME_SHORT="$(hostname -s 2>/dev/null || echo vServer)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+
+# ─── State-Helper ──────────────────────────────────────────────────────
+# State-Format (JSON): {"last_status": "up"|"down", "last_alert_at": "ISO", "consecutive_failures": N}
+read_state() {
+    if [[ -f "$STATE_FILE" ]]; then
+        cat "$STATE_FILE"
+    else
+        echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}'
+    fi
+}
+
+write_state() {
+    local status="$1"
+    local consecutive="$2"
+    local alert_ts="$3"
+    cat > "$STATE_FILE" <<EOF
+{"last_status":"$status","last_alert_at":"$alert_ts","consecutive_failures":$consecutive,"updated_at":"$TS"}
+EOF
+}
+
+# ─── Discord-Alert ─────────────────────────────────────────────────────
+send_discord_alert() {
+    local title="$1"
+    local description="$2"
+    local color="$3"  # 0xRRGGBB als Decimal
+
+    if [[ -z "$WEBHOOK_URL" ]]; then
+        echo "[watchdog] WARN: SHADOWOPS_WATCHDOG_WEBHOOK nicht gesetzt — kein Discord-Alert"
+        return 1
+    fi
+
+    local payload
+    payload=$(cat <<EOF
+{
+  "username": "ShadowOps Watchdog",
+  "embeds": [{
+    "title": "$title",
+    "description": "$description",
+    "color": $color,
+    "footer": {"text": "Host: $HOSTNAME_SHORT — $TS"}
+  }]
+}
+EOF
+)
+
+    local http_code
+    http_code=$(curl -s -o /tmp/watchdog_resp.json -w "%{http_code}" \
+        --max-time 15 \
+        -H "Content-Type: application/json" \
+        -X POST -d "$payload" \
+        "$WEBHOOK_URL" || echo "000")
+
+    if [[ "$http_code" =~ ^2 ]]; then
+        echo "[watchdog] Discord-Alert gesendet (HTTP $http_code)"
+        return 0
+    else
+        echo "[watchdog] ERROR: Discord-Webhook fehlgeschlagen (HTTP $http_code)"
+        cat /tmp/watchdog_resp.json 2>/dev/null | head -2
+        return 1
+    fi
+}
+
+# ─── Health-Check ──────────────────────────────────────────────────────
+check_health() {
+    local resp http_code bot_ready
+
+    # Curl mit Timeout, fängt Connection-Refused und Hangs ab
+    if ! resp=$(curl -s -m "$CURL_TIMEOUT_S" -w "\n%{http_code}" "$HEALTH_URL" 2>/dev/null); then
+        echo "DOWN:curl_failed"
+        return 1
+    fi
+
+    http_code=$(echo "$resp" | tail -n1)
+    body=$(echo "$resp" | head -n -1)
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "DOWN:http_$http_code"
+        return 1
+    fi
+
+    # JSON-Feld bot_ready prüfen — wenn Bot zwar HTTP-up aber discord-disconnected,
+    # gilt es als down. Tolerant: fehlt das Feld → trotzdem up (legacy-Format).
+    bot_ready=$(echo "$body" | grep -oE '"bot_ready"\s*:\s*(true|false)' | grep -oE '(true|false)' || echo "true")
+    if [[ "$bot_ready" != "true" ]]; then
+        echo "DOWN:bot_not_ready"
+        return 1
+    fi
+
+    echo "UP"
+    return 0
+}
+
+# ─── Main ──────────────────────────────────────────────────────────────
+main() {
+    local state last_status consecutive
+    state=$(read_state)
+    last_status=$(echo "$state" | grep -oE '"last_status":"[^"]*"' | cut -d'"' -f4)
+    consecutive=$(echo "$state" | grep -oE '"consecutive_failures":[0-9]+' | cut -d':' -f2)
+    last_status="${last_status:-up}"
+    consecutive="${consecutive:-0}"
+
+    # `|| true` ist nötig: check_health gibt bewusst non-zero zurück bei DOWN.
+    # Ohne || true würde `set -e` das Script abbrechen bevor wir den Status parsen.
+    local result
+    result=$(check_health || true)
+    local status="${result%%:*}"
+    local reason="${result#*:}"
+
+    if [[ "$status" == "UP" ]]; then
+        # Recovery-Pfad: alert nur wenn vorher down. `|| true` weil Webhook-Fehler
+        # nicht den State-Write blockieren darf (Idempotenz vor Cosmetic).
+        if [[ "$last_status" == "down" ]]; then
+            send_discord_alert \
+                "✅ ShadowOps Bot wieder UP" \
+                "Bot ist wieder erreichbar nach $consecutive Fehlversuch(en).\n\`$HEALTH_URL\`" \
+                3066993 || true  # grün (0x2ECC71)
+        fi
+        write_state "up" 0 ""
+        echo "[watchdog] OK — Bot healthy"
+        exit 0
+    fi
+
+    # DOWN-Pfad
+    consecutive=$((consecutive + 1))
+
+    # Erst ab 2 konsekutiven Failures alerten — vermeidet false-positives bei
+    # transienten Netzwerk-Issues oder Bot-Restart-Phasen.
+    if [[ "$consecutive" -ge 2 && "$last_status" != "down" ]]; then
+        if send_discord_alert \
+            "🔴 ShadowOps Bot DOWN" \
+            "Health-Check fehlgeschlagen ($consecutive konsekutive Failures): \`$reason\`\nEndpoint: \`$HEALTH_URL\`\n\nSofort prüfen: \`systemctl status shadowops-bot\` und \`journalctl -u shadowops-bot -n 50\`" \
+            15158332  # rot (0xE74C3C)
+        then
+            write_state "down" "$consecutive" "$TS"
+            echo "[watchdog] ALERT gesendet — Bot down ($reason)"
+            exit 0
+        else
+            write_state "down" "$consecutive" ""
+            echo "[watchdog] FAIL — Bot down ($reason) UND Webhook fehlgeschlagen"
+            exit 1
+        fi
+    fi
+
+    # Noch nicht im Alert-Threshold ODER bereits gealertet
+    write_state "$([[ $consecutive -ge 2 ]] && echo down || echo up)" "$consecutive" "$([[ "$last_status" == "down" ]] && echo "$TS" || echo "")"
+    echo "[watchdog] Bot down ($reason), consecutive=$consecutive, last_status=$last_status — kein neuer Alert"
+    exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Schließt die einzige Solo-Dev-relevante Lücke nach dem heutigen Cleanup: **3 Tage Bot-Down unbemerkt**.

### Was rein kommt

1. **Bot-Watchdog** — `scripts/bot-watchdog.sh` + systemd-Timer alle 5 Min. Pingt Health-Endpoint, alert via Discord-Webhook **direkt** (nicht über den Bot — sonst Henne/Ei). Anti-Spam-State-File, Threshold 2 konsekutive Failures.
2. **Monatlicher Backup-Restore-Test** — `scripts/backup-restore-test.sh` wrapt `~/ZERODOX/scripts/backup-test.sh`. Alert NUR bei Failure (Stille = OK).
3. **MONITORING_SETUP.md** — Schritt-für-Schritt Anleitung: Discord-Webhook erstellen, `~/.config/shadowops-watchdog.env` anlegen.

### Was bewusst NICHT drin ist

- Kein Webhook im Repo (Template `*.env.example` ohne echte URL)
- Keine TOCTOU-Race-Condition-Fixes (Enterprise-Overkill für Solo-Dev)
- Keine Multi-Channel-Alerts (Discord-Webhook reicht — wenn der down ist, ist Discord selbst kaputt)

### Setup nach Merge (einmalig)

```bash
# 1. Discord-Webhook erstellen (Server-Einstellungen → Integrationen → Webhooks)
# 2. Config anlegen
cp deploy/shadowops-watchdog.env.example ~/.config/shadowops-watchdog.env
nano ~/.config/shadowops-watchdog.env     # → Webhook-URL eintragen
chmod 600 ~/.config/shadowops-watchdog.env
# 3. Reload (Timer + Service sind bereits installiert)
systemctl --user daemon-reload
systemctl --user restart shadowops-watchdog.timer
# 4. Test-Alert
SHADOWOPS_HEALTH_URL="http://127.0.0.1:9999/health" \
  ~/shadowops-bot/scripts/bot-watchdog.sh
```

## Test plan

- [x] Watchdog UP-Path: bot healthy → exit 0, kein Alert
- [x] Watchdog DOWN-Path 1×: consecutive=1, no alert (under threshold)
- [x] Watchdog DOWN-Path 2×: would alert (WARN: kein webhook → safe)
- [x] Recovery: state→up, would alert "wieder UP"
- [x] State-File-Persistenz über Runs hinweg
- [x] Backup-Test-Wrapper startet das richtige Script (smoke)
- [x] systemd-Timer beide aktiv (`systemctl --user list-timers`)
- [ ] **Nach Merge:** Webhook konfigurieren → echter Test mit kurzem Bot-Stop → Discord-Alert kommt an
- [ ] **Nach 1. Juni:** erster Backup-Test läuft automatisch, prüfen ob Log in `~/.local/state/shadowops-bot/backup-test/` landet

🤖 Generated with [Claude Code](https://claude.com/claude-code)