### PR TITLE
feat(monitoring): Watchdogs auch für ZERODOX und GuildScout

### DIFF
--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -1,26 +1,36 @@
 # ShadowOps Monitoring — Setup-Anleitung
 
-> Externer Watchdog für den Bot + monatlicher Backup-Restore-Test.
-> Beide alerten via Discord-Webhook **direkt** (nicht über den Bot selbst),
-> damit auch ein toter Bot Alarme schlagen kann.
+> Externe Watchdogs für ShadowOps-Bot, ZERODOX und GuildScout + monatlicher
+> Backup-Restore-Test. Alle Alerts gehen direkt via Discord-Webhook (nicht
+> über den shadowops-bot selbst), damit auch ein toter Bot Alarme schlagen kann.
 
 ## Architektur
 
 ```
-                ┌──────────────────────────┐
-                │ Discord (critical-Channel)│
-                └────────────▲─────────────┘
-                             │ Webhook (POST)
-                             │
-   ┌─────────────────┐       │       ┌──────────────────────┐
-   │ Bot-Watchdog    │───────┘       │ Backup-Restore-Test  │
-   │ alle 5 Minuten  │               │ am 1. jedes Monats   │
-   │ (systemd-Timer) │               │ (systemd-Timer)      │
-   └────────┬────────┘               └──────────────────────┘
-            │ pingt
-            ▼
-   http://127.0.0.1:8766/health
+                              ┌──────────────────────────┐
+                              │ Discord (critical-Channel)│
+                              └────────────▲─────────────┘
+                                           │ Webhook (POST)
+                                           │
+       ┌────────────────────┬──────────────┴──────────────┬──────────────────┐
+       │                    │                             │                  │
+ ┌─────┴──────┐    ┌────────┴────────┐         ┌──────────┴────────┐ ┌───────┴──────┐
+ │ shadowops- │    │ zerodox-        │         │ guildscout-       │ │ backup-test  │
+ │ watchdog   │    │ watchdog        │         │ watchdog          │ │ monatlich    │
+ │ alle 5 min │    │ alle 5 min      │         │ alle 5 min        │ │ 1. d. Monats │
+ └─────┬──────┘    └────────┬────────┘         └──────────┬────────┘ └──────────────┘
+       │ pingt              │ pingt                       │ pingt
+       ▼                    ▼                             ▼
+ :8766/health    https://zerodox.de/api/health    localhost:8765/health
 ```
+
+Alle drei Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
+Script, parametrisiert via Env-Vars (`WATCHDOG_SERVICE_NAME`, `WATCHDOG_HEALTH_URL`).
+Das ursprüngliche `scripts/bot-watchdog.sh` bleibt als Backward-Compat-Variante
+für den shadowops-bot Watchdog erhalten.
+
+State-Files sind pro Service getrennt (`data/watchdog_state_<service>.json`),
+damit Failure-Counter und Alert-Status sich nicht beeinflussen.
 
 ## Erst-Einrichtung (einmalig)
 
@@ -52,6 +62,8 @@ chmod 600 ~/.config/shadowops-watchdog.env
 ```bash
 systemctl --user daemon-reload
 systemctl --user restart shadowops-watchdog.timer
+systemctl --user restart zerodox-watchdog.timer
+systemctl --user restart guildscout-watchdog.timer
 ```
 
 ### 4. Funktionstest
@@ -72,13 +84,22 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 
 ## Was wird wann alertiert?
 
-### Bot-Watchdog (alle 5 Minuten)
+### Watchdog-Familie (jeder alle 5 Minuten, gestaffelt)
 
-- **🔴 Bot DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
-  Verhindert false-positives bei Bot-Restart oder kurzem Netzwerk-Hiccup.
-- **✅ Bot wieder UP** — sobald der Bot nach einem Down-Alert wieder antwortet.
-- **Keine Wiederholungs-Alerts** — wenn der Bot Stunden down ist, kommt nur EIN
-  Initial-Alert, kein Spam.
+| Service | Endpoint | Bot-Ready-Check |
+|---|---|---|
+| `shadowops-bot` | http://127.0.0.1:8766/health | ja (`bot_ready=true` Pflicht) |
+| `zerodox` | https://zerodox.de/api/health | nein (HTTP 200 reicht) |
+| `guildscout` | http://localhost:8765/health | nein (HTTP 200 reicht) |
+
+Pro Service:
+- **🔴 \<service\> DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
+- **✅ \<service\> wieder UP** — sobald der Service nach einem Down-Alert wieder antwortet.
+- **Keine Wiederholungs-Alerts** — Stunden-langes Down führt zu EINEM Alert.
+- **State pro Service getrennt** — wenn shadowops-bot down ist, beeinflusst das nicht den ZERODOX-Counter.
+
+Die ZERODOX-URL `https://zerodox.de/api/health` läuft über das Internet → testet
+DNS-Auflösung + Traefik-Routing + TLS-Zertifikat + App-Health in einem.
 
 ### Backup-Restore-Test (1. jedes Monats, 04:50 lokal)
 
@@ -91,11 +112,20 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 ## Wartung / Inspektion
 
 ```bash
-# Beide Timer auf einen Blick
-systemctl --user list-timers shadowops-watchdog.timer shadowops-backup-test.timer
+# Alle 4 Timer auf einen Blick
+systemctl --user list-timers \
+  shadowops-watchdog.timer zerodox-watchdog.timer guildscout-watchdog.timer \
+  shadowops-backup-test.timer
 
-# Letzten 50 Watchdog-Läufe
+# Letzten 50 Läufe pro Service
 journalctl --user -u shadowops-watchdog.service --no-pager -n 50
+journalctl --user -u zerodox-watchdog.service --no-pager -n 50
+journalctl --user -u guildscout-watchdog.service --no-pager -n 50
+
+# State-Files pro Service inspizieren
+cat ~/shadowops-bot/data/watchdog_state.json
+cat ~/shadowops-bot/data/watchdog_state_zerodox.json
+cat ~/shadowops-bot/data/watchdog_state_guildscout.json
 
 # Backup-Test-Logs (lokal)
 ls -la ~/.local/state/shadowops-bot/backup-test/

--- a/deploy/guildscout-watchdog.service
+++ b/deploy/guildscout-watchdog.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=GuildScout Health Watchdog — Health-Check + Discord-Alert
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=guildscout
+Environment=WATCHDOG_HEALTH_URL=http://localhost:8765/health
+Environment=WATCHDOG_REQUIRE_BOT_READY=0
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/guildscout-watchdog.timer
+++ b/deploy/guildscout-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=GuildScout Watchdog Timer — alle 5 Minuten (mit Jitter)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 4 Minuten nach Boot (versetzt zu shadowops:2 und zerodox:3)
+OnBootSec=4min
+OnUnitActiveSec=5min
+RandomizedDelaySec=45s
+AccuracySec=15s
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/deploy/zerodox-watchdog.service
+++ b/deploy/zerodox-watchdog.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=ZERODOX Health Watchdog — externer Health-Check + Discord-Alert
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=zerodox
+Environment=WATCHDOG_HEALTH_URL=https://zerodox.de/api/health
+Environment=WATCHDOG_REQUIRE_BOT_READY=0
+# Webhook-URL kommt aus dem EnvironmentFile (gleicher wie shadowops-watchdog).
+# Falls dort als SHADOWOPS_WATCHDOG_WEBHOOK gesetzt: Backward-Compat-Fallback
+# im Script greift automatisch.
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/zerodox-watchdog.timer
+++ b/deploy/zerodox-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=ZERODOX Watchdog Timer — alle 5 Minuten (mit Jitter)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 3 Minuten nach Boot (versetzt zum shadowops-Watchdog auf 2min)
+OnBootSec=3min
+OnUnitActiveSec=5min
+RandomizedDelaySec=45s
+AccuracySec=15s
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# service-watchdog.sh — Generischer Health-Endpoint-Watchdog für beliebige
+# Services. Postet bei Down/Recovery via Discord-Webhook **direkt** — kein
+# Bot-Indirektion, damit auch ein toter Service alertieren kann.
+#
+# Defaults sind auf den ShadowOps-Bot ausgelegt; jedes andere Service braucht
+# nur die Env-Vars überschreiben (siehe deploy/zerodox-watchdog.service als
+# Beispiel).
+#
+# Erweiterung von bot-watchdog.sh (PR #253) für ZERODOX und GuildScout —
+# damit auch deren Ausfälle direkt alertieren, NICHT nur via shadowops-bot
+# project_monitor (das selbst tot sein könnte).
+#
+# Konfiguration via Env-Vars (mit Defaults):
+#   WATCHDOG_SERVICE_NAME — Display-Name für Discord-Embed (default "shadowops-bot")
+#   WATCHDOG_HEALTH_URL   — Health-Endpoint (default http://127.0.0.1:8766/health)
+#   WATCHDOG_STATE_FILE   — State-Persistenz pro Service
+#                           (default data/watchdog_state_<service>.json)
+#   WATCHDOG_WEBHOOK      — Discord-Webhook-URL (Pflicht für Alert)
+#   WATCHDOG_TIMEOUT_S    — Curl-Timeout (default 10)
+#   WATCHDOG_REQUIRE_BOT_READY — wenn "1": prüfe zusätzlich JSON-Feld
+#                                bot_ready=true (Default 1 für shadowops, sonst 0)
+#
+# Backward-Compat: Falls SHADOWOPS_HEALTH_URL/SHADOWOPS_WATCHDOG_WEBHOOK/
+# SHADOWOPS_WATCHDOG_STATE/SHADOWOPS_WATCHDOG_TIMEOUT gesetzt sind, werden
+# diese als Fallback genutzt (alte systemd-Units brechen nicht).
+#
+# Exit-Codes:
+#   0 = Service healthy oder Alert erfolgreich
+#   1 = Service down UND Webhook-Call fehlgeschlagen
+#   2 = Konfigurationsfehler
+
+set -euo pipefail
+
+# ─── Konfiguration mit Backward-Compat ─────────────────────────────────
+SERVICE_NAME="${WATCHDOG_SERVICE_NAME:-shadowops-bot}"
+HEALTH_URL="${WATCHDOG_HEALTH_URL:-${SHADOWOPS_HEALTH_URL:-http://127.0.0.1:8766/health}}"
+WEBHOOK_URL="${WATCHDOG_WEBHOOK:-${SHADOWOPS_WATCHDOG_WEBHOOK:-}}"
+CURL_TIMEOUT_S="${WATCHDOG_TIMEOUT_S:-${SHADOWOPS_WATCHDOG_TIMEOUT:-10}}"
+# REQUIRE_BOT_READY: shadowops-bot liefert bot_ready im Health-JSON.
+# Generische Services (ZERODOX, GuildScout) haben das nicht — Default OFF
+# für non-shadowops Services. Explizit setzbar via Env.
+if [[ -z "${WATCHDOG_REQUIRE_BOT_READY:-}" ]]; then
+    if [[ "$SERVICE_NAME" == "shadowops-bot" ]]; then
+        WATCHDOG_REQUIRE_BOT_READY=1
+    else
+        WATCHDOG_REQUIRE_BOT_READY=0
+    fi
+fi
+
+# State-File: pro Service eigene Datei (mehrere Services laufen parallel)
+SERVICE_SLUG="$(echo "$SERVICE_NAME" | tr 'A-Z ' 'a-z_' | tr -cd 'a-z0-9_-')"
+DEFAULT_STATE="/home/cmdshadow/shadowops-bot/data/watchdog_state_${SERVICE_SLUG}.json"
+# Spezialfall: alte Pfad-Konvention für shadowops-bot weiterführen
+if [[ "$SERVICE_NAME" == "shadowops-bot" && -f "/home/cmdshadow/shadowops-bot/data/watchdog_state.json" ]]; then
+    DEFAULT_STATE="/home/cmdshadow/shadowops-bot/data/watchdog_state.json"
+fi
+STATE_FILE="${WATCHDOG_STATE_FILE:-${SHADOWOPS_WATCHDOG_STATE:-$DEFAULT_STATE}}"
+
+HOSTNAME_SHORT="$(hostname -s 2>/dev/null || echo vServer)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+
+# ─── State-Helper ──────────────────────────────────────────────────────
+read_state() {
+    if [[ -f "$STATE_FILE" ]]; then
+        cat "$STATE_FILE"
+    else
+        echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}'
+    fi
+}
+
+write_state() {
+    local status="$1"
+    local consecutive="$2"
+    local alert_ts="$3"
+    cat > "$STATE_FILE" <<EOF
+{"last_status":"$status","last_alert_at":"$alert_ts","consecutive_failures":$consecutive,"updated_at":"$TS","service":"$SERVICE_NAME"}
+EOF
+}
+
+# ─── Discord-Alert ─────────────────────────────────────────────────────
+send_discord_alert() {
+    local title="$1"
+    local description="$2"
+    local color="$3"
+
+    if [[ -z "$WEBHOOK_URL" ]]; then
+        echo "[watchdog:$SERVICE_NAME] WARN: WATCHDOG_WEBHOOK nicht gesetzt — kein Discord-Alert"
+        return 1
+    fi
+
+    local payload
+    payload=$(cat <<EOF
+{
+  "username": "ShadowOps Watchdog",
+  "embeds": [{
+    "title": "$title",
+    "description": "$description",
+    "color": $color,
+    "footer": {"text": "Service: $SERVICE_NAME — Host: $HOSTNAME_SHORT — $TS"}
+  }]
+}
+EOF
+)
+
+    local http_code
+    http_code=$(curl -s -o /tmp/watchdog_resp.json -w "%{http_code}" \
+        --max-time 15 \
+        -H "Content-Type: application/json" \
+        -X POST -d "$payload" \
+        "$WEBHOOK_URL" || echo "000")
+
+    if [[ "$http_code" =~ ^2 ]]; then
+        echo "[watchdog:$SERVICE_NAME] Discord-Alert gesendet (HTTP $http_code)"
+        return 0
+    else
+        echo "[watchdog:$SERVICE_NAME] ERROR: Discord-Webhook fehlgeschlagen (HTTP $http_code)"
+        cat /tmp/watchdog_resp.json 2>/dev/null | head -2
+        return 1
+    fi
+}
+
+# ─── Health-Check ──────────────────────────────────────────────────────
+check_health() {
+    local resp http_code body
+
+    if ! resp=$(curl -s -m "$CURL_TIMEOUT_S" -w "\n%{http_code}" "$HEALTH_URL" 2>/dev/null); then
+        echo "DOWN:curl_failed"
+        return 1
+    fi
+
+    http_code=$(echo "$resp" | tail -n1)
+    body=$(echo "$resp" | head -n -1)
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "DOWN:http_$http_code"
+        return 1
+    fi
+
+    # Optional: bot_ready-Feld checken (nur wenn explizit gewünscht)
+    if [[ "$WATCHDOG_REQUIRE_BOT_READY" == "1" ]]; then
+        local bot_ready
+        bot_ready=$(echo "$body" | grep -oE '"bot_ready"\s*:\s*(true|false)' | grep -oE '(true|false)' || echo "true")
+        if [[ "$bot_ready" != "true" ]]; then
+            echo "DOWN:bot_not_ready"
+            return 1
+        fi
+    fi
+
+    echo "UP"
+    return 0
+}
+
+# ─── Main ──────────────────────────────────────────────────────────────
+main() {
+    local state last_status consecutive
+    state=$(read_state)
+    last_status=$(echo "$state" | grep -oE '"last_status":"[^"]*"' | cut -d'"' -f4)
+    consecutive=$(echo "$state" | grep -oE '"consecutive_failures":[0-9]+' | cut -d':' -f2)
+    last_status="${last_status:-up}"
+    consecutive="${consecutive:-0}"
+
+    local result
+    result=$(check_health || true)
+    local status="${result%%:*}"
+    local reason="${result#*:}"
+
+    if [[ "$status" == "UP" ]]; then
+        if [[ "$last_status" == "down" ]]; then
+            send_discord_alert \
+                "✅ $SERVICE_NAME wieder UP" \
+                "Service ist wieder erreichbar nach $consecutive Fehlversuch(en).\n\`$HEALTH_URL\`" \
+                3066993 || true  # grün
+        fi
+        write_state "up" 0 ""
+        echo "[watchdog:$SERVICE_NAME] OK — healthy"
+        exit 0
+    fi
+
+    # DOWN-Pfad
+    consecutive=$((consecutive + 1))
+
+    if [[ "$consecutive" -ge 2 && "$last_status" != "down" ]]; then
+        if send_discord_alert \
+            "🔴 $SERVICE_NAME DOWN" \
+            "Health-Check fehlgeschlagen ($consecutive konsekutive Failures): \`$reason\`\nEndpoint: \`$HEALTH_URL\`\n\nSofort prüfen: Service-Status und Logs." \
+            15158332  # rot
+        then
+            write_state "down" "$consecutive" "$TS"
+            echo "[watchdog:$SERVICE_NAME] ALERT gesendet — down ($reason)"
+            exit 0
+        else
+            write_state "down" "$consecutive" ""
+            echo "[watchdog:$SERVICE_NAME] FAIL — down ($reason) UND Webhook fehlgeschlagen"
+            exit 1
+        fi
+    fi
+
+    write_state "$([[ $consecutive -ge 2 ]] && echo down || echo up)" "$consecutive" "$([[ "$last_status" == "down" ]] && echo "$TS" || echo "")"
+    echo "[watchdog:$SERVICE_NAME] down ($reason), consecutive=$consecutive, last_status=$last_status — kein neuer Alert"
+    exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Erweiterung der Bot-Down-Detection (PR #253) auf ZERODOX und GuildScout. shadowops-bot's project_monitor überwacht beide bereits — aber wenn shadowops-bot selbst down ist, hört das niemand. Diese externen Watchdogs sind unabhängig und alerten direkt via Discord (Defense-in-Depth).

### Was rein kommt

| Watchdog | Endpoint | Was es testet |
|---|---|---|
| shadowops-bot (bereits live) | http://127.0.0.1:8766/health | Bot ready, Health-Server |
| **zerodox** (neu) | https://zerodox.de/api/health | DNS + Traefik + TLS + App in einem (Internet-Route) |
| **guildscout** (neu) | http://localhost:8765/health | API healthy |

### Code-Struktur

- `scripts/service-watchdog.sh` — neue generische Variante (Env-parametrisiert)
- `scripts/bot-watchdog.sh` — bleibt unverändert (Backward-Compat für shadowops-Watchdog)
- 2× neue systemd-Units (`zerodox-watchdog.{service,timer}`, `guildscout-watchdog.{service,timer}`)
- State-Files getrennt pro Service (`data/watchdog_state_<slug>.json`)
- Timer gestaffelt: shadowops-bot 5min-Offset 2, zerodox 3, guildscout 4 (kein Cron-Stau)

### Backward-Compat

`SHADOWOPS_*`-Env-Vars werden weiter akzeptiert. Bestehender shadowops-Watchdog-Service ist unverändert.

## Test plan

- [x] `service-watchdog.sh` mit 3 Service-Konfigurationen lokal getestet → alle 3 "OK — healthy"
- [x] Negativtest mit 404-URL → consecutive=1, kein false-positive Alert
- [x] systemd-Units installiert + getestet (`systemctl --user start zerodox-watchdog.service` → OK in 4s)
- [x] Alle 4 Timer aktiv (`systemctl --user list-timers`)
- [ ] **Nach Merge:** 24h Beobachtung — kein false-positive (jeder Timer feuert 288× pro Tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)