### PR TITLE
feat(watchdog): WATCHDOG_HEALTH_JQ_FILTER für mayday-ci-runner (Issue mayday-sim#437)

### DIFF
--- a/deploy/mayday-ci-runner-watchdog.service
+++ b/deploy/mayday-ci-runner-watchdog.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=mayday-ci Runner Health Watchdog — Alert bei CI_RUNNER_DOWN (#425)
+Documentation=https://github.com/Commandershadow9/mayday-sim/issues/425
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/mayday-ci-runner-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=mayday-ci-runner
+Environment=WATCHDOG_HEALTH_URL=http://10.8.0.10:9100/health
+Environment=WATCHDOG_MODE=http
+Environment=WATCHDOG_REQUIRE_BOT_READY=0
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=mayday-ci-runner-watchdog
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/deploy/mayday-ci-runner-watchdog.timer
+++ b/deploy/mayday-ci-runner-watchdog.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Timer: mayday-ci Runner Health Check alle 5 Min (#425)
+
+[Timer]
+OnBootSec=6min
+OnUnitActiveSec=5min
+RandomizedDelaySec=45s
+AccuracySec=15s
+Persistent=false
+Unit=mayday-ci-runner-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -21,6 +21,17 @@
 #   WATCHDOG_TIMEOUT_S    — Curl-Timeout (default 10)
 #   WATCHDOG_REQUIRE_BOT_READY — wenn "1": prüfe zusätzlich JSON-Feld
 #                                bot_ready=true (Default 1 für shadowops, sonst 0)
+#   WATCHDOG_HEALTH_JQ_FILTER — optional: jq-Boolean-Expression gegen Response-Body.
+#                                Wenn gesetzt: HTTP-Status wird IGNORIERT (außer
+#                                curl-Fehler), stattdessen Truth-Source = jq-Result.
+#                                Beispiele:
+#                                  .components.ci_runner.ok
+#                                    → true wenn Komponente sich selbst als ok meldet
+#                                  '[.alerts[] | select(.component == "ci_runner" and .severity == "critical")] | length == 0'
+#                                    → true wenn keine critical-alerts für component
+#                                Use-Case: Aggregierte Health-Endpoints filtern auf eine
+#                                Komponente (z.B. mayday-ci-Pool bei runner-health.service
+#                                der auch ZERODOX-Pool aggregiert).
 #
 # Backward-Compat: Falls SHADOWOPS_HEALTH_URL/SHADOWOPS_WATCHDOG_WEBHOOK/
 # SHADOWOPS_WATCHDOG_STATE/SHADOWOPS_WATCHDOG_TIMEOUT gesetzt sind, werden
@@ -135,6 +146,34 @@ check_health_http() {
     http_code=$(echo "$resp" | tail -n1)
     body=$(echo "$resp" | head -n -1)
 
+    # JQ-Filter-Mode: HTTP-Status wird ignoriert, jq-Boolean-Expression ist Truth-Source.
+    # Use-Case: aggregierte Health-Endpoints die status:critical melden weil EINE von
+    # vielen Komponenten down ist — Watchdog soll aber nur auf SEINE Komponente reagieren.
+    if [[ -n "${WATCHDOG_HEALTH_JQ_FILTER:-}" ]]; then
+        if ! command -v jq >/dev/null 2>&1; then
+            echo "DOWN:jq_not_installed"
+            return 1
+        fi
+        local jq_result
+        jq_result=$(echo "$body" | jq -r "$WATCHDOG_HEALTH_JQ_FILTER" 2>/dev/null || echo "ERROR")
+        case "$jq_result" in
+            true)
+                echo "UP"
+                return 0
+                ;;
+            false)
+                echo "DOWN:jq_filter_false"
+                return 1
+                ;;
+            *)
+                # Filter lieferte weder true noch false (Syntax-Error, null, missing key, …)
+                echo "DOWN:jq_filter_invalid:$jq_result"
+                return 1
+                ;;
+        esac
+    fi
+
+    # Default-Mode: HTTP-Status ist Truth-Source.
     if [[ "$http_code" != "200" ]]; then
         echo "DOWN:http_$http_code"
         return 1

--- a/tests/unit/test_service_watchdog_jq_filter.py
+++ b/tests/unit/test_service_watchdog_jq_filter.py
@@ -1,0 +1,214 @@
+"""
+Tests fuer service-watchdog.sh — JSON-Path-Filter (Issue mayday-sim#437).
+
+Verifiziert dass `WATCHDOG_HEALTH_JQ_FILTER` aggregierte Health-Endpoints
+korrekt auf eine Komponente filtert. Use-Case: runner-health.service auf
+V-Server1 meldet HTTP 503 (globaler status: critical) auch wenn die
+mayday-ci-runner-Komponente selbst `ok: true` ist.
+
+Tests starten einen lokalen HTTP-Stub-Server pro Test und prueft den
+Exit-Code + Log-Output des Shell-Scripts.
+"""
+import http.server
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "service-watchdog.sh"
+
+
+# ---------- HTTP-Stub-Helper ----------
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@contextmanager
+def stub_health_server(status_code: int, body: dict | str):
+    """Start einen Mini-HTTP-Server der bei /health konfigurierten Status+Body liefert."""
+    if isinstance(body, dict):
+        body_bytes = json.dumps(body).encode()
+        content_type = "application/json"
+    else:
+        body_bytes = body.encode() if isinstance(body, str) else body
+        content_type = "text/plain"
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(status_code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+        def log_message(self, *_args, **_kwargs):  # silence
+            pass
+
+    port = _free_port()
+    server = http.server.HTTPServer(("127.0.0.1", port), Handler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{port}/health"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _run_watchdog(env_extra: dict, expect_alert: bool = False) -> subprocess.CompletedProcess:
+    """Run service-watchdog.sh mit isoliertem State-File und Stub-Webhook (mock)."""
+    tmpdir = tempfile.mkdtemp(prefix="watchdog-test-")
+    state_file = os.path.join(tmpdir, "state.json")
+
+    # Webhook absichtlich auf Mock-Endpoint umlenken damit kein realer Discord-Call
+    # passiert — Recovery/Down-Alerts werden nicht echt gesendet im Test.
+    with stub_health_server(204, "") as webhook_url:
+        env = {
+            **os.environ,
+            "WATCHDOG_SERVICE_NAME": "test-service",
+            "WATCHDOG_STATE_FILE": state_file,
+            "WATCHDOG_WEBHOOK": webhook_url,
+            "WATCHDOG_REQUIRE_BOT_READY": "0",
+            "WATCHDOG_TIMEOUT_S": "5",
+            **env_extra,
+        }
+        try:
+            return subprocess.run(
+                ["bash", str(SCRIPT)],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------- Tests ----------
+
+@pytest.fixture(scope="module")
+def script_exists():
+    assert SCRIPT.exists(), f"service-watchdog.sh nicht gefunden: {SCRIPT}"
+    assert shutil.which("jq"), "jq nicht installiert"
+    assert shutil.which("curl"), "curl nicht installiert"
+
+
+def test_jq_filter_true_makes_endpoint_healthy_despite_503(script_exists):
+    """Kern-Use-Case Issue #437: HTTP 503 aber ci_runner.ok=true → UP."""
+    body = {
+        "status": "critical",
+        "components": {
+            "ci_runner": {"ok": True, "services_active": 3, "services_configured": 3},
+            "github_runners": {"ok": False, "services_active": 12, "services_configured": 14},
+        },
+        "alerts": [
+            {"code": "RUNNER_DOWN", "severity": "critical", "component": "github_runners"},
+        ],
+    }
+    with stub_health_server(503, body) as url:
+        result = _run_watchdog({
+            "WATCHDOG_HEALTH_URL": url,
+            "WATCHDOG_HEALTH_JQ_FILTER": ".components.ci_runner.ok",
+        })
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK — healthy" in result.stdout
+
+
+def test_jq_filter_false_marks_endpoint_down_despite_http_200(script_exists):
+    """Edge: HTTP 200 aber Component-Filter sagt down → DOWN."""
+    body = {
+        "status": "ok",
+        "components": {"ci_runner": {"ok": False, "services_active": 1, "services_configured": 3}},
+    }
+    with stub_health_server(200, body) as url:
+        result = _run_watchdog({
+            "WATCHDOG_HEALTH_URL": url,
+            "WATCHDOG_HEALTH_JQ_FILTER": ".components.ci_runner.ok",
+        })
+    # consecutive=1, last_status=up → kein neuer Alert aber DOWN-Pfad
+    assert "down (jq_filter_false)" in result.stdout
+
+
+def test_jq_filter_missing_field_returns_invalid(script_exists):
+    """Edge: Filter findet Feld nicht (null) → DOWN:jq_filter_invalid."""
+    body = {"status": "ok", "components": {"other": {"ok": True}}}
+    with stub_health_server(200, body) as url:
+        result = _run_watchdog({
+            "WATCHDOG_HEALTH_URL": url,
+            "WATCHDOG_HEALTH_JQ_FILTER": ".components.ci_runner.ok",
+        })
+    assert "jq_filter_invalid:null" in result.stdout
+
+
+def test_jq_filter_syntax_error_returns_invalid(script_exists):
+    """Edge: jq-Syntax-Error → DOWN:jq_filter_invalid:ERROR."""
+    body = {"status": "ok"}
+    with stub_health_server(200, body) as url:
+        result = _run_watchdog({
+            "WATCHDOG_HEALTH_URL": url,
+            "WATCHDOG_HEALTH_JQ_FILTER": "this is not valid jq syntax !!!",
+        })
+    assert "jq_filter_invalid" in result.stdout
+
+
+def test_alert_filter_expression_works(script_exists):
+    """Schema-v1-Alternative: filtere alerts[] auf component → UP wenn keine critical-Alerts."""
+    body = {
+        "status": "critical",
+        "components": {"ci_runner": {"ok": True}},
+        "alerts": [
+            {"code": "RUNNER_DOWN", "severity": "critical", "component": "github_runners"},
+            {"code": "LOAD_HIGH", "severity": "critical", "component": "load"},
+        ],
+    }
+    filter_expr = (
+        '[.alerts[] | select(.component == "ci_runner" and .severity == "critical")] '
+        '| length == 0'
+    )
+    with stub_health_server(503, body) as url:
+        result = _run_watchdog({
+            "WATCHDOG_HEALTH_URL": url,
+            "WATCHDOG_HEALTH_JQ_FILTER": filter_expr,
+        })
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK — healthy" in result.stdout
+
+
+def test_default_mode_unchanged_without_filter(script_exists):
+    """Backward-Compat: ohne Filter zaehlt HTTP-Status weiterhin."""
+    body = {"status": "ok"}
+    with stub_health_server(503, body) as url:
+        result = _run_watchdog({"WATCHDOG_HEALTH_URL": url})
+    assert "down (http_503)" in result.stdout
+
+
+def test_default_mode_up_on_http_200_without_filter(script_exists):
+    """Backward-Compat: HTTP 200 ohne Filter → UP."""
+    body = {"status": "ok"}
+    with stub_health_server(200, body) as url:
+        result = _run_watchdog({"WATCHDOG_HEALTH_URL": url})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK — healthy" in result.stdout
+
+
+def test_curl_unreachable_endpoint_returns_down(script_exists):
+    """Edge: curl scheitert (Port unreachable) → DOWN:curl_failed."""
+    # Bind+release einen Port damit definitiv nichts dort lauscht
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}/health"
+    result = _run_watchdog({
+        "WATCHDOG_HEALTH_URL": url,
+        "WATCHDOG_HEALTH_JQ_FILTER": ".components.ci_runner.ok",  # auch mit Filter
+    })
+    assert "curl_failed" in result.stdout


### PR DESCRIPTION
## Kontext

Folge-Fix aus dem Phase-4-Live-Roll-out von `mayday-ci-runner-watchdog.service` (mayday-sim#425). Der Watchdog feuert False-Positives weil `service-watchdog.sh` ausschließlich den HTTP-Status auswertet — der aggregierte `runner-health.service`-Endpoint auf V-Server1 liefert HTTP 503 sobald **irgendeine** Komponente kaputt ist (ZERODOX-Slots, LOAD_HIGH), selbst wenn `components.ci_runner.ok: true`.

Closes: [mayday-sim#437](https://github.com/Commandershadow9/mayday-sim/issues/437)
Refs: mayday-sim#425 (Parent — Phase 4 Monitoring), mayday-sim#421 (Konzept-Parent)

## Änderungen

### 1. `scripts/service-watchdog.sh` (+39 LOC) — Commit 9c7b6e6

Neue ENV-Var `WATCHDOG_HEALTH_JQ_FILTER`: jq-Boolean-Expression gegen Response-Body. Wenn gesetzt, wird der HTTP-Status ignoriert (außer bei curl-Fehler) und das jq-Result ist Truth-Source.

\`\`\`bash
# Beispiel: ci_runner-Komponente checken
WATCHDOG_HEALTH_JQ_FILTER=.components.ci_runner.ok

# Alternative: alerts[] für die Komponente filtern
WATCHDOG_HEALTH_JQ_FILTER='[.alerts[] | select(.component == "ci_runner" and .severity == "critical")] | length == 0'
\`\`\`

Backward-kompatibel — Default-Verhalten (HTTP-Status als Truth-Source) bleibt für alle 6 anderen Watchdogs unverändert.

### 2. `deploy/mayday-ci-runner-watchdog.{service,timer}` — Commit 9c7b6e6

Live-Watchdog für mayday-ci-Pool auf V-Server1. 5-Min-Cycle, postet bei DOWN/Recovery in `#dev-alerts`.

### 3. `tests/unit/test_service_watchdog_jq_filter.py` — Commit cc30694

8 pytest-Tests mit HTTP-Stub-Server-Fixtures:

* ✅ HTTP 503 + ci_runner.ok=true → UP (Kern-Use-Case)
* ✅ HTTP 200 + ci_runner.ok=false → DOWN:jq_filter_false
* ✅ Missing field → DOWN:jq_filter_invalid:null
* ✅ Syntax-Error → DOWN:jq_filter_invalid:ERROR
* ✅ Alert-Filter-Expression → UP
* ✅ Backward-Compat: HTTP 503 ohne Filter → DOWN:http_503
* ✅ Backward-Compat: HTTP 200 ohne Filter → UP
* ✅ curl unreachable → DOWN:curl_failed

\`\`\`
$ .venv/bin/python -m pytest tests/unit/test_service_watchdog_jq_filter.py -v --override-ini="addopts="
============================== 8 passed in 4.22s ===============================
\`\`\`

## Live-Verifikation auf vServer

Vor Filter-Aktivierung:
\`\`\`
[watchdog:mayday-ci-runner] down (http_503), consecutive=10, last_status=down — kein neuer Alert
\`\`\`

Nach `WATCHDOG_HEALTH_JQ_FILTER=.components.ci_runner.ok` in `~/.config/mayday-ci-runner-watchdog.env`:
\`\`\`
[watchdog:mayday-ci-runner] Discord-Alert gesendet (HTTP 204)
[watchdog:mayday-ci-runner] OK — healthy
\`\`\`

Recovery-Alert in `#dev-alerts` angekommen. State: `{"last_status":"up","consecutive_failures":0}`.

## Konsequenz für mayday-sim#425 DoD

- ✅ False-Positive bei ci_runner.ok=true behoben
- 🟡 Outage-Test offen — keydev kann ihn jetzt durchführen (vorher blockiert weil State permanent `down` war)

## Test-Plan

- [x] Unit-Tests grün (8/8)
- [x] Live-Roll-out verifiziert (Recovery-Alert in #dev-alerts angekommen)
- [ ] Outage-Test durch keydev: `systemctl stop` einer mayday-ci-Slot → DOWN-Alert innerhalb 5 min, Recovery-Alert nach `systemctl start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)