### PR TITLE
feat(monitoring): AI Agent Framework Watchdog (systemd-mode) + Doku-Pflege

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -42,3 +42,23 @@ paths:
 | `setup.sh` | Erstinstallation (venv, Dependencies, Config) |
 | `update-config.sh` | Config-Migration bei Updates |
 | `get_bot_invite.py` | Discord Bot Invite-URL generieren |
+| `bot-watchdog.sh` | Watchdog fuer shadowops-bot (Backward-Compat-Wrapper, seit 2026-05-17) |
+| `service-watchdog.sh` | Generischer Watchdog (HTTP- oder systemd-Mode), parametrisiert via Env-Vars |
+| `backup-restore-test.sh` | Wrapper um `~/ZERODOX/scripts/backup-test.sh` mit Discord-Alert |
+
+## Watchdog-Familie (seit 2026-05-17 — Defense-in-Depth gegen shadowops-bot-Down)
+
+5 user-systemd Watchdogs pruefen alle 5 Minuten ihren Service und alerten bei Down/Recovery direkt via Discord-Webhook. **Webhook-URL:** in `~/.config/shadowops-watchdog.env` (chmod 600). **Setup-Anleitung:** `deploy/MONITORING_SETUP.md`.
+
+| Timer | Mode | Endpoint/Units | Boot-Offset |
+|-------|------|----------------|-------------|
+| `shadowops-watchdog.timer` | http | http://127.0.0.1:8766/health (bot_ready=true Pflicht) | 2 min |
+| `zerodox-watchdog.timer` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 3 min |
+| `guildscout-watchdog.timer` | http | http://localhost:8765/health | 4 min |
+| `mayday-sim-watchdog.timer` | http | http://127.0.0.1:3200/api/health | 5 min |
+| `ai-agent-framework-watchdog.timer` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 6 min |
+| `shadowops-backup-test.timer` | — | monatlich 1. d. Monats 04:50, Wrapper um ZERODOX backup-test.sh | OnCalendar |
+
+**State-Files pro Service:** `data/watchdog_state_<service>.json` (gitignored). Alert nach 2 konsekutiven Failures (~10 Min), Recovery-Alert wenn vorher down war. State-Files getrennt damit Counter sich nicht beeinflussen.
+
+**Service-Files in `deploy/`:** Quelldateien fuer die Watchdogs. User-systemd-Symlinks in `~/.config/systemd/user/`. Git-Updates auf `deploy/*.service|*.timer` wirken sofort (Symlink), `daemon-reload` nur bei Schema-Aenderungen noetig.

--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -6,6 +6,29 @@ Wenn Dateien hinzugefuegt, geloescht oder verschoben werden:
 - Neue Cogs/Integrationen in die entsprechende Tabelle eintragen
 - Geloeschte Dateien aus Tabellen entfernen
 
+## Monitoring-Pflicht bei neuen kritischen Services (seit 2026-05-17)
+Vorfall: 14.-17.05.2026 — shadowops-bot war 3 Tage down, niemand hat es bemerkt.
+Loesung: 5 externe Watchdogs alarmen jetzt direkt via Discord-Webhook (PR #253, #255, #256).
+
+**Regel:** Wenn ein neuer kritischer Service auf dem Server hinzukommt:
+1. Health-Endpoint definieren — entweder HTTP (Default) oder systemd-Unit-Status (fallback)
+2. Watchdog-Service-File in `deploy/<name>-watchdog.{service,timer}` anlegen (Template: bestehende kopieren)
+3. Symlink in `~/.config/systemd/user/`, `daemon-reload + enable + start`
+4. Mit Recovery-State (`{"last_status":"down",...}`) einmal triggern → Discord-Alert verifizieren
+5. `deploy/MONITORING_SETUP.md` Tabelle erweitern
+
+**Backward-Compat-Regel fuer Watchdog-Script:** `scripts/service-watchdog.sh` ist parametrisiert via `WATCHDOG_MODE=http|systemd`. Niemals das alte `scripts/bot-watchdog.sh` aendern — es bleibt Source-of-Truth fuer den shadowops-bot Watchdog (Backward-Compat-Wrapper).
+
+## Worker-PR-Dedup (seit 2026-05-17)
+Jeder kritische Worker (Doku, Cleanup, Guardian, SEO-Agent, AI-Agent) der GitHub-PRs erzeugt MUSS:
+1. **State-File pflegen** in `.routines/state/<worker>.json` (oder vergleichbarer Speicher) mit `open_prs: [...]`
+2. **Vor PR-Creation pruefen**: `gh pr list --search "label:worker:<name> state:open"`
+3. **Stable Branch-Names** wie `claude/doku/drift` statt `claude/doku/drift-YYYY-MM-DD` → `git push --force-with-lease` zum Update statt neuer PR
+
+**Hard-Gate:** Jedes Repo hat `.github/workflows/worker-dedup-gate.yml`. Diese Action lehnt PRs mit `worker:*`-Label automatisch ab wenn ein anderer offener PR mit demselben Label existiert. Bei Aenderung: zuerst Pre-Existing-Konflikte aufloesen.
+
+Vorfall-Historie: 17.05.2026 Cleanup — Doku-Worker hat 3 Wochen lang taeglich Drift-PRs erzeugt (27 Duplikate). Worker-Gate verhindert das jetzt strukturell.
+
 ## Code-Aenderungen
 - Vor Aenderungen an laufenden Services: `sudo systemctl status shadowops-bot` pruefen
 - Schema-Aenderungen: ALLE Properties muessen in `required` stehen (Codex Structured Output)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,23 @@ shadowops-bot/
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
 - `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
 
+## Externes Monitoring (seit 2026-05-17 — Defense-in-Depth)
+
+Zusätzlich zum internen `project_monitor.py` laufen 5 unabhängige user-systemd Watchdogs, die alle 5 Minuten ihre Services prüfen und Down/Recovery direkt via Discord-Webhook in `#🩺-uptime-alerts` posten (NICHT über den Bot — funktioniert auch wenn shadowops-bot tot ist):
+
+| Watchdog | Mode | Target |
+|---|---|---|
+| `shadowops-watchdog` | http | http://127.0.0.1:8766/health |
+| `zerodox-watchdog` | http | https://zerodox.de/api/health |
+| `guildscout-watchdog` | http | http://localhost:8765/health |
+| `mayday-sim-watchdog` | http | http://127.0.0.1:3200/api/health |
+| `ai-agent-framework-watchdog` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent |
+| `shadowops-backup-test` | — | monatlich 1. d. Monats, Wrapper um `~/ZERODOX/scripts/backup-test.sh` |
+
+**Script:** `scripts/service-watchdog.sh` (generisch, parametrisiert) und `scripts/bot-watchdog.sh` (Backward-Compat). **Service-Files:** `deploy/<name>-watchdog.{service,timer}`. **Webhook-Config:** `~/.config/shadowops-watchdog.env` (chmod 600). **Setup-Anleitung:** [`deploy/MONITORING_SETUP.md`](./deploy/MONITORING_SETUP.md).
+
+**Regel beim Hinzufügen eines neuen kritischen Services:** Watchdog-Service-File aus `deploy/` kopieren, Env-Vars anpassen, Symlink in `~/.config/systemd/user/`, `daemon-reload + enable + start`, Recovery-Alert testen. Tabelle hier UND in `MONITORING_SETUP.md` erweitern.
+
 ## Coding-Conventions
 
 - **Naming:** `snake_case` fuer Funktionen/Variablen, `PascalCase` fuer Klassen, `UPPER_CASE` fuer Konstanten.

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -7,26 +7,30 @@
 ## Architektur
 
 ```
-                              ┌──────────────────────────┐
-                              │ Discord (critical-Channel)│
-                              └────────────▲─────────────┘
+                              ┌─────────────────────────────┐
+                              │ Discord #🩺-uptime-alerts   │
+                              │ (System & Projekte Kategorie)│
+                              └────────────▲────────────────┘
                                            │ Webhook (POST)
                                            │
-       ┌──────────────┬───────────────────┬─┴─────────────────┬──────────────┐
-       │              │                   │                   │              │
- ┌─────┴──────┐ ┌────┴────────┐ ┌─────────┴─────┐ ┌───────────┴────┐ ┌──────┴───────┐
- │ shadowops- │ │ zerodox-    │ │ guildscout-   │ │ mayday-sim-    │ │ backup-test  │
- │ watchdog   │ │ watchdog    │ │ watchdog      │ │ watchdog       │ │ monatlich    │
- │ alle 5 min │ │ alle 5 min  │ │ alle 5 min    │ │ alle 5 min     │ │ 1. d. Monats │
- └─────┬──────┘ └────┬────────┘ └────────┬──────┘ └──────────┬─────┘ └──────────────┘
-       │ pingt       │ pingt             │ pingt             │ pingt
-       ▼             ▼                   ▼                   ▼
- :8766/health    https://...   localhost:8765/health   127.0.0.1:3200/api/health
-                /api/health
+       ┌─────────┬───────────┬─────────────┴────┬────────────┬────────────┐
+       │         │           │                  │            │            │
+   shadowops- zerodox-   guildscout-       mayday-sim-  ai-agent-      backup-test
+   watchdog   watchdog   watchdog          watchdog     framework-     monatlich
+   alle 5min  alle 5min  alle 5min         alle 5min    watchdog       1. d. Monats
+                                                        alle 5min
+       │         │           │                  │            │
+       ▼         ▼           ▼                  ▼            ▼
+  :8766/    https://    localhost:8765   127.0.0.1:3200  systemctl --user
+  health    zerodox.de  /health          /api/health     is-active
+            /api/health                                  (3 Core-Agents)
 ```
 
-Alle vier Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
-Script, parametrisiert via Env-Vars (`WATCHDOG_SERVICE_NAME`, `WATCHDOG_HEALTH_URL`).
+Alle fünf Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
+Script, parametrisiert via Env-Vars. Zwei Modi:
+- `WATCHDOG_MODE=http` (Default): curl auf `WATCHDOG_HEALTH_URL`
+- `WATCHDOG_MODE=systemd`: prüft `systemctl is-active` für jede Unit in `WATCHDOG_SYSTEMD_UNITS` (Komma-separiert)
+
 Das ursprüngliche `scripts/bot-watchdog.sh` bleibt als Backward-Compat-Variante
 für den shadowops-bot Watchdog erhalten.
 
@@ -39,9 +43,15 @@ damit Failure-Counter und Alert-Status sich nicht beeinflussen.
 
 1. In Discord: **Server-Einstellungen → Integrationen → Webhooks**
 2. **"Neuer Webhook"** klicken
-3. Name: `ShadowOps Watchdog`, Channel: `critical` (oder ein anderer dedizierter Alert-Channel)
+3. Name: `ShadowOps Watchdog`, Channel: `🩺-uptime-alerts` (Kategorie `📦 System & Projekte`)
+   - **Wichtig:** NICHT in `🚨-critical` posten — das ist für Security-Alerts. Uptime-Down ist eine andere Klasse.
 4. **"Webhook-URL kopieren"** — die URL sieht aus wie
    `https://discord.com/api/webhooks/1234.../abcd...`
+
+Falls der Channel noch nicht existiert: er kann via Discord-Bot-MCP angelegt werden:
+- Name: `🩺-uptime-alerts`
+- Kategorie: `📦 System & Projekte` (ID `1441655479867805727`)
+- Topic: `Service-Watchdogs (shadowops-bot, zerodox, guildscout, mayday-sim, ai-agent-framework) — Down + Recovery Alerts`
 
 ### 2. Config-Datei anlegen
 
@@ -66,6 +76,7 @@ systemctl --user restart shadowops-watchdog.timer
 systemctl --user restart zerodox-watchdog.timer
 systemctl --user restart guildscout-watchdog.timer
 systemctl --user restart mayday-sim-watchdog.timer
+systemctl --user restart ai-agent-framework-watchdog.timer
 ```
 
 ### 4. Funktionstest
@@ -88,12 +99,13 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 
 ### Watchdog-Familie (jeder alle 5 Minuten, gestaffelt)
 
-| Service | Endpoint | Bot-Ready-Check | Boot-Offset |
+| Service | Mode | Endpoint/Units | Boot-Offset |
 |---|---|---|---|
-| `shadowops-bot` | http://127.0.0.1:8766/health | ja (`bot_ready=true` Pflicht) | 2 min |
-| `zerodox` | https://zerodox.de/api/health | nein (HTTP 200 reicht) | 3 min |
-| `guildscout` | http://localhost:8765/health | nein (HTTP 200 reicht) | 4 min |
-| `mayday-sim` | http://127.0.0.1:3200/api/health | nein (HTTP 200 reicht) | 5 min |
+| `shadowops-bot` | http | http://127.0.0.1:8766/health (bot_ready=true Pflicht) | 2 min |
+| `zerodox` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 3 min |
+| `guildscout` | http | http://localhost:8765/health | 4 min |
+| `mayday-sim` | http | http://127.0.0.1:3200/api/health | 5 min |
+| `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 6 min |
 
 Pro Service:
 - **🔴 \<service\> DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
@@ -115,22 +127,24 @@ DNS-Auflösung + Traefik-Routing + TLS-Zertifikat + App-Health in einem.
 ## Wartung / Inspektion
 
 ```bash
-# Alle 5 Timer auf einen Blick
+# Alle 6 Timer auf einen Blick
 systemctl --user list-timers \
   shadowops-watchdog.timer zerodox-watchdog.timer guildscout-watchdog.timer \
-  mayday-sim-watchdog.timer shadowops-backup-test.timer
+  mayday-sim-watchdog.timer ai-agent-framework-watchdog.timer shadowops-backup-test.timer
 
 # Letzten 50 Läufe pro Service
 journalctl --user -u shadowops-watchdog.service --no-pager -n 50
 journalctl --user -u zerodox-watchdog.service --no-pager -n 50
 journalctl --user -u guildscout-watchdog.service --no-pager -n 50
 journalctl --user -u mayday-sim-watchdog.service --no-pager -n 50
+journalctl --user -u ai-agent-framework-watchdog.service --no-pager -n 50
 
 # State-Files pro Service inspizieren
 cat ~/shadowops-bot/data/watchdog_state.json
 cat ~/shadowops-bot/data/watchdog_state_zerodox.json
 cat ~/shadowops-bot/data/watchdog_state_guildscout.json
 cat ~/shadowops-bot/data/watchdog_state_mayday-sim.json
+cat ~/shadowops-bot/data/watchdog_state_ai-agent-framework.json
 
 # Backup-Test-Logs (lokal)
 ls -la ~/.local/state/shadowops-bot/backup-test/

--- a/deploy/ai-agent-framework-watchdog.service
+++ b/deploy/ai-agent-framework-watchdog.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=AI Agent Framework Watchdog — systemd-Status-Check der 3 Core-Agents
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=ai-agent-framework
+Environment=WATCHDOG_MODE=systemd
+Environment=WATCHDOG_SYSTEMD_USER=1
+Environment=WATCHDOG_SYSTEMD_UNITS=guildscout-feedback-agent,zerodox-support-agent,seo-agent
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/ai-agent-framework-watchdog.timer
+++ b/deploy/ai-agent-framework-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=AI Agent Framework Watchdog Timer — alle 5 Minuten (mit Jitter)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 6 Minuten nach Boot (versetzt zu shadowops:2, zerodox:3, guildscout:4, mayday:5)
+OnBootSec=6min
+OnUnitActiveSec=5min
+RandomizedDelaySec=45s
+AccuracySec=15s
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/deploy/shadowops-watchdog.env.example
+++ b/deploy/shadowops-watchdog.env.example
@@ -2,7 +2,9 @@
 #
 # Setup:
 #   1. In Discord: Server-Einstellungen → Integrationen → Webhooks → "Neuer Webhook"
-#      Name: "ShadowOps Watchdog", Channel: dein critical-Channel
+#      Name: "ShadowOps Watchdog", Channel: dedizierter Uptime-Alert-Channel
+#      (z.B. #🩺-uptime-alerts in Kategorie 📦 System & Projekte —
+#       NICHT in #🚨-critical, das ist fuer Security-Alerts)
 #   2. URL kopieren und HIER eintragen (NICHT in Git committen!)
 #   3. Datei kopieren nach ~/.config/shadowops-watchdog.env (chmod 600)
 #   4. systemd reloaden: systemctl --user daemon-reload

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -123,8 +123,8 @@ EOF
     fi
 }
 
-# ─── Health-Check ──────────────────────────────────────────────────────
-check_health() {
+# ─── Health-Check (HTTP-Mode) ──────────────────────────────────────────
+check_health_http() {
     local resp http_code body
 
     if ! resp=$(curl -s -m "$CURL_TIMEOUT_S" -w "\n%{http_code}" "$HEALTH_URL" 2>/dev/null); then
@@ -152,6 +152,52 @@ check_health() {
 
     echo "UP"
     return 0
+}
+
+# ─── Health-Check (systemd-Mode) ───────────────────────────────────────
+# Prueft jede Unit in $WATCHDOG_SYSTEMD_UNITS (Komma-separiert) ueber
+# `systemctl is-active`. Wenn auch nur EINE Unit nicht active → DOWN.
+# Nutzt --user wenn $WATCHDOG_SYSTEMD_USER=1 (Default 1), sonst System.
+check_health_systemd() {
+    if [[ -z "${WATCHDOG_SYSTEMD_UNITS:-}" ]]; then
+        echo "DOWN:no_units_configured"
+        return 1
+    fi
+
+    local user_flag=""
+    if [[ "${WATCHDOG_SYSTEMD_USER:-1}" == "1" ]]; then
+        user_flag="--user"
+    fi
+
+    local failed_units=""
+    IFS=',' read -ra units <<< "$WATCHDOG_SYSTEMD_UNITS"
+    for unit in "${units[@]}"; do
+        unit=$(echo "$unit" | xargs)  # trim whitespace
+        [[ -z "$unit" ]] && continue
+        local status
+        status=$(systemctl $user_flag is-active "$unit" 2>/dev/null || echo "unknown")
+        if [[ "$status" != "active" ]]; then
+            failed_units="${failed_units}${unit}=${status} "
+        fi
+    done
+
+    if [[ -n "$failed_units" ]]; then
+        echo "DOWN:$(echo $failed_units | tr ' ' ',' | sed 's/,$//')"
+        return 1
+    fi
+    echo "UP"
+    return 0
+}
+
+# ─── Health-Check Dispatcher ───────────────────────────────────────────
+check_health() {
+    case "${WATCHDOG_MODE:-http}" in
+        http)    check_health_http ;;
+        systemd) check_health_systemd ;;
+        *)       echo "DOWN:invalid_mode_${WATCHDOG_MODE}"
+                 return 1
+                 ;;
+    esac
 }
 
 # ─── Main ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Vervollständigt die Watchdog-Familie auf 5 Services und pflegt die Doku überall ein.

### Was rein kommt

- **`scripts/service-watchdog.sh`** — neuer `WATCHDOG_MODE` Parameter (`http`/`systemd`). Bei `systemd`: prüft `systemctl --user is-active` für jede Unit in `WATCHDOG_SYSTEMD_UNITS`. Backward-Compat: Default `http`, alle 4 bestehenden Watchdogs unverändert.
- **`deploy/ai-agent-framework-watchdog.{service,timer}`** — 6. Watchdog, systemd-Mode, prüft die 3 Core-Agents: `guildscout-feedback-agent`, `zerodox-support-agent`, `seo-agent`. Boot-Offset 6 Min.

### Channel-Trennung Security vs Uptime

Webhook umgestellt vom Security-Channel `#🚨-critical` auf neuen dedizierten `#🩺-uptime-alerts` (Kategorie `📦 System & Projekte`). Semantische Trennung — Security-Findings und Uptime-Down sind unterschiedliche Klassen.

### Doku-Pflege überall

- **`CLAUDE.md`** — neue Sektion "Externes Monitoring" mit Watchdog-Tabelle und Regel für neue Services
- **`.claude/rules/infrastructure.md`** — 3 neue Scripts + komplette Watchdog-Familie-Tabelle
- **`.claude/rules/safety.md`** — zwei neue Regel-Sektionen:
  - "Monitoring-Pflicht bei neuen kritischen Services" (5-Schritte-Checkliste)
  - "Worker-PR-Dedup" (State-File-Regeln + Stable-Branch + GitHub-Action-Gate)
- **`deploy/MONITORING_SETUP.md`** — komplett aktualisiert mit 5-Watchdog-Architektur und Channel-Trennung
- **`deploy/shadowops-watchdog.env.example`** — Channel-Hinweis korrigiert

## Test plan

- [x] `service-watchdog.sh` HTTP-Mode bleibt funktional (4 bestehende Watchdogs)
- [x] systemd-Mode mit 3 Core-Agents → "OK — healthy"
- [x] systemd-Mode mit FAKE-Service → DOWN korrekt erkannt
- [x] Alle 5 Watchdogs Recovery-Alerts gegen neuen Channel: 5× HTTP 204
- [x] systemd-Unit installiert, Timer aktiv, gestaffelt (6 Min Offset)
- [ ] **Nach Merge:** 24h Beobachtung, keine false-positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)