### PR TITLE
docs: Drift-Korrekturen — security_engine/ + fixers/ + patch_notes/ + schemas/ + Watchdog-Count + pytest -x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 | AI Fallback | Claude CLI | claude-sonnet-4-6 / claude-opus-4-6 |
 | Container | Docker | mit Trivy fuer Scans |
 | Service | systemd | `/etc/systemd/system/shadowops-bot.service` |
-| Tests | pytest | 150+ Tests, unit + integration |
+| Tests | pytest | 250+ Tests, unit + integration |
 | Webhook | GitHub Webhooks | HMAC-SHA256 verifiziert |
 
 ## Architektur-Prinzipien
@@ -44,9 +44,11 @@ shadowops-bot/
 │   ├── bot.py                    # Haupt-Bot
 │   ├── cogs/                     # Slash-Commands (admin, inspector, monitoring)
 │   ├── integrations/             # Externe Systeme (siehe unten)
-│   └── utils/                    # config, logging, embeds, state
+│   ├── patch_notes/              # Patch Notes Pipeline v6 (5-Stufen State Machine, ~2100 Zeilen)
+│   ├── schemas/                  # JSON-Schemas fuer Structured Output (fix_strategy, patch_notes, incident_analysis, jules_review)
+│   └── utils/                    # config, logging, embeds, state, alert_humanizer
 ├── tests/
-│   ├── unit/                     # 161+ Unit-Tests
+│   ├── unit/                     # 250+ Unit-Tests
 │   ├── integration/              # End-to-End-Workflows
 │   └── conftest.py
 ├── config/
@@ -57,7 +59,7 @@ shadowops-bot/
 │   └── PROJECT_*.md              # Per-projekt-Notizen
 ├── deploy/
 │   ├── shadowops-bot.service          # systemd Bot-Service
-│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (10 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift + Backup-Test)
+│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (11 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift + Backup-Test)
 │   ├── shadowops-watchdog.env.example # Webhook-Env Template
 │   └── MONITORING_SETUP.md            # Setup-Anleitung Watchdogs
 ├── .github/
@@ -71,7 +73,8 @@ shadowops-bot/
 │   ├── SETUP_GUIDE.md
 │   ├── reference/api.md
 │   ├── adr/                      # Architecture Decision Records
-│   └── plans/                    # Design-Dokumente
+│   ├── design/                   # Design-Dokumente (aktuelle Planung)
+│   └── plans/                    # Aeltere Design-Dokumente (archiviert)
 ├── data/                         # Runtime-Daten (gitignored)
 ├── logs/                         # Logs (gitignored)
 ├── .claude/                      # KI-spezifische Configs
@@ -89,11 +92,13 @@ shadowops-bot/
 - `code_analyzer.py` — Code Structure Analyzer (Git-History + AST)
 - `context_manager.py` — RAG: Project-Context + DO-NOT-TOUCH + Infra
 - `github_integration/` — Webhooks mit HMAC-SHA256 Verification + Jules Workflow (Package: core, webhook_mixin, event_handlers_mixin, jules_workflow_mixin, notifications_mixin, ci_mixin, agent_review/)
+- `security_engine/` — Autonomer SecurityScanAgent (scan_agent.py), CircuitBreaker, DB-Layer (db.py), Fixer-Adapters, ActivityMonitor, LearningBridge, Prompts (Package: engine, scan_agent, reactive, proactive, deep_scan, executor, fixer_adapters, learning_bridge, activity_monitor, prompts, models, db, migrations)
+- `fixers/` — Konkrete Fix-Implementierungen: fail2ban_fixer.py, crowdsec_fixer.py, aide_fixer.py, trivy_fixer.py, walg_fixer.py
 - `project_monitor.py` — Multi-Project Health-Checks
 - `deployment_manager.py` — Auto-Deploy mit Backup/Rollback. **WICHTIG:** Project-Name-Lookup ist dash↔underscore-tolerant (`mayday-sim` ↔ `mayday_sim`, seit 2026-05-25 — siehe `.claude/rules/safety.md`). Gleiche Logik in `github_integration/ci_mixin.py:_trigger_deployment()`.
 - `incident_manager.py` — Incident Threads in Discord
 - `customer_notifications.py` — Customer-Facing Alerts (Multi-Guild)
-- `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Integrationen
+- `fail2ban.py` / `crowdsec.py` / `aide.py` / `docker.py` — Security-Event-Quellen (Monitoring-Integrationen)
 
 ## Externes Monitoring (seit 2026-05-17 — Defense-in-Depth)
 
@@ -238,7 +243,7 @@ Worker-Konventionen:
 
 ## Statistik (Stand v5.1)
 
-20.000+ LoC, 150+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
+20.000+ LoC, 250+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
 
 ## Aktuelle Doku
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 | AI Fallback | Claude CLI | claude-sonnet-4-6 / claude-opus-4-6 |
 | Container | Docker | mit Trivy fuer Scans |
 | Service | systemd | `/etc/systemd/system/shadowops-bot.service` |
-| Tests | pytest | 250+ Tests, unit + integration |
+| Tests | pytest | 700+ Tests, unit + integration |
 | Webhook | GitHub Webhooks | HMAC-SHA256 verifiziert |
 
 ## Architektur-Prinzipien
@@ -48,7 +48,7 @@ shadowops-bot/
 │   ├── schemas/                  # JSON-Schemas fuer Structured Output (fix_strategy, patch_notes, incident_analysis, jules_review)
 │   └── utils/                    # config, logging, embeds, state, alert_humanizer
 ├── tests/
-│   ├── unit/                     # 250+ Unit-Tests
+│   ├── unit/                     # 700+ Unit-Tests
 │   ├── integration/              # End-to-End-Workflows
 │   └── conftest.py
 ├── config/
@@ -59,7 +59,7 @@ shadowops-bot/
 │   └── PROJECT_*.md              # Per-projekt-Notizen
 ├── deploy/
 │   ├── shadowops-bot.service          # systemd Bot-Service
-│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (11 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift + Backup-Test)
+│   ├── *-watchdog.{service,timer}     # Externe Uptime-Watchdogs (14 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift + Backup-Test)
 │   ├── shadowops-watchdog.env.example # Webhook-Env Template
 │   └── MONITORING_SETUP.md            # Setup-Anleitung Watchdogs
 ├── .github/
@@ -243,7 +243,7 @@ Worker-Konventionen:
 
 ## Statistik (Stand v5.1)
 
-20.000+ LoC, 250+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
+20.000+ LoC, 700+ Tests, 3 PostgreSQL DBs (21+7+11 Tabellen), 4 Security-Integrationen, 15 Discord-Commands, 3 Monitored Projects (GuildScout, ZERODOX, AI Agents).
 
 ## Aktuelle Doku
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ shadowops-bot/
 │   ├── integrations/             # Externe Systeme (siehe unten)
 │   ├── patch_notes/              # Patch Notes Pipeline v6 (5-Stufen State Machine, ~2100 Zeilen)
 │   ├── schemas/                  # JSON-Schemas fuer Structured Output (fix_strategy, patch_notes, incident_analysis, jules_review)
-│   └── utils/                    # config, logging, embeds, state, alert_humanizer
+│   └── utils/                    # config, logging, embeds, state, alert_humanizer, health_server, message_handler, circuit_breaker, changelog_parser, process_lock
 ├── tests/
 │   ├── unit/                     # 700+ Unit-Tests
 │   ├── integration/              # End-to-End-Workflows

--- a/README.md
+++ b/README.md
@@ -381,7 +381,12 @@ shadowops-bot/
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
 │       ├── discord_logger.py           # Discord Channel Logger
-│       └── alert_humanizer.py          # Status-Telemetrie zu mensch-lesbarem Deutsch
+│       ├── alert_humanizer.py          # Status-Telemetrie zu mensch-lesbarem Deutsch
+│       ├── health_server.py            # HTTP /health-Endpoint + Changelog REST API
+│       ├── message_handler.py          # Discord Rate-Limit + Message-Splitting
+│       ├── circuit_breaker.py          # Leichtgewichtiger Circuit Breaker (Util-Variante)
+│       ├── changelog_parser.py         # CHANGELOG.md Parser fuer Patch Notes
+│       └── process_lock.py             # Cross-Process Singleton Lock (fcntl + Stale-Detection)
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
 │   ├── unit/                           # Unit Tests (700+, 67 Dateien)

--- a/README.md
+++ b/README.md
@@ -311,15 +311,18 @@ Multi-Project:
 pip3 install -r requirements.txt
 pip3 install -r requirements-dev.txt
 
-# Tests ausführen
-pytest tests/ -v
+# Tests ausfuehren (IMMER -x verwenden — stoppt bei erstem Fehler, verhindert OOM auf 8 GB VPS)
+pytest tests/unit/test_NAME.py -x
+
+# Gesamte Test-Suite (selten, nur lokal mit ausreichend RAM)
+pytest tests/ -x -v
 
 # Mit Coverage
-pytest tests/ --cov=src --cov-report=html
+pytest tests/ -x --cov=src --cov-report=html
 
 # Einzelne Test-Kategorie
-pytest tests/unit/ -v
-pytest tests/integration/ -v
+pytest tests/unit/ -x -v
+pytest tests/integration/ -x -v
 
 # Bot lokal testen
 python3 src/bot.py
@@ -355,26 +358,30 @@ shadowops-bot/
 │   │   ├── code_analyzer.py            # Code Structure Analyzer
 │   │   ├── context_manager.py          # RAG Context Manager
 │   │   ├── github_integration/         # GitHub Webhooks + Jules Workflow (Package)
+│   │   ├── security_engine/            # Autonomer SecurityScanAgent + CircuitBreaker + DB
 │   │   ├── project_monitor.py          # Multi-Project Monitoring
 │   │   ├── deployment_manager.py       # Auto-Deployment
 │   │   ├── incident_manager.py         # Incident Tracking
 │   │   ├── customer_notifications.py   # Customer-Facing Alerts
-│   │   ├── fixers/                     # Security Fixers (fail2ban, crowdsec, aide, wal-g)
+│   │   ├── fixers/                     # Security Fixers (fail2ban, crowdsec, aide, trivy, wal-g)
 │   │   ├── analyst/                    # Security Analyst (Legacy-Referenz)
 │   │   ├── ai_learning/                # Continuous Learning Agent
 │   │   ├── fail2ban.py                 # Fail2ban Integration
 │   │   ├── crowdsec.py                 # CrowdSec Integration
 │   │   ├── aide.py                     # AIDE Integration
 │   │   └── docker.py                   # Docker Scan Integration
+│   ├── patch_notes/                    # Patch Notes Pipeline v6 (5-Stufen State Machine)
+│   ├── schemas/                        # JSON-Schemas fuer Structured Output (Codex/Claude)
 │   └── utils/
 │       ├── config.py                   # Config-Loader
-│       ├── state_manager.py            # NEU: State-Management
+│       ├── state_manager.py            # State-Management
 │       ├── logger.py                   # Logging
 │       ├── embeds.py                   # Discord Embed-Builder
-│       └── discord_logger.py           # Discord Channel Logger
+│       ├── discord_logger.py           # Discord Channel Logger
+│       └── alert_humanizer.py          # Status-Telemetrie zu mensch-lesbarem Deutsch
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (161)
+│   ├── unit/                           # Unit Tests (250+)
 │   │   ├── test_config.py
 │   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
 │   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
@@ -394,7 +401,7 @@ shadowops-bot/
 │   └── logrotate.conf                  # Log-Rotation
 ├── deploy/                             # Deployment + Watchdogs
 │   ├── shadowops-bot.service           # systemd Bot-Service
-│   ├── *-watchdog.{service,timer}      # Externe Uptime-Watchdogs (6x HTTP/systemd + Backup-Test)
+│   ├── *-watchdog.{service,timer}      # Externe Uptime-Watchdogs (11 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift)
 │   ├── shadowops-watchdog.env.example  # Webhook-Env Template
 │   └── MONITORING_SETUP.md             # Setup-Anleitung Watchdogs
 ├── .github/

--- a/README.md
+++ b/README.md
@@ -384,16 +384,18 @@ shadowops-bot/
 │       └── alert_humanizer.py          # Status-Telemetrie zu mensch-lesbarem Deutsch
 ├── tests/
 │   ├── conftest.py                     # Test Fixtures
-│   ├── unit/                           # Unit Tests (250+)
+│   ├── unit/                           # Unit Tests (700+, 67 Dateien)
 │   │   ├── test_config.py
-│   │   ├── test_ai_engine.py           # 43 Tests (Router, Codex, Claude, AIEngine)
-│   │   ├── test_smart_queue.py         # 21 Tests (Pool, Lock, Circuit Breaker)
+│   │   ├── test_ai_engine.py
+│   │   ├── test_smart_queue.py
 │   │   ├── test_orchestrator.py
 │   │   ├── test_knowledge_base.py
 │   │   ├── test_event_watcher.py
 │   │   ├── test_github_integration.py
 │   │   ├── test_project_monitor.py
-│   │   └── test_incident_manager.py
+│   │   ├── test_incident_manager.py
+│   │   ├── agent_review/               # Multi-Agent-Pipeline Tests
+│   │   └── security_engine/            # SecurityScanAgent Tests
 │   └── integration/
 │       └── test_learning_workflow.py   # End-to-End Tests
 ├── config/
@@ -404,7 +406,7 @@ shadowops-bot/
 │   └── logrotate.conf                  # Log-Rotation
 ├── deploy/                             # Deployment + Watchdogs
 │   ├── shadowops-bot.service           # systemd Bot-Service
-│   ├── *-watchdog.{service,timer}      # Externe Uptime-Watchdogs (11 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift)
+│   ├── *-watchdog.{service,timer}      # Externe Uptime-Watchdogs (14 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift)
 │   ├── shadowops-watchdog.env.example  # Webhook-Env Template
 │   └── MONITORING_SETUP.md             # Setup-Anleitung Watchdogs
 ├── .github/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Event → TaskRouter → Codex CLI (Primary)
 #### Mobile Workflow (Owner-only)
 - `/claude [prompt] [project] [model] [timeout]` - Headless Claude-Session auf dem Server starten und Antwort in Discord empfangen (owner-only)
 
+#### Server Setup
+- `/setup-customer-server` - Monitoring-Channels für Customer-Server einrichten (Admin)
+
 ### 🎨 Features
 - **Rich Embeds** - Farbcodierte Alerts (🔴 CRITICAL, 🟠 HIGH, 🟢 OK)
 - **Multi-Channel Support** - Kategorisierte Channels (Security, AI Learning, Deployments, etc.)


### PR DESCRIPTION
## Aenderungen

Faktische Fehler in CLAUDE.md und README.md korrigiert. Keine inhaltlichen Neuerungen — nur Synchronisierung bestehender Doku mit dem Code.

### CLAUDE.md

| # | Problem | Fix |
|---|---------|-----|
| 1 | `patch_notes/` fehlte in Verzeichnis-Struktur | Eintrag mit Beschreibung ergaenzt |
| 2 | `schemas/` fehlte in Verzeichnis-Struktur | Eintrag mit Beschreibung ergaenzt |
| 3 | `security_engine/` fehlte in Modul-Liste | Package-Eintrag mit Sub-Modulen ergaenzt |
| 4 | `fixers/` fehlte in Modul-Liste | Eintrag mit allen 5 Fixern ergaenzt |
| 5 | Watchdog-Count in deploy-Dir-Kommentar: `10 Watchdogs` — tatsaechlich sind es jetzt 14 (disk-hygiene + doku-drift + ki-cost kamen mit #291) | Auf `14 Watchdogs` korrigiert |
| 6 | `fail2ban.py`-Beschreibung: `Security-Integrationen` — diese Files sind Event-Quellen, nicht Integration-Packages | Auf `Security-Event-Quellen (Monitoring-Integrationen)` praezisiert |
| 7 | `utils/` Kommentar nannte `alert_humanizer` nicht — neues Modul seit 2026-05-29 | Beschreibung ergaenzt |
| 8 | `docs/design/` existiert mit 4 aktuellen Design-Docs, fehlte im Verzeichnisbaum | Eintrag hinzugefuegt, `plans/` als archiviert markiert |
| 9 | Test-Count: `150+` / `161+` → `700+` | Korrigiert (Tech-Stack-Tabelle + Verzeichnisbaum + Statistik-Sektion) |
| 10 | `utils/` Kommentar fehlte: circuit_breaker, health_server, message_handler, changelog_parser, process_lock | Alle 5 Module ergaenzt (seit #259/#190 im Repo) |

### README.md

| # | Problem | Fix |
|---|---------|-----|
| 11 | `security_engine/` fehlte in Verzeichnis-Struktur | Eintrag ergaenzt |
| 12 | `fixers/`-Kommentar listete `fail2ban, crowdsec, aide, wal-g` — `trivy_fixer.py` fehlte | `trivy` ergaenzt |
| 13 | Testing-Commands ohne `-x` Flag — auf dem 8 GB VPS Pflicht (OOM-Gefahr bei parallelen Tests) | Alle pytest-Aufrufe um `-x` ergaenzt |
| 14 | `patch_notes/` und `schemas/` fehlten in der src-Verzeichnisstruktur | Eintraege ergaenzt |
| 15 | Watchdog-Kommentar: `6x HTTP/systemd + Backup-Test` — tatsaechlich 14 Watchdogs mit jq-filter und build-drift | Korrigiert auf `14 Watchdogs: HTTP/systemd/jq-filter/build-drift/state-drift` |
| 16 | `alert_humanizer.py` fehlte in `utils/` Sektion | Eintrag mit Kurzbeschreibung ergaenzt |
| 17 | Test-Count: `161` → `700+` | Korrigiert |
| 18 | `/setup-customer-server` fehlte in Slash-Commands-Sektion | Neuer Abschnitt "Server Setup" ergaenzt |
| 19 | Test-File-Listing hatte falsche Inline-Counts (`43`/`21`) und fehlte `agent_review/` + `security_engine/` Unterverzeichnisse | Counts entfernt, Unterverzeichnisse ergaenzt |
| 20 | `utils/`-Sektion fehlte: circuit_breaker.py, health_server.py, message_handler.py, changelog_parser.py, process_lock.py | Alle 5 Module mit Kurzbeschreibung ergaenzt (seit #259/#190 im Repo) |

## Geprueft

- Alle genannten Verzeichnisse und Dateien existieren in `src/` bzw. `deploy/` (verifiziert via `find`)
- Watchdog-Count 14 via `ls deploy/*watchdog* | sort -u` bestaetigt
- Test-Count 700+ via `grep -rh "def test_" tests/unit/ | wc -l` bestaetigt
- utils-Module alle via `ls src/utils/` verifiziert
- Keine Logik-Aenderungen, nur Doku
- DO-NOT-TOUCH.md respektiert

## Refresh-Historie

- 2026-05-25: Initialer Lauf (kein State-File vorhanden nach Fresh-Clone)
- 2026-05-28: Force-Push-Refresh nach 3 neuen Main-Commits (memory-watchdog, post_deploy_command docs, dash-underscore lookup). Watchdog-Count in CLAUDE.md dir-Kommentar neu aufgenommen.
- 2026-05-29: Force-Push-Refresh nach Alert-Humanizer (#287). Neu: alert_humanizer.py in utils/, docs/design/ im Baum, Test-Count 150/161 → 250+ (alle drei Stellen in CLAUDE.md + README).
- 2026-05-30: Force-Push-Refresh nach #288 + #289. Rebase auf cd02d86. Neu: /setup-customer-server in README Slash-Commands-Sektion ergaenzt (fehlte seit Einfuehrung des Cogs).
- 2026-05-31: Force-Push-Refresh nach #291 (Selbstpflege-Watchdogs). Rebase auf 73b6b7f. Neu: Watchdog-Count 11 → 14, Test-Count 250+ → 700+ (720 Funktionen in 67 Dateien), README Test-File-Listing Inline-Counts entfernt, agent_review/ + security_engine/ Unterverzeichnisse ergaenzt.
- 2026-06-02: Force-Push-Refresh (Doku-Lauf 2026-06-02). Neu: 5 fehlende utils-Module in README-Struktur-Baum ergaenzt (circuit_breaker.py, health_server.py, message_handler.py, changelog_parser.py, process_lock.py — existieren seit #259/#190, wurden beim letzten Refresh uebersehen). CLAUDE.md utils-Kommentar entsprechend erweitert. Commit 37fe380.