### PR TITLE
docs: Drift-Korrekturen deploy/-Struktur + staler Ollama-Fehler

### DIFF
--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,34 +2,27 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": "2026-05-16T00:00:00Z",
-  "last_drift_check": "2026-05-16T00:00:00Z",
+  "last_run": "2026-05-18T00:00:00Z",
+  "last_drift_check": "2026-05-18T00:00:00Z",
   "open_prs": [
     {
-      "branch": "claude/doku/drift-2026-05-16",
-      "title": "docs: drift-Korrekturen README, CLAUDE.md, api.md",
+      "branch": "claude/doku/drift",
+      "title": "docs: Drift-Korrekturen deploy/-Struktur + staler Ollama-Fehler",
       "scope": "drift",
-      "created": "2026-05-16"
+      "created": "2026-05-18"
     },
     {
-      "branch": "claude/doku/gaps-2026-05-16",
-      "title": "docs: fehlende Slash-Commands in api.md + discord-bot.md Cog-Tabelle",
+      "branch": "claude/doku/gaps",
+      "title": "docs: README Anti-Bloat — Highlights v3.1-v3.4 in CHANGELOG.md auslagern",
       "scope": "gaps",
-      "created": "2026-05-16"
+      "created": "2026-05-18"
     }
   ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": "2026-05-16" },
-    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-16" },
-    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-16" },
+    "README.md": { "last_synced_with_code_at": "2026-05-18" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-18" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-18" },
     ".claude/rules/discord-bot.md": { "last_synced_with_code_at": "2026-05-16" }
   },
-  "open_questions": [
-    {
-      "id": "q1",
-      "created": "2026-05-16",
-      "file": "README.md",
-      "note": "README ist 775 Zeilen (Limit: 500). Highlights v3.1-v3.4 sind mehr als 2 Versionen alt und koennten in CHANGELOG.md migriert werden. Kein PR erstellt — Entscheidung beim Maintainer."
-    }
-  ]
+  "open_questions": []
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,15 @@ shadowops-bot/
 │   ├── INFRASTRUCTURE.md
 │   └── PROJECT_*.md              # Per-projekt-Notizen
 ├── deploy/
-│   └── shadowops-bot.service     # systemd Unit
+│   ├── shadowops-bot.service          # systemd Bot-Service
+│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (6x HTTP/systemd + Backup-Test)
+│   ├── shadowops-watchdog.env.example # Webhook-Env Template
+│   └── MONITORING_SETUP.md            # Setup-Anleitung Watchdogs
+├── .github/
+│   └── workflows/
+│       ├── ci.yml                     # Test-Pipeline (pytest)
+│       ├── worker-dedup-gate.yml      # Verhindert Duplikat-Worker-PRs
+│       └── auto-label-pr.yml          # Auto-Labeling nach Conventional Commits
 ├── scripts/                      # Wartungs-Skripte
 ├── docs/
 │   ├── SECURITY_ANALYST.md
@@ -212,4 +220,4 @@ Worker-Konventionen:
 
 ## Letztes Update dieser Datei
 
-2026-04-26 — initiales Setup, generiert aus Worker-Bundle.
+2026-05-18 — deploy/-Verzeichnis aktualisiert (Watchdog-Services), .github/workflows/ hinzugefuegt.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🗡️ ShadowOps - Active Security Guardian v5.1 🚀
 
-**Status:** AKTIV | **Version:** 5.1.0 | **Letzte Aktualisierung:** 12.04.2026
+**Status:** AKTIV | **Version:** 5.1.0 | **Letzte Aktualisierung:** 18.05.2026
 
 **ShadowOps** ist ein **vollständig autonomer Security Guardian** mit lernfähigem AI Security Analyst, KI-gesteuerter Auto-Remediation, adaptiver Session-Steuerung und wachsender Knowledge-DB — kein statischer Scanner, sondern ein **System das aus seinen Erfahrungen lernt und immer besser wird**.
 
@@ -562,8 +562,16 @@ shadowops-bot/
 │   ├── config.recommended.yaml         # Empfehlungen
 │   ├── safe_upgrades.yaml              # Upgrade-Pfade
 │   └── logrotate.conf                  # Log-Rotation
-├── deploy/                             # Deployment
-│   └── shadowops-bot.service           # systemd Unit
+├── deploy/                             # Deployment + Watchdogs
+│   ├── shadowops-bot.service           # systemd Bot-Service
+│   ├── *-watchdog.{service,timer}      # Externe Uptime-Watchdogs (6x HTTP/systemd + Backup-Test)
+│   ├── shadowops-watchdog.env.example  # Webhook-Env Template
+│   └── MONITORING_SETUP.md             # Setup-Anleitung Watchdogs
+├── .github/
+│   └── workflows/
+│       ├── ci.yml                      # Test-Pipeline
+│       ├── worker-dedup-gate.yml       # Worker-PR-Dedup-Gate
+│       └── auto-label-pr.yml           # Auto-Labeling
 ├── scripts/                            # Utility-Skripte
 │   ├── restart.sh                      # Bot neustarten (--pull, --logs)
 │   ├── diagnose-bot.sh                 # Diagnose

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,7 +1,7 @@
 ---
 title: 🔧 ShadowOps API Documentation v5.1
 status: active
-last_reviewed: 2026-04-15
+last_reviewed: 2026-05-18
 owner: CommanderShadow9
 ---
 
@@ -955,7 +955,6 @@ DSN kommt aus `config.security_analyst_dsn` (Env: `SECURITY_ANALYST_DB_URL`).
 
 #### AI Service Errors
 - `No AI providers enabled` - All AI services disabled
-- `Ollama connection failed` - Cannot reach Ollama server
 - `AI request timeout` - AI provider took too long
 
 #### Deployment Errors
@@ -1066,4 +1065,4 @@ sudo ufw status
 
 ---
 
-**API Documentation v5.1** | Last Updated: 2026-04-12
+**API Documentation v5.1** | Last Updated: 2026-05-18


### PR DESCRIPTION
## Aenderungen

### CLAUDE.md + README.md — deploy/ Verzeichnis aktualisiert

Nach PRs #253–#258 (externe Watchdog-Infrastruktur) wurde `deploy/` nie in den Verzeichnisbaum-Darstellungen nachgezogen. Bisher stand dort nur `shadowops-bot.service`, tatsaechlich liegen dort jetzt 16+ Dateien.

**Korrektur:**
- `deploy/` zeigt jetzt: Bot-Service, Watchdog-{service,timer}-Glob, env.example, MONITORING_SETUP.md
- `.github/workflows/` (ci.yml, worker-dedup-gate.yml, auto-label-pr.yml) in beiden Strukturbaeumen ergaenzt

### api.md — Veralteter Ollama-Fehler entfernt

Zeile `Ollama connection failed - Cannot reach Ollama server` war noch in der Fehlerliste. Ollama wurde in v4.0 vollstaendig entfernt (1364 Zeilen Dead Code). Der Eintrag ist seit ca. 6 Monaten falsch.

### api.md + README.md — Datums-Metadaten aktualisiert

- `last_reviewed: 2026-04-15` → `2026-05-18`
- `Last Updated: 2026-04-12` → `2026-05-18`
- `Letzte Aktualisierung: 12.04.2026` → `18.05.2026`

### .routines/state/doku.json — State-Update

`last_run`, `last_drift_check`, `open_prs`, `tracked_files` auf aktuellen Stand gebracht. `open_questions` geleert (q1 README-Bloat wird in PR claude/doku/gaps behandelt).

## Begruendung pro Item

| Item | Grund |
|------|-------|
| deploy/-Struktur | PRs #253–#258 fuegte 6 Watchdog-Services + Timer + MONITORING_SETUP.md hinzu — Doku zeigte nur noch 1/16 der Dateien |
| .github/workflows/ | worker-dedup-gate.yml (PR #249) ist funktionskritisch fuer Worker-Safety — fehlt in beiden Verzeichnisbaeumen |
| Ollama-Fehler | Ollama seit v4.0 entfernt, Fehler-Eintrag erzeugt falsche Erwartungen beim Troubleshooting |
| Datums-Metadaten | Routine-Pflicht: Doku-Kurator-Lauf aktualisiert reviewed-Timestamps |

---
_Generated by [Claude Code](https://claude.ai/code/session_016qq4dpV15YsdU6ZZkGhQCC)_