### PR TITLE
feat(monitoring): mayday-sim Watchdog hinzufügen

### DIFF
--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -12,19 +12,20 @@
                               └────────────▲─────────────┘
                                            │ Webhook (POST)
                                            │
-       ┌────────────────────┬──────────────┴──────────────┬──────────────────┐
-       │                    │                             │                  │
- ┌─────┴──────┐    ┌────────┴────────┐         ┌──────────┴────────┐ ┌───────┴──────┐
- │ shadowops- │    │ zerodox-        │         │ guildscout-       │ │ backup-test  │
- │ watchdog   │    │ watchdog        │         │ watchdog          │ │ monatlich    │
- │ alle 5 min │    │ alle 5 min      │         │ alle 5 min        │ │ 1. d. Monats │
- └─────┬──────┘    └────────┬────────┘         └──────────┬────────┘ └──────────────┘
-       │ pingt              │ pingt                       │ pingt
-       ▼                    ▼                             ▼
- :8766/health    https://zerodox.de/api/health    localhost:8765/health
+       ┌──────────────┬───────────────────┬─┴─────────────────┬──────────────┐
+       │              │                   │                   │              │
+ ┌─────┴──────┐ ┌────┴────────┐ ┌─────────┴─────┐ ┌───────────┴────┐ ┌──────┴───────┐
+ │ shadowops- │ │ zerodox-    │ │ guildscout-   │ │ mayday-sim-    │ │ backup-test  │
+ │ watchdog   │ │ watchdog    │ │ watchdog      │ │ watchdog       │ │ monatlich    │
+ │ alle 5 min │ │ alle 5 min  │ │ alle 5 min    │ │ alle 5 min     │ │ 1. d. Monats │
+ └─────┬──────┘ └────┬────────┘ └────────┬──────┘ └──────────┬─────┘ └──────────────┘
+       │ pingt       │ pingt             │ pingt             │ pingt
+       ▼             ▼                   ▼                   ▼
+ :8766/health    https://...   localhost:8765/health   127.0.0.1:3200/api/health
+                /api/health
 ```
 
-Alle drei Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
+Alle vier Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
 Script, parametrisiert via Env-Vars (`WATCHDOG_SERVICE_NAME`, `WATCHDOG_HEALTH_URL`).
 Das ursprüngliche `scripts/bot-watchdog.sh` bleibt als Backward-Compat-Variante
 für den shadowops-bot Watchdog erhalten.
@@ -64,6 +65,7 @@ systemctl --user daemon-reload
 systemctl --user restart shadowops-watchdog.timer
 systemctl --user restart zerodox-watchdog.timer
 systemctl --user restart guildscout-watchdog.timer
+systemctl --user restart mayday-sim-watchdog.timer
 ```
 
 ### 4. Funktionstest
@@ -86,11 +88,12 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 
 ### Watchdog-Familie (jeder alle 5 Minuten, gestaffelt)
 
-| Service | Endpoint | Bot-Ready-Check |
-|---|---|---|
-| `shadowops-bot` | http://127.0.0.1:8766/health | ja (`bot_ready=true` Pflicht) |
-| `zerodox` | https://zerodox.de/api/health | nein (HTTP 200 reicht) |
-| `guildscout` | http://localhost:8765/health | nein (HTTP 200 reicht) |
+| Service | Endpoint | Bot-Ready-Check | Boot-Offset |
+|---|---|---|---|
+| `shadowops-bot` | http://127.0.0.1:8766/health | ja (`bot_ready=true` Pflicht) | 2 min |
+| `zerodox` | https://zerodox.de/api/health | nein (HTTP 200 reicht) | 3 min |
+| `guildscout` | http://localhost:8765/health | nein (HTTP 200 reicht) | 4 min |
+| `mayday-sim` | http://127.0.0.1:3200/api/health | nein (HTTP 200 reicht) | 5 min |
 
 Pro Service:
 - **🔴 \<service\> DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
@@ -112,20 +115,22 @@ DNS-Auflösung + Traefik-Routing + TLS-Zertifikat + App-Health in einem.
 ## Wartung / Inspektion
 
 ```bash
-# Alle 4 Timer auf einen Blick
+# Alle 5 Timer auf einen Blick
 systemctl --user list-timers \
   shadowops-watchdog.timer zerodox-watchdog.timer guildscout-watchdog.timer \
-  shadowops-backup-test.timer
+  mayday-sim-watchdog.timer shadowops-backup-test.timer
 
 # Letzten 50 Läufe pro Service
 journalctl --user -u shadowops-watchdog.service --no-pager -n 50
 journalctl --user -u zerodox-watchdog.service --no-pager -n 50
 journalctl --user -u guildscout-watchdog.service --no-pager -n 50
+journalctl --user -u mayday-sim-watchdog.service --no-pager -n 50
 
 # State-Files pro Service inspizieren
 cat ~/shadowops-bot/data/watchdog_state.json
 cat ~/shadowops-bot/data/watchdog_state_zerodox.json
 cat ~/shadowops-bot/data/watchdog_state_guildscout.json
+cat ~/shadowops-bot/data/watchdog_state_mayday-sim.json
 
 # Backup-Test-Logs (lokal)
 ls -la ~/.local/state/shadowops-bot/backup-test/

--- a/deploy/mayday-sim-watchdog.service
+++ b/deploy/mayday-sim-watchdog.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=mayday-sim Health Watchdog — Container-Stack-Health-Check + Discord-Alert
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=mayday-sim
+Environment=WATCHDOG_HEALTH_URL=http://127.0.0.1:3200/api/health
+Environment=WATCHDOG_REQUIRE_BOT_READY=0
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/mayday-sim-watchdog.timer
+++ b/deploy/mayday-sim-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=mayday-sim Watchdog Timer — alle 5 Minuten (mit Jitter)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 5 Minuten nach Boot (versetzt zu shadowops:2, zerodox:3, guildscout:4)
+OnBootSec=5min
+OnUnitActiveSec=5min
+RandomizedDelaySec=45s
+AccuracySec=15s
+Persistent=false
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Vervollständigt die Watchdog-Familie auf 4 Services. mayday-sim (Docker-Container-Stack `leitstelle-*`) bekommt jetzt einen unabhängigen Health-Check mit Discord-Alert.

| Service | Endpoint | Boot-Offset |
|---|---|---|
| shadowops-bot | :8766/health | 2 min |
| zerodox | https://zerodox.de/api/health | 3 min |
| guildscout | localhost:8765/health | 4 min |
| **mayday-sim** | localhost:3200/api/health | **5 min** |

## Test plan

- [x] service-watchdog.sh manuell mit mayday-sim Service-Name → "OK — healthy"
- [x] Recovery-Alert über echten Webhook getestet → HTTP 204
- [x] Alle 5 Timer aktiv und gestaffelt
- [ ] **Nach Merge:** 24h-Beobachtung, kein false-positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)