### PR TITLE
feat(github): Discord-Alert bei direct-push auf main (Auto-Deploy-Block-Notification)

### DIFF
--- a/src/integrations/github_integration/core.py
+++ b/src/integrations/github_integration/core.py
@@ -110,6 +110,14 @@ class GitHubIntegration(JulesWorkflowMixin,
         self.runner = None
         self.site = None
 
+        # Direct-Push-Alert Dedup-Cache (FIFO, max 100 Eintraege, TTL 1h).
+        # Vermeidet Spam-Alerts bei force-pushes auf denselben SHA.
+        # Schluessel: f"{repo}:{sha}", Wert: monotonic-Timestamp (Sekunden).
+        # Siehe NotificationsMixin._send_direct_push_alert.
+        self._direct_push_alert_cache: Dict[str, float] = {}
+        self._direct_push_alert_cache_max = 100
+        self._direct_push_alert_cache_ttl_seconds = 3600
+
         # Jules SecOps Workflow — lazy init (async connect in _jules_startup)
         jules_raw = _get_section('jules_workflow', {})
         self._jules_enabled = bool(jules_raw.get('enabled', False))

--- a/src/integrations/github_integration/event_handlers_mixin.py
+++ b/src/integrations/github_integration/event_handlers_mixin.py
@@ -80,6 +80,28 @@ class EventHandlersMixin:
                     f"Use a Branch+PR workflow with mandatory review."
                 )
 
+                # Discord-Alert posten: ohne diese Notification entsteht silent
+                # inconsistency (Code in main, nicht deployed). Per-SHA Dedup
+                # verhindert Spam bei force-pushes. Siehe _send_direct_push_alert.
+                head_commit_obj = payload.get('head_commit') or {}
+                commit_msg = head_commit_obj.get('message') or ''
+                if not commit_msg and commits:
+                    commit_msg = commits[-1].get('message', '') or ''
+                try:
+                    await self._send_direct_push_alert(
+                        repo=normalized_repo,
+                        branch=branch,
+                        sha=head_commit or '',
+                        commit_message=commit_msg,
+                        pusher=pusher,
+                    )
+                except Exception as alert_err:
+                    # Alert-Fehler darf den Push-Handler nicht crashen
+                    self.logger.error(
+                        f"❌ Direct-Push-Alert fehlgeschlagen: {alert_err}",
+                        exc_info=True,
+                    )
+
         except Exception as e:
             self.logger.error(f"❌ Error handling push event: {e}", exc_info=True)
 

--- a/src/integrations/github_integration/notifications_mixin.py
+++ b/src/integrations/github_integration/notifications_mixin.py
@@ -1406,6 +1406,97 @@ class NotificationsMixin:
 
         await channel.send(embed=embed)
 
+    async def _send_direct_push_alert(
+        self,
+        repo: str,
+        branch: str,
+        sha: str,
+        commit_message: str,
+        pusher: str,
+    ):
+        """
+        Discord-Alert bei direct-push auf main (Auto-Deploy-Block-Notification).
+
+        Hintergrund: Seit PR #135 / Issue #131 (2026-04-17) ist Auto-Deploy auf
+        direct-Pushes geblockt. Ohne diese Notification entsteht silent
+        inconsistency — Code in main, aber nicht deployed.
+
+        Dedup pro Repo+SHA via Instanz-Cache (FIFO, max 100 Eintraege, TTL 1h).
+        Channel-Fehler werden geloggt aber nicht propagiert (best-effort).
+        """
+        import time as _t
+
+        cache_key = f"{repo}:{sha}"
+        now = _t.monotonic()
+        cache = self._direct_push_alert_cache
+        ttl = self._direct_push_alert_cache_ttl_seconds
+
+        # TTL-Cleanup (lazy, beim Schreibzugriff)
+        expired_keys = [k for k, ts in cache.items() if now - ts > ttl]
+        for k in expired_keys:
+            cache.pop(k, None)
+
+        # Dedup-Check
+        if cache_key in cache:
+            self.logger.debug(
+                f"⏭️ Direct-Push-Alert geskippt (dedup): {cache_key}"
+            )
+            return
+
+        # FIFO-Eviction wenn voll
+        if len(cache) >= self._direct_push_alert_cache_max:
+            # Aelteste rauswerfen (insert-order ist FIFO bei dict)
+            try:
+                oldest_key = next(iter(cache))
+                cache.pop(oldest_key, None)
+            except StopIteration:
+                pass
+
+        cache[cache_key] = now
+
+        channel = self.bot.get_channel(self.deployment_channel_id)
+        if not channel:
+            self.logger.warning(
+                f"⚠️ Direct-Push-Alert kann nicht gesendet werden: "
+                f"deployment_log channel ({self.deployment_channel_id}) nicht gefunden."
+            )
+            return
+
+        short_sha = sha[:7] if sha else '-'
+        # Erste Zeile der Commit-Message (Subject)
+        commit_subject = (commit_message or '').splitlines()[0][:200] if commit_message else '-'
+
+        embed = discord.Embed(
+            title="⚠️ Direct push detected — Auto-Deploy BLOCKIERT",
+            description=(
+                f"**{repo}** hat einen direct-push auf `{branch}` empfangen. "
+                f"Aus Security-Gruenden (PR #135 / Issue #131) wurde der "
+                f"Auto-Deploy NICHT ausgefuehrt — der Code ist in `{branch}`, "
+                f"aber **nicht auf dem Server**."
+            ),
+            color=discord.Color.orange(),
+            timestamp=datetime.now(timezone.utc),
+        )
+        embed.add_field(name="Repository", value=repo, inline=True)
+        embed.add_field(name="Branch", value=f"`{branch}`", inline=True)
+        embed.add_field(name="Commit", value=f"`{short_sha}`", inline=True)
+        embed.add_field(name="Pusher", value=pusher or '-', inline=True)
+        embed.add_field(name="Message", value=commit_subject, inline=False)
+        embed.add_field(
+            name="Aktion",
+            value="Run on server: `scripts/restart.sh --pull`",
+            inline=False,
+        )
+        embed.set_footer(text="Auto-Deploy-Block | PR #135 / Issue #131")
+
+        try:
+            await channel.send(embed=embed)
+        except Exception as e:
+            self.logger.error(
+                f"❌ Direct-Push-Alert konnte nicht gesendet werden: {e}",
+                exc_info=True,
+            )
+
     async def _send_release_notification(
         self, action: str, repo: str, tag: str, name: str,
         author: str, is_prerelease: bool, url: str

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -151,6 +151,195 @@ class TestPushEventHandling:
         integration._send_push_notification.assert_called_once()
 
 
+class TestDirectPushAlert:
+    """
+    Tests fuer den Discord-Alert beim direct-push auf main mit aktivem auto_deploy
+    (Auto-Deploy-Block-Notification — verhindert silent inconsistency).
+    Hintergrund: PR #135 / Issue #131 — Auto-Deploy auf direct-push ist GEBLOCKT.
+    Aber: Niemand wird informiert. Heute (2026-05-24) gab es 3 direct-pushes,
+    alle korrekt geblockt, aber kein Alert. Dieser Test fordert das Alert ein.
+    """
+
+    @pytest.mark.asyncio
+    async def test_direct_push_to_main_triggers_alert(self, mock_bot, enabled_config):
+        """Direct-Push auf main + auto_deploy=True → Discord-Alert wird gesendet."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration._trigger_deployment = AsyncMock()
+        integration._send_push_notification = AsyncMock()
+        integration._send_direct_push_alert = AsyncMock()
+        integration._reserve_commit_processing = Mock(return_value=True)
+
+        payload = {
+            'repository': {
+                'name': 'shadowops-bot',
+                'full_name': 'Commandershadow9/shadowops-bot',
+                'html_url': 'https://github.com/Commandershadow9/shadowops-bot'
+            },
+            'ref': 'refs/heads/main',
+            'pusher': {'name': 'CommanderShadow'},
+            'head_commit': {'id': 'abc1234567890def'},
+            'commits': [
+                {
+                    'id': 'abc1234567890def',
+                    'message': 'fix: typo in docstring\n\nLonger body here',
+                    'author': {'name': 'CommanderShadow'}
+                }
+            ]
+        }
+
+        await integration.handle_push_event(payload)
+
+        integration._send_direct_push_alert.assert_called_once()
+        call_kwargs = integration._send_direct_push_alert.call_args.kwargs
+        assert call_kwargs['repo'] == 'shadowops-bot'
+        assert call_kwargs['branch'] == 'main'
+        assert call_kwargs['sha'] == 'abc1234567890def'
+        assert call_kwargs['pusher'] == 'CommanderShadow'
+        # Erste Zeile der Commit-Message kommt im Embed nochmal vor —
+        # hier reichen wir die volle message durch, der Builder splittet.
+        assert 'fix: typo in docstring' in call_kwargs['commit_message']
+
+    @pytest.mark.asyncio
+    async def test_direct_push_to_feature_branch_does_not_trigger_alert(
+        self, mock_bot, enabled_config
+    ):
+        """Push auf non-deploy-branch → KEIN Alert."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration._trigger_deployment = AsyncMock()
+        integration._send_push_notification = AsyncMock()
+        integration._send_direct_push_alert = AsyncMock()
+        integration._reserve_commit_processing = Mock(return_value=True)
+
+        payload = {
+            'repository': {
+                'name': 'shadowops-bot',
+                'full_name': 'Commandershadow9/shadowops-bot',
+                'html_url': 'https://github.com/Commandershadow9/shadowops-bot'
+            },
+            'ref': 'refs/heads/feat/some-branch',
+            'pusher': {'name': 'CommanderShadow'},
+            'head_commit': {'id': 'feedface'},
+            'commits': [
+                {'id': 'feedface', 'message': 'wip', 'author': {'name': 'CommanderShadow'}}
+            ]
+        }
+
+        await integration.handle_push_event(payload)
+
+        integration._send_direct_push_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_direct_push_alert_is_deduped_per_sha(self, mock_bot, enabled_config):
+        """Selber SHA zweimal (force-push) → nur 1 Alert."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration._trigger_deployment = AsyncMock()
+        integration._send_push_notification = AsyncMock()
+        integration._reserve_commit_processing = Mock(return_value=True)
+
+        # Wir verifizieren das Dedup-Verhalten via Channel.send Mock (echte Methode laufen lassen).
+        channel = mock_bot.get_channel.return_value
+        channel.send.reset_mock()
+
+        payload = {
+            'repository': {
+                'name': 'shadowops-bot',
+                'full_name': 'Commandershadow9/shadowops-bot',
+                'html_url': 'https://github.com/Commandershadow9/shadowops-bot'
+            },
+            'ref': 'refs/heads/main',
+            'pusher': {'name': 'CommanderShadow'},
+            'head_commit': {'id': 'deadbeef12345'},
+            'commits': [
+                {'id': 'deadbeef12345', 'message': 'fix: thing', 'author': {'name': 'CommanderShadow'}}
+            ]
+        }
+
+        # Erster Push → Alert
+        await integration.handle_push_event(payload)
+        first_call_count = channel.send.call_count
+        assert first_call_count >= 1, "Erster Direct-Push muss Alert senden"
+
+        # Reset reserve_commit_processing dedup (push handler-level dedup)
+        # damit handle_push_event nicht selbst dedupe-skipped — wir wollen den
+        # SHA-Dedup im Alert testen, nicht den push-event-Dedup.
+        integration._reserve_commit_processing = Mock(return_value=True)
+
+        # Zweiter Push mit gleichem SHA → KEIN zusaetzlicher Alert
+        await integration.handle_push_event(payload)
+        second_call_count = channel.send.call_count
+        assert second_call_count == first_call_count, (
+            f"Zweiter Push mit gleichem SHA darf KEINEN weiteren Alert senden "
+            f"(first={first_call_count}, second={second_call_count})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_direct_push_alert_uses_deployment_channel(
+        self, mock_bot, enabled_config
+    ):
+        """_send_direct_push_alert resolved deployment_log Channel und sendet Embed."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        channel = mock_bot.get_channel.return_value
+        channel.send.reset_mock()
+
+        await integration._send_direct_push_alert(
+            repo='shadowops-bot',
+            branch='main',
+            sha='abc1234567890',
+            commit_message='fix: typo',
+            pusher='CommanderShadow',
+        )
+
+        # Channel-Resolution muss deployment_log nutzen
+        mock_bot.get_channel.assert_any_call(enabled_config.channels['deployment_log'])
+        # Embed muss gesendet worden sein
+        assert channel.send.called
+        send_kwargs = channel.send.call_args.kwargs
+        assert 'embed' in send_kwargs
+        embed = send_kwargs['embed']
+        # Titel + Felder pruefen
+        assert 'Direct push' in embed.title or 'BLOCKIERT' in embed.title
+
+    @pytest.mark.asyncio
+    async def test_send_direct_push_alert_no_channel_logs_warning(
+        self, mock_bot, enabled_config
+    ):
+        """Kein Channel gefunden → Logger-Warnung, kein Crash."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        # Channel-Lookup fehlschlagen lassen
+        mock_bot.get_channel = Mock(return_value=None)
+
+        # Darf NICHT crashen
+        await integration._send_direct_push_alert(
+            repo='shadowops-bot',
+            branch='main',
+            sha='abc1234567',
+            commit_message='fix: x',
+            pusher='Tester',
+        )
+        # Soft-Assertion: keine Exception ist der eigentliche Pass.
+
+    @pytest.mark.asyncio
+    async def test_direct_push_alert_cache_eviction(self, mock_bot, enabled_config):
+        """Cache evicted alte Eintraege wenn ueber MAX (100) — kein Memory-Leak."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        channel = mock_bot.get_channel.return_value
+
+        # 101 unique SHAs senden — der erste soll evicted sein
+        for i in range(101):
+            channel.send.reset_mock()
+            await integration._send_direct_push_alert(
+                repo='shadowops-bot',
+                branch='main',
+                sha=f'sha{i:08d}',
+                commit_message=f'commit {i}',
+                pusher='Tester',
+            )
+
+        # Cache MUSS <= 100 Eintraege haben (FIFO-Eviction)
+        cache = integration._direct_push_alert_cache
+        assert len(cache) <= 100, f"Cache exceeded 100 entries: {len(cache)}"
+
+
 class TestPullRequestHandling:
     """Tests for pull request event handling."""
 


### PR DESCRIPTION
## Warum

Seit PR #135 / Issue #131 (2026-04-17) ist Auto-Deploy auf direct-Pushes auf `main` **geblockt** (Security-Gate). Das ist gewollt — un-reviewed Code soll nicht deployt werden.

Aber: bisher gab es nur einen **Logger-WARNING**, keinen Discord-Alert. Wenn jemand das nicht im Log sieht, ist der Code in `main`, aber **nicht auf dem Server**. Silent inconsistency.

**Heute (2026-05-24)** wurden 3 direct-pushes von cmdshadow auf shadowops-bot/main korrekt geblockt:
1. drift-watchdog deploy
2. PR #274 squash
3. docstring fix

Alle drei: kein Alert. Drift Server↔Repo wurde erst beim manuellen `scripts/restart.sh --pull` bemerkt.

## Was

Wenn der existierende Auto-Deploy-Block in `event_handlers_mixin.py:77-81` greift, postet der Bot jetzt einen Embed in `#deployment-log`:

```
⚠️ Direct push detected — Auto-Deploy BLOCKIERT
**shadowops-bot** hat einen direct-push auf `main` empfangen. Aus Security-Gruenden
(PR #135 / Issue #131) wurde der Auto-Deploy NICHT ausgefuehrt — der Code ist in
`main`, aber nicht auf dem Server.

Repository: shadowops-bot   Branch: `main`   Commit: `abc1234`
Pusher: CommanderShadow
Message: fix: typo in docstring
Aktion: Run on server: `scripts/restart.sh --pull`
```

## Wie

- **Channel-Resolution:** `self.bot.get_channel(self.deployment_channel_id)` — exakt dasselbe Pattern wie `_send_deployment_success`/`_send_release_notification`.
- **Dedup-Cache:** Instanz-`dict` (insert-order = FIFO) in `core.py.__init__`, max 100 Eintraege, TTL 1h. Schluessel: `f"{repo}:{sha}"`. Schuetzt vor Spam bei force-pushes & doppelten Webhook-Deliveries.
- **Fail-Safe:** Channel nicht gefunden → Logger-Warnung, kein Crash. Alert-Exceptions im Push-Handler abgefangen — Alert-Fehler darf den Push-Handler nicht crashen.
- **Block selbst unveraendert:** Auto-Deploy bleibt geblockt (das ist gewollt, Teil von PR #135). Diese PR FÜGT NUR ein Alert hinzu.

## Tests

6 neue Tests in `tests/unit/test_github_integration.py::TestDirectPushAlert`:

- main + auto_deploy → Alert mit korrekten Feldern
- feature-branch + auto_deploy → KEIN Alert
- selber SHA zweimal → nur 1 Alert (Dedup)
- Channel-Resolution → deployment_log + Embed gesendet
- Channel nicht gefunden → kein Crash
- Cache evicted nach 100 Eintraegen (kein Memory-Leak)

Run lokal: 31 passed, 1 warning in 0.27s. Keine Regressionen.

## Test plan

- [ ] `pytest tests/unit/test_github_integration.py::TestDirectPushAlert -v --no-cov`
- [ ] Code-Review: `_send_direct_push_alert` in `notifications_mixin.py`
- [ ] Confirmation: Auto-Deploy bleibt geblockt (kein Verhalten-Change am Block selbst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)