### PR TITLE
feat(monitoring): cmdshadow-design Watchdog (Stale-Detection-Mode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Zusätzlich zum internen `project_monitor.py` laufen 5 unabhängige user-systemd
 | `guildscout-watchdog` | http | http://localhost:8765/health |
 | `mayday-sim-watchdog` | http | http://127.0.0.1:3200/api/health |
 | `ai-agent-framework-watchdog` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent |
+| `cmdshadow-design-watchdog` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h, 1h-Cycle) |
 | `shadowops-backup-test` | — | monatlich 1. d. Monats, Wrapper um `~/ZERODOX/scripts/backup-test.sh` |
 
 **Script:** `scripts/service-watchdog.sh` (generisch, parametrisiert) und `scripts/bot-watchdog.sh` (Backward-Compat). **Service-Files:** `deploy/<name>-watchdog.{service,timer}`. **Webhook-Config:** `~/.config/shadowops-watchdog.env` (chmod 600). **Setup-Anleitung:** [`deploy/MONITORING_SETUP.md`](./deploy/MONITORING_SETUP.md).

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -26,13 +26,18 @@
             /api/health                                  (3 Core-Agents)
 ```
 
-Alle fünf Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
-Script, parametrisiert via Env-Vars. Zwei Modi:
+Alle sechs Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
+Script, parametrisiert via Env-Vars. Drei Modi:
 - `WATCHDOG_MODE=http` (Default): curl auf `WATCHDOG_HEALTH_URL`
 - `WATCHDOG_MODE=systemd`: prüft `systemctl is-active` für jede Unit in `WATCHDOG_SYSTEMD_UNITS` (Komma-separiert)
+- `WATCHDOG_MODE=systemd-result`: prüft Result + Alter (`ExecMainStartTimestamp`) des letzten Laufs für oneshot/Daily-Jobs. `WATCHDOG_MAX_AGE_HOURS` (Default 36h) — bei `stale_*h` → DOWN.
 
 Das ursprüngliche `scripts/bot-watchdog.sh` bleibt als Backward-Compat-Variante
 für den shadowops-bot Watchdog erhalten.
+
+### Sonderrolle: cmdshadow-design
+
+cmdshadow-design ist ein **Claude-Plugin (Multi-Skill Design-Tool), kein laufender Service**. Daher gibt's keinen kontinuierlich pingbaren Endpoint. Stattdessen läuft täglich um 06:00 `cmdshadow-design-healthcheck.service` (oneshot) mit 6 Stufen (Brand-Spec, Pre-Publish, Scripts, Vitest 26 Tests). Der Watchdog prüft alle 1h ob dieser Daily-Healthcheck **rechtzeitig erfolgreich gelaufen** ist. Wenn nicht (z.B. Timer broken, Service-Failure, Stale > 36h): Discord-Alert.
 
 State-Files sind pro Service getrennt (`data/watchdog_state_<service>.json`),
 damit Failure-Counter und Alert-Status sich nicht beeinflussen.
@@ -77,6 +82,7 @@ systemctl --user restart zerodox-watchdog.timer
 systemctl --user restart guildscout-watchdog.timer
 systemctl --user restart mayday-sim-watchdog.timer
 systemctl --user restart ai-agent-framework-watchdog.timer
+systemctl --user restart cmdshadow-design-watchdog.timer
 ```
 
 ### 4. Funktionstest
@@ -97,15 +103,16 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 
 ## Was wird wann alertiert?
 
-### Watchdog-Familie (jeder alle 5 Minuten, gestaffelt)
+### Watchdog-Familie (gestaffelt — meist alle 5 Min, Daily-Jobs alle 1h)
 
-| Service | Mode | Endpoint/Units | Boot-Offset |
-|---|---|---|---|
-| `shadowops-bot` | http | http://127.0.0.1:8766/health (bot_ready=true Pflicht) | 2 min |
-| `zerodox` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 3 min |
-| `guildscout` | http | http://localhost:8765/health | 4 min |
-| `mayday-sim` | http | http://127.0.0.1:3200/api/health | 5 min |
-| `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 6 min |
+| Service | Mode | Endpoint/Units | Cycle | Boot-Offset |
+|---|---|---|---|---|
+| `shadowops-bot` | http | http://127.0.0.1:8766/health (bot_ready=true Pflicht) | 5 min | 2 min |
+| `zerodox` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 5 min | 3 min |
+| `guildscout` | http | http://localhost:8765/health | 5 min | 4 min |
+| `mayday-sim` | http | http://127.0.0.1:3200/api/health | 5 min | 5 min |
+| `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 5 min | 6 min |
+| `cmdshadow-design` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h) | 1 h | 8 min |
 
 Pro Service:
 - **🔴 \<service\> DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
@@ -127,10 +134,11 @@ DNS-Auflösung + Traefik-Routing + TLS-Zertifikat + App-Health in einem.
 ## Wartung / Inspektion
 
 ```bash
-# Alle 6 Timer auf einen Blick
+# Alle 7 Timer auf einen Blick
 systemctl --user list-timers \
   shadowops-watchdog.timer zerodox-watchdog.timer guildscout-watchdog.timer \
-  mayday-sim-watchdog.timer ai-agent-framework-watchdog.timer shadowops-backup-test.timer
+  mayday-sim-watchdog.timer ai-agent-framework-watchdog.timer \
+  cmdshadow-design-watchdog.timer shadowops-backup-test.timer
 
 # Letzten 50 Läufe pro Service
 journalctl --user -u shadowops-watchdog.service --no-pager -n 50

--- a/deploy/cmdshadow-design-watchdog.service
+++ b/deploy/cmdshadow-design-watchdog.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=cmdshadow-design Watchdog — Stale-Detection des Daily-Healthcheck
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=cmdshadow-design
+# systemd-result-Mode: prueft das ERGEBNIS des letzten Healthcheck-Laufs
+# (oneshot-Service, laeuft nicht 24/7). Frische-Toleranz 36h — daily um 06:00
+# bedeutet bei normaler Funktion <24h, mit 12h Reserve gegen Fehlstart.
+Environment=WATCHDOG_MODE=systemd-result
+Environment=WATCHDOG_SYSTEMD_USER=1
+Environment=WATCHDOG_SYSTEMD_UNITS=cmdshadow-design-healthcheck.service
+Environment=WATCHDOG_MAX_AGE_HOURS=36
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/cmdshadow-design-watchdog.timer
+++ b/deploy/cmdshadow-design-watchdog.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=cmdshadow-design Watchdog Timer — stuendlich (Stale-Check, kein kontinuierliches Polling)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 8 Minuten nach Boot (versetzt: shadowops:2, zerodox:3, guildscout:4,
+# mayday:5, agents:6, cmdshadow-design:8 — Lücke bei 7 für zukünftige Services).
+# Intervall: 1h (vs. 5min bei klassischen Watchdogs) — wir checken einen Daily-Job,
+# keine 24/7-Service-Verfügbarkeit. Spart Ressourcen, immer noch früh genug
+# wenn der Healthcheck mal nicht läuft.
+OnBootSec=8min
+OnUnitActiveSec=1h
+RandomizedDelaySec=3min
+AccuracySec=1min
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -189,14 +189,93 @@ check_health_systemd() {
     return 0
 }
 
+# ─── Health-Check (systemd-result-Mode) ────────────────────────────────
+# Fuer oneshot-Services (z.B. Daily-Healthcheck) die NICHT 24/7 laufen.
+# Prueft das ERGEBNIS des letzten Laufs:
+#   - Result=success (sonst → DOWN)
+#   - ExecMainStartTimestamp innerhalb $WATCHDOG_MAX_AGE_HOURS (Default 36h)
+# Wenn Service Result=success aber zu alt: DOWN:stale.
+# Wenn Service noch nie gelaufen ist: DOWN:never_ran.
+check_health_systemd_result() {
+    if [[ -z "${WATCHDOG_SYSTEMD_UNITS:-}" ]]; then
+        echo "DOWN:no_units_configured"
+        return 1
+    fi
+
+    local user_flag=""
+    if [[ "${WATCHDOG_SYSTEMD_USER:-1}" == "1" ]]; then
+        user_flag="--user"
+    fi
+
+    local max_age_hours="${WATCHDOG_MAX_AGE_HOURS:-36}"
+    local max_age_seconds=$((max_age_hours * 3600))
+    local now_epoch
+    now_epoch=$(date +%s)
+
+    local issues=""
+    IFS=',' read -ra units <<< "$WATCHDOG_SYSTEMD_UNITS"
+    for unit in "${units[@]}"; do
+        unit=$(echo "$unit" | xargs)
+        [[ -z "$unit" ]] && continue
+
+        # systemctl show liefert KEY=VALUE — robust parsen
+        local props
+        props=$(systemctl $user_flag show "$unit" \
+            --property=Result,ExecMainStartTimestamp,LoadState 2>/dev/null || echo "")
+        if [[ -z "$props" ]]; then
+            issues="${issues}${unit}=no_status "
+            continue
+        fi
+
+        local load_state result_state start_ts
+        load_state=$(echo "$props" | grep -oE '^LoadState=.*' | cut -d= -f2-)
+        result_state=$(echo "$props" | grep -oE '^Result=.*' | cut -d= -f2-)
+        start_ts=$(echo "$props" | grep -oE '^ExecMainStartTimestamp=.*' | cut -d= -f2-)
+
+        if [[ "$load_state" != "loaded" ]]; then
+            issues="${issues}${unit}=not_loaded "
+            continue
+        fi
+        if [[ -z "$start_ts" ]]; then
+            issues="${issues}${unit}=never_ran "
+            continue
+        fi
+        if [[ "$result_state" != "success" ]]; then
+            issues="${issues}${unit}=result_${result_state} "
+            continue
+        fi
+
+        # Alter pruefen: ExecMainStartTimestamp in epoch konvertieren
+        local start_epoch age
+        start_epoch=$(date -d "$start_ts" +%s 2>/dev/null || echo 0)
+        if [[ "$start_epoch" -eq 0 ]]; then
+            issues="${issues}${unit}=bad_timestamp "
+            continue
+        fi
+        age=$((now_epoch - start_epoch))
+        if [[ "$age" -gt "$max_age_seconds" ]]; then
+            local hours=$((age / 3600))
+            issues="${issues}${unit}=stale_${hours}h "
+        fi
+    done
+
+    if [[ -n "$issues" ]]; then
+        echo "DOWN:$(echo $issues | tr ' ' ',' | sed 's/,$//')"
+        return 1
+    fi
+    echo "UP"
+    return 0
+}
+
 # ─── Health-Check Dispatcher ───────────────────────────────────────────
 check_health() {
     case "${WATCHDOG_MODE:-http}" in
-        http)    check_health_http ;;
-        systemd) check_health_systemd ;;
-        *)       echo "DOWN:invalid_mode_${WATCHDOG_MODE}"
-                 return 1
-                 ;;
+        http)           check_health_http ;;
+        systemd)        check_health_systemd ;;
+        systemd-result) check_health_systemd_result ;;
+        *)              echo "DOWN:invalid_mode_${WATCHDOG_MODE}"
+                        return 1
+                        ;;
     esac
 }
 


### PR DESCRIPTION
## Summary

7. und letztes Watchdog-Target — aber als **Sonderrolle**, weil cmdshadow-design ein Claude-Plugin ist (kein 24/7-Service). Statt klassischem Uptime-Check: **Stale-Detection** des Daily-Healthcheck-Cron.

### Was rein kommt

- **`scripts/service-watchdog.sh`** — neuer `WATCHDOG_MODE=systemd-result`
  - Prüft `Result=success` + `ExecMainStartTimestamp` Alter via `systemctl show`
  - `WATCHDOG_MAX_AGE_HOURS` (Default 36h) für Stale-Schwelle
  - DOWN-States: `not_loaded`, `never_ran`, `result_<state>`, `stale_<N>h`, `bad_timestamp`

- **`deploy/cmdshadow-design-watchdog.{service,timer}`**
  - Mode: `systemd-result`
  - Unit: `cmdshadow-design-healthcheck.service` (oneshot, läuft daily 06:00)
  - Max-Age: 36h (= Daily-Schedule + 12h Reserve)
  - Cycle: **1h** (vs. 5min bei klassischen Watchdogs — Daily-Job braucht kein hochfrequentes Polling)

### Doku-Pflege

- `CLAUDE.md` — Watchdog-Tabelle erweitert um cmdshadow-design
- `MONITORING_SETUP.md` — neue Sektion "Sonderrolle: cmdshadow-design" erklärt das Pattern
- 7-Watchdog-Übersicht durchgängig aktualisiert

## Test plan

- [x] systemd-result-Mode mit frischem Healthcheck (10h alt, max_age=36h) → OK
- [x] Stale-Detection: max_age=1h → `stale_10h` DOWN
- [x] Non-existent Unit → `not_loaded` DOWN
- [x] Recovery-Alert via Discord-Webhook → HTTP 204
- [x] Timer gestaffelt (Offset 8 min, stündlich)
- [x] HTTP-Mode + systemd-Mode beider 5 anderen Watchdogs **bleiben unverändert** (Smoke-Test mit altem service-watchdog.sh: shadowops-bot OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)