### PR TITLE
docs: /claude Cog + Watchdog-Tabellen-Drift (mayday-ci-runner + build-drift)

### DIFF
--- a/.claude/rules/discord-bot.md
+++ b/.claude/rules/discord-bot.md
@@ -21,6 +21,7 @@ paths:
 | `admin.py` | AdminCog | `/scan`, `/stop-all-fixes`, `/remediation-stats`, `/set-approval-mode`, `/reload-context`, `/release-notes`, `/pending-notes`, `/mark-duplicate` |
 | `inspector.py` | InspectorCog | `/get-ai-stats`, `/projekt-status`, `/alle-projekte`, `/agent-stats`, `/security-engine` |
 | `customer_setup_commands.py` | CustomerSetupCommands | `/setup-customer-server` |
+| `claude_cli.py` | ClaudeCLICog | `/claude` (owner-only: headless Claude-Session per Mobile-Trigger) |
 | `cron_heartbeat.py` | CronHeartbeatCog | (intern, keine Slash Commands) |
 | `phase_5e_health_aggregator.py` | Phase5eHealthAggregator | (intern, kein Slash Command — pollt 3 Hosts) |
 

--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": "2026-05-23T00:00:00Z",
-  "last_drift_check": "2026-05-23T00:00:00Z",
+  "last_run": "2026-05-24T00:00:00Z",
+  "last_drift_check": "2026-05-24T00:00:00Z",
   "open_prs": [
     {
       "branch": "claude/doku/drift",

--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,15 +2,15 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": "2026-05-22T00:00:00Z",
-  "last_drift_check": "2026-05-22T00:00:00Z",
+  "last_run": "2026-05-23T00:00:00Z",
+  "last_drift_check": "2026-05-23T00:00:00Z",
   "open_prs": [
     {
       "branch": "claude/doku/drift",
       "title": "docs: /claude Cog + Watchdog-Tabellen-Drift (mayday-ci-runner + build-drift)",
       "scope": "drift",
       "created": "2026-05-21",
-      "refreshed": "2026-05-22"
+      "refreshed": "2026-05-23"
     },
     {
       "branch": "claude/doku/gaps",
@@ -24,7 +24,7 @@
     "CLAUDE.md": { "last_synced_with_code_at": "2026-05-22" },
     "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-21" },
     ".claude/rules/discord-bot.md": { "last_synced_with_code_at": "2026-05-21" },
-    "deploy/MONITORING_SETUP.md": { "last_synced_with_code_at": "2026-05-22" }
+    "deploy/MONITORING_SETUP.md": { "last_synced_with_code_at": "2026-05-23" }
   },
   "open_questions": [
     {

--- a/.routines/state/doku.json
+++ b/.routines/state/doku.json
@@ -2,27 +2,36 @@
   "schema_version": 1,
   "repo": "Commandershadow9/shadowops-bot",
   "worker": "doku",
-  "last_run": "2026-05-18T00:00:00Z",
-  "last_drift_check": "2026-05-18T00:00:00Z",
+  "last_run": "2026-05-22T00:00:00Z",
+  "last_drift_check": "2026-05-22T00:00:00Z",
   "open_prs": [
     {
       "branch": "claude/doku/drift",
-      "title": "docs: Drift-Korrekturen deploy/-Struktur + staler Ollama-Fehler",
+      "title": "docs: /claude Cog + Watchdog-Tabellen-Drift (mayday-ci-runner + build-drift)",
       "scope": "drift",
-      "created": "2026-05-18"
+      "created": "2026-05-21",
+      "refreshed": "2026-05-22"
     },
     {
       "branch": "claude/doku/gaps",
-      "title": "docs: README Anti-Bloat — Highlights v3.1-v3.4 in CHANGELOG.md auslagern",
+      "title": "docs: README Anti-Bloat — Changelog v1.0-v3.2 Duplikate entfernen",
       "scope": "gaps",
-      "created": "2026-05-18"
+      "created": "2026-05-21"
     }
   ],
   "tracked_files": {
-    "README.md": { "last_synced_with_code_at": "2026-05-18" },
-    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-18" },
-    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-18" },
-    ".claude/rules/discord-bot.md": { "last_synced_with_code_at": "2026-05-16" }
+    "README.md": { "last_synced_with_code_at": "2026-05-21" },
+    "CLAUDE.md": { "last_synced_with_code_at": "2026-05-22" },
+    "docs/reference/api.md": { "last_synced_with_code_at": "2026-05-21" },
+    ".claude/rules/discord-bot.md": { "last_synced_with_code_at": "2026-05-21" },
+    "deploy/MONITORING_SETUP.md": { "last_synced_with_code_at": "2026-05-22" }
   },
-  "open_questions": []
+  "open_questions": [
+    {
+      "file": "src/integrations/zerodox_auto_fix_gate.py",
+      "question": "Docstring erwaehnt /zerodox-auto-fix-toggle als Activation-Command, aber kein app_commands.command() dafuer in src/cogs/ gefunden. Ist der Command noch nicht implementiert oder via Config-Flag aktiviert? Falls Command geplant: Doku in README + api.md nachtragen sobald implementiert.",
+      "created": "2026-05-21",
+      "status": "open"
+    }
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ shadowops-bot/
 │   └── PROJECT_*.md              # Per-projekt-Notizen
 ├── deploy/
 │   ├── shadowops-bot.service          # systemd Bot-Service
-│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (6x HTTP/systemd + Backup-Test)
+│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (8 Watchdogs: HTTP/systemd/jq-filter/build-drift + Backup-Test)
 │   ├── shadowops-watchdog.env.example # Webhook-Env Template
 │   └── MONITORING_SETUP.md            # Setup-Anleitung Watchdogs
 ├── .github/
@@ -97,7 +97,7 @@ shadowops-bot/
 
 ## Externes Monitoring (seit 2026-05-17 — Defense-in-Depth)
 
-Zusätzlich zum internen `project_monitor.py` laufen 5 unabhängige user-systemd Watchdogs, die alle 5 Minuten ihre Services prüfen und Down/Recovery direkt via Discord-Webhook in `#🩺-uptime-alerts` posten (NICHT über den Bot — funktioniert auch wenn shadowops-bot tot ist):
+Zusätzlich zum internen `project_monitor.py` laufen 8 unabhängige user-systemd Watchdogs (Zyklen: 5–15 min je nach Watchdog, cmdshadow-design 1h, Backup-Test monatlich) und posten Down/Recovery direkt via Discord-Webhook in `#🩺-uptime-alerts` (NICHT über den Bot — funktioniert auch wenn shadowops-bot tot ist):
 
 | Watchdog | Mode | Target |
 |---|---|---|
@@ -108,6 +108,7 @@ Zusätzlich zum internen `project_monitor.py` laufen 5 unabhängige user-systemd
 | `ai-agent-framework-watchdog` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent |
 | `cmdshadow-design-watchdog` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h, 1h-Cycle) |
 | `mayday-ci-runner-watchdog` | http + jq-filter | http://10.8.0.10:9100/health, filter=`.components.ci_runner.ok` (#mayday-sim#425) |
+| `mayday-sim-build-drift-watchdog` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD — Alert bei >30 min Drift, Zyklus 15 min (#mayday-sim#416) |
 | `shadowops-backup-test` | — | monatlich 1. d. Monats, Wrapper um `~/ZERODOX/scripts/backup-test.sh` |
 
 **Script:** `scripts/service-watchdog.sh` (generisch, parametrisiert) und `scripts/bot-watchdog.sh` (Backward-Compat). **Service-Files:** `deploy/<name>-watchdog.{service,timer}`. **Webhook-Config:** `~/.config/shadowops-watchdog.env` (chmod 600). **Setup-Anleitung:** [`deploy/MONITORING_SETUP.md`](./deploy/MONITORING_SETUP.md).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Event → TaskRouter → Codex CLI (Primary)
 - `/projekt-status [name]` - Status für spezifisches Projekt (Uptime, Response Time, Health)
 - `/alle-projekte` - Übersicht aller überwachten Projekte
 
+#### Mobile Workflow (Owner-only)
+- `/claude [prompt] [project] [model] [timeout]` - Headless Claude-Session auf dem Server starten und Antwort in Discord empfangen (owner-only)
+
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
 - **Multi-Channel Support** - Kategorisierte Channels (Security, AI Learning, Deployments, etc.)
@@ -339,6 +342,7 @@ shadowops-bot/
 │   │   ├── inspector.py                # /get-ai-stats, /projekt-status, /agent-stats, ...
 │   │   ├── monitoring.py               # /status, /bans, /threats, /docker, /aide
 │   │   ├── customer_setup_commands.py  # /setup-customer-server
+│   │   ├── claude_cli.py               # /claude (owner-only Mobile-Trigger)
 │   │   ├── cron_heartbeat.py           # Cron-Heartbeat
 │   │   └── phase_5e_health_aggregator.py  # Health-Aggregation
 │   ├── integrations/
@@ -535,7 +539,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for detailed version history.
 - **PostgreSQL Databases**: 3 (security_analyst: 21 Tabellen, agent_learning: 7 Tabellen, seo_agent: 11 Tabellen)
 - **Learning Pipeline Tables**: 11 (Security: fix_attempts, fix_verifications, finding_quality, scan_coverage · Shared: agent_feedback, agent_quality_scores, agent_knowledge · Patch Notes: pn_generations, pn_variants, pn_examples · SEO: seo_fix_impact)
 - **Scan Areas**: 10 (firewall, ssh, docker, permissions, packages, services, logs, network, credentials, dependencies)
-- **Discord Commands**: 15 (inkl. /agent-stats)
+- **Discord Commands**: 16 (inkl. /agent-stats, /claude)
 - **Monitored Projects**: 3 (GuildScout, ZERODOX, AI Agents)
 - **Auto Discord-Posts**: Session-Summaries, Feedback-Auswertungen, Weekly Summary, Meilensteine
 

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -115,6 +115,8 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 | `mayday-sim` | http | http://127.0.0.1:3200/api/health | 5 min | 5 min |
 | `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 5 min | 6 min |
 | `cmdshadow-design` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h) | 1 h | 8 min |
+| `mayday-ci-runner` | http + jq-filter | http://10.8.0.10:9100/health, filter `.components.ci_runner.ok` (#mayday-sim#425) | 5 min | 7 min |
+| `mayday-sim-build-drift` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD (max. 30 min Drift, #mayday-sim#416) | 15 min | 2 min |
 
 Pro Service:
 - **🔴 \<service\> DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).
@@ -136,11 +138,12 @@ DNS-Auflösung + Traefik-Routing + TLS-Zertifikat + App-Health in einem.
 ## Wartung / Inspektion
 
 ```bash
-# Alle 7 Timer auf einen Blick
+# Alle 9 Timer auf einen Blick
 systemctl --user list-timers \
   shadowops-watchdog.timer zerodox-watchdog.timer guildscout-watchdog.timer \
   mayday-sim-watchdog.timer ai-agent-framework-watchdog.timer \
-  cmdshadow-design-watchdog.timer shadowops-backup-test.timer
+  cmdshadow-design-watchdog.timer shadowops-backup-test.timer \
+  mayday-ci-runner-watchdog.timer mayday-sim-build-drift-watchdog.timer
 
 # Letzten 50 Läufe pro Service
 journalctl --user -u shadowops-watchdog.service --no-pager -n 50

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -26,11 +26,13 @@
             /api/health                                  (3 Core-Agents)
 ```
 
-Alle sechs Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
+Alle Watchdogs nutzen `scripts/service-watchdog.sh` — ein generisches
 Script, parametrisiert via Env-Vars. Drei Modi:
 - `WATCHDOG_MODE=http` (Default): curl auf `WATCHDOG_HEALTH_URL`
 - `WATCHDOG_MODE=systemd`: prüft `systemctl is-active` für jede Unit in `WATCHDOG_SYSTEMD_UNITS` (Komma-separiert)
 - `WATCHDOG_MODE=systemd-result`: prüft Result + Alter (`ExecMainStartTimestamp`) des letzten Laufs für oneshot/Daily-Jobs. `WATCHDOG_MAX_AGE_HOURS` (Default 36h) — bei `stale_*h` → DOWN.
+
+**Optionaler JSON-Pfad-Filter (http-Mode):** `WATCHDOG_HEALTH_JQ_FILTER` — wenn gesetzt, wird der HTTP-Statuscode ignoriert und stattdessen eine jq-Boolean-Expression gegen den Response-Body ausgewertet. Nützlich wenn ein Endpoint HTTP 503 zurückgibt sobald *irgendeine* Komponente kaputt ist, aber nur eine bestimmte Komponente überwacht werden soll. Beispiel: `WATCHDOG_HEALTH_JQ_FILTER=.components.ci_runner.ok`. Test-Coverage: `tests/unit/test_service_watchdog_jq_filter.py`.
 
 Das ursprüngliche `scripts/bot-watchdog.sh` bleibt als Backward-Compat-Variante
 für den shadowops-bot Watchdog erhalten.
@@ -85,6 +87,8 @@ systemctl --user restart ai-agent-framework-watchdog.timer
 systemctl --user restart cmdshadow-design-watchdog.timer
 # Seit #416: Build-Drift-Detection fuer mayday-sim
 systemctl --user restart mayday-sim-build-drift-watchdog.timer
+# Seit #273: CI-Runner-Health mit jq-Filter (mayday-sim#437)
+systemctl --user restart mayday-ci-runner-watchdog.timer
 ```
 
 ### 4. Funktionstest

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -315,6 +315,32 @@ Shows overview of all monitored projects.
 
 ---
 
+### Mobile Workflow Commands
+
+#### `/claude`
+Starts a headless Claude CLI session on the server and returns the output as Discord messages. Designed for the owner to trigger Claude tasks from mobile without SSH.
+
+**Permissions:** Owner-only (user ID check, not role-based)
+**Parameters:**
+- `prompt` (required): The task for Claude
+- `project` (optional): Working directory — one of `home`, `zerodox`, `guildscout`, `shadowops`, `agents`, `sharedui`, `design` (default: `home`)
+- `model` (optional): `sonnet` (default), `opus`, `haiku`
+- `timeout` (optional): Seconds until abort (default: 300, max: 600)
+
+**Returns:** Header embed (model, elapsed, exit code) followed by Claude's output in code-block chunks (≤1900 chars each)
+
+**Security notes:**
+- Project paths are a fixed whitelist — no path traversal possible
+- Any user other than the owner receives an ephemeral error
+- Requires `claude` CLI at `~/.local/bin/claude`
+
+**Example:**
+```
+/claude prompt:"run tests in shadowops" project:shadowops model:sonnet
+```
+
+---
+
 ## Configuration Reference
 
 ### Complete `config/config.yaml` Structure


### PR DESCRIPTION
## Änderungen

### Commit 1 — /claude Cog-Dokumentation
- **README.md — Slash Commands**: `/claude` unter neuer Sektion "Mobile Workflow (Owner-only)" ergänzt mit Kurzbeschreibung aller Parameter
- **README.md — Projekt-Struktur**: `claude_cli.py` in die Cogs-Liste eingetragen
- **README.md — Statistiken**: Discord-Commands-Zähler 15 → 16
- **.claude/rules/discord-bot.md**: `ClaudeCLICog` mit `/claude`-Eintrag in die Cogs-Tabelle aufgenommen
- **docs/reference/api.md**: Neuer Abschnitt "Mobile Workflow Commands → /claude" mit Parametern, Rückgabewert, Security-Notes und Beispiel

### Commit 2 — Watchdog-Tabellen-Drift
- **CLAUDE.md**: `mayday-sim-build-drift-watchdog` in die Watchdog-Tabelle eingetragen (fehlte komplett)
- **CLAUDE.md**: Watchdog-Zähler korrigiert (5→8 in Beschreibung, 6x→8 in deploy/-Kommentar)
- **deploy/MONITORING_SETUP.md**: `mayday-ci-runner` und `mayday-sim-build-drift` in die Alert-Tabelle eingetragen
- **deploy/MONITORING_SETUP.md**: `list-timers`-Befehl in Wartungs-Sektion auf 9 Timer erweitert
- **.routines/state/doku.json**: State-Update mit aktuellem Lauf-Timestamp

### Commit 3 — MONITORING_SETUP.md Ergänzungen (2026-05-23)
- **deploy/MONITORING_SETUP.md**: `WATCHDOG_HEALTH_JQ_FILTER` im Modi-Abschnitt erklärt — war in CLAUDE.md dokumentiert, fehlte in MONITORING_SETUP.md
- **deploy/MONITORING_SETUP.md**: `mayday-ci-runner-watchdog.timer` zum systemd-Reload-Block ergänzt (fehlte noch im Erst-Einrichtungs-Abschnitt)
- **deploy/MONITORING_SETUP.md**: "Alle sechs Watchdogs" → "Alle Watchdogs" (Zahl war veraltet, jetzt 9)
- **.routines/state/doku.json**: State-Update 2026-05-23

## Begründung

**Commit 1:** Cog `src/cogs/claude_cli.py` wurde mit PR #263 (`feat: /claude Mobile-Workflow Slash-Command`) gemergt. Die Dokumentation in README, api.md und discord-bot.md wurde dabei nicht mitgezogen.

**Commit 2 (Refresh 2026-05-22):**
- `mayday-sim-build-drift-watchdog` Service-File liegt seit PR #416/Commit `d6edbdc` in `deploy/`, ist aber in keiner Doku-Tabelle aufgetaucht.
- `mayday-ci-runner-watchdog` wurde per Commit `519813b` in CLAUDE.md nachgetragen, fehlte aber weiterhin in MONITORING_SETUP.md.

**Commit 3 (Refresh 2026-05-23):**
- `WATCHDOG_HEALTH_JQ_FILTER` wurde via feat(watchdog) PR #273 (Commit `11a4a7d`, 2026-05-20) eingeführt. CLAUDE.md wurde direkt via Commit `519813b` aktualisiert, aber MONITORING_SETUP.md hatte nur den tabellarischen Eintrag aus Commit 2 — keine Erklärung des Features.
- `mayday-ci-runner-watchdog.timer` fehlte noch im Erst-Einrichtungs-Restart-Block (war nur in der Alert-Tabelle und list-timers).

## open_questions (kein PR — zu unsicher)

`src/integrations/zerodox_auto_fix_gate.py` Docstring erwähnt `/zerodox-auto-fix-toggle` als Aktivierungs-Command, aber kein `app_commands.command()` dafür in `src/cogs/` gefunden. Ist der Command noch nicht implementiert? Falls ja, muss er in README + api.md nachgetragen werden. Tracking in `.routines/state/doku.json:open_questions`.

## Refresh-Historie

- 2026-05-21: Erstellt (Commit 1: /claude Cog-Docs)
- 2026-05-22: Refreshed — Commit 2 hinzugefügt (Watchdog-Tabellen-Drift: mayday-ci-runner + build-drift)
- 2026-05-23: Refreshed — Commit 3 hinzugefügt (WATCHDOG_HEALTH_JQ_FILTER-Erklärung + mayday-ci-runner Restart-Block + "Alle sechs" → "Alle")