### PR TITLE
feat: Alert-Humanizer — Mensch-lesbare Discord-Meldungen

### DIFF
--- a/docs/2026-05-28-alert-humanizer-design.md
+++ b/docs/2026-05-28-alert-humanizer-design.md
@@ -1,0 +1,145 @@
+# Design: Alert-Humanizer — Mensch-lesbare Discord-Meldungen
+
+**Datum:** 2026-05-28
+**Branch:** `feat/alert-humanizer`
+**Status:** Design — Implementierung folgt
+**Motivation:** Die Discord-Alerts (Runner-VM-Drift, Deploy, Incidents, Health) sind Status-Telemetrie statt Mensch-lesbarer Meldungen: Status-Enums (`DRIFT (unreachable → critical)`), Roh-Codes (`LOAD_CRITICAL`), Rohzahlen (`Load 1min=32.23 on 8 CPUs`) — ohne *was ist los / wie schlimm / was tun*.
+
+## Problem (konkretes Beispiel)
+
+**Ist-Zustand** (`#🏗️-runner-vm`):
+```
+🔴 Runner-VM: DRIFT (unreachable → critical)
+Vorher: unreachable · Jetzt: critical
+🔴 Critical Alerts
+• LOAD_CRITICAL (load) — Load 1min=32.23 on 8 CPUs
+🟡 Warning Alerts
+• DISK_HIGH (disk) — Disk usage 84.8% on /
+```
+Drei solche Pings über 3h (DRIFT → DRIFT → RECOVERED) ohne Verknüpfung — in Wahrheit *ein* selbst-erholter Vorfall.
+
+**Ziel-Zustand:**
+```
+🔴 CI-Runner-VM überlastet (war kurz nicht erreichbar)
+Die Runner-VM (10.8.0.10) antwortet wieder, meldet aber akute Überlast.
+
+🔴 CPU-Last 32,2 auf 8 Kernen — 4× überlastet
+🟡 Platte zu 84,8 % voll (/)
+
+→ Dringlichkeit: hoch · CI-Jobs könnten hängen bleiben
+→ Check: hängende Build-Jobs auf der VM · Runbook: mayday-ci-runner.md
+Verlauf: nicht erreichbar → kritisch · vor 2 Min
+```
+
+## Anti-Patterns (von allen Buildern geteilt)
+
+1. **Status-Enum ohne Erklärung** — `LOAD_CRITICAL`, `DISK_HIGH`, `DRIFT (x→y)`
+2. **Rohzahl ohne Kontext** — `Load 1min=32.23 on 8 CPUs` (ist das viel?)
+3. **Keine Dringlichkeit/Handlung** — kein "muss ich ran?" / "was tun?"
+4. **Keine Runbook-Verweise**
+5. **Kein Vorfalls-Zusammenhang** — jeder State-Change = eigener Ping
+
+## Architektur
+
+Ein zentrales, **dependency-freies, rein funktionales** Modul (wie `health_schema_v1.py` — nur dataclasses + stdlib, kein pydantic). Alle Embed-Builder rufen dieselben Übersetzungs-Funktionen.
+
+### Modul 1: `src/utils/alert_humanizer.py` (neu, pure functions, voll testbar)
+
+```python
+# --- Status-Übergänge ---
+def humanize_transition(prev: str, new: str) -> TransitionInfo:
+    """ok|degraded|critical|unreachable × Übergang → Klartext + Dringlichkeit."""
+    # Returns: TransitionInfo(headline, urgency, emoji, is_recovery)
+    # Beispiele:
+    #   (unreachable, critical) → "überlastet (war kurz nicht erreichbar)", urgency=HIGH
+    #   (critical, degraded)    → "erholt sich (noch nicht stabil)", urgency=MEDIUM
+    #   (degraded, ok)          → "wieder stabil", urgency=NONE, is_recovery=True
+    #   (ok, unreachable)       → "nicht mehr erreichbar", urgency=CRITICAL
+
+@dataclass
+class TransitionInfo:
+    headline: str        # "überlastet (war kurz nicht erreichbar)"
+    urgency: Urgency     # Enum NONE|LOW|MEDIUM|HIGH|CRITICAL
+    emoji: str
+    is_recovery: bool
+
+# --- Alert-Codes (Rohcode → Label + Kontext-Formatter) ---
+def humanize_alert(alert: HealthAlert) -> str:
+    """HealthAlert(code, component, message) → eine lesbare Zeile.
+    Bekannte Codes bekommen Klartext + Metrik-Kontext; unbekannte
+    fallen auf Title-Case(code) + message zurück (nie Information verlieren)."""
+    # LOAD_CRITICAL/LOAD_HIGH  → "CPU-Last 32,2 auf 8 Kernen — 4× überlastet"
+    # DISK_HIGH/DISK_CRITICAL  → "Platte zu 84,8 % voll (/)"
+    # MEM_*/MEMORY_*           → "Arbeitsspeicher zu X % belegt"
+    # SERVICE_DOWN/_FAILED     → "Dienst <name> läuft nicht"
+    # <unbekannt>              → "<Title-Case-Code>: <message>"
+
+ALERT_LABELS: dict[str, AlertSpec]   # code → (label, parser, runbook_hint)
+
+# --- Metrik-Parser (Rohstring → Verhältnis/Kontext) ---
+def parse_load(message: str) -> str | None:   # "Load 1min=32.23 on 8 CPUs" → "32,2 auf 8 Kernen (4× überlastet)"
+def parse_disk(message: str) -> str | None:   # "Disk usage 84.8% on /" → "84,8 % voll (/)"
+# Parser sind defensiv: Regex-Match scheitert → None → Fallback auf Rohmessage.
+
+# --- Dringlichkeit → Handlungs-Hinweis ---
+def urgency_line(urgency: Urgency) -> str:    # "→ Dringlichkeit: hoch · CI-Jobs könnten hängen bleiben"
+
+# --- Runbook-Verweis pro Rolle/Komponente ---
+RUNBOOKS: dict[str, str]   # role|component → Runbook-Pfad
+def runbook_for(role: str, components: list[str]) -> str | None
+```
+
+**Lokalisierung:** Deutsch, Komma als Dezimaltrenner (32,2), Umlaute Pflicht.
+**Robustheit:** Jede Funktion hat einen Fallback der NIE Information verschluckt — unbekannter Code/unparsebare Metrik → Rohwert durchreichen, nie leer.
+
+### Modul 2: Incident-Grouping in `phase_5e_health_aggregator.py`
+
+State-Changes desselben Hosts innerhalb eines **Incident-Fensters** zu *einem* Vorfall bündeln:
+
+- **Incident-Start:** erster Drift weg von `ok` (→ degraded/critical/unreachable).
+- **Während offen:** weitere Drifts (critical→degraded etc.) **editieren die bestehende Incident-Message** (Discord `message.edit`) statt neue Posts — Verlauf als Timeline im selben Embed.
+- **Incident-Ende:** Drift zurück auf `ok` → Recovery, Embed final editiert mit **Gesamt-Downtime** + "selbst-erholt (keine manuelle Aktion erkennbar)" wenn zutreffend.
+- **State:** `dict[host, OpenIncident]` im Cog (in-memory reicht; SQLite-`health_history` ist schon da für Persistenz/Recovery-after-restart als optionaler Ausbau).
+- **OpenIncident:** `{host, started_at, message_id, transitions: list[(ts, prev, new)], worst_status}`.
+
+Ergebnis: aus 3 Pings (DRIFT→DRIFT→RECOVERED über 3h) wird **eine** sich aktualisierende Nachricht mit Timeline + finaler Downtime.
+
+## Migration der 5 Builder (alle nutzen Humanizer)
+
+| Datei | Builder | Änderung |
+|---|---|---|
+| `cogs/phase_5e_health_aggregator.py` | `_build_drift_embed`, `_build_status_embed`, `_build_trend_embed` | Humanizer + Incident-Grouping |
+| `cogs/deployment_manager.py` | `_send_deploy_success/_failure` | Schritt-Liste → Klartext-Zusammenfassung, Dauer mit Kontext, Fehler-Step hervorgehoben |
+| `cogs/project_monitor.py` | `_create_incident_embed/_recovery_embed` | `humanize_transition` + Downtime-Klartext + Runbook |
+| `cogs/incident_manager.py` | `_create_incident_embed` | Severity-Enum → Dringlichkeit-Klartext |
+| `utils/embeds.py` | `EmbedBuilder.create_alert` + neu `EmbedBuilder.health_drift()` | Humanizer als gemeinsame Quelle, damit `create_alert` denselben Ton trifft |
+
+**Konsistenz-Anker:** `STATUS_EMOJI`/`STATUS_COLOR` (phase_5e:67/74) bleiben Single-Source — der Humanizer importiert sie bzw. sie wandern nach `alert_humanizer.py` und phase_5e importiert von dort (dedupliziert).
+
+## Teststrategie (pytest, dependency-frei)
+
+- `tests/unit/test_alert_humanizer.py` (neu): jede pure function gegen Tabelle von (input → erwarteter Output). Schwerpunkte:
+  - Alle bekannten Status-Übergänge (4×4 Matrix, sinnvolle Teilmenge)
+  - Bekannte Alert-Codes (LOAD/DISK/MEM/SERVICE) mit echten message-Strings aus Prod
+  - **Fallback-Pfade:** unbekannter Code, unparsebare Metrik → Rohwert bleibt erhalten (kein Crash, keine leere Zeile)
+  - Dezimal-Lokalisierung (32.23 → "32,2")
+- `tests/unit/test_phase_5e_health_aggregator.py` (erweitern): Incident-Grouping — 3 Drifts erzeugen 1 Message (edit), Recovery zeigt Downtime.
+- Bestehende Tests müssen grün bleiben (Embed-Struktur-Asserts ggf. anpassen).
+- **Einzeln ausführen** (`.venv/bin/python -m pytest tests/unit/test_alert_humanizer.py -q`).
+
+## Umsetzungs-Reihenfolge (Abhängigkeit)
+
+1. **`alert_humanizer.py` + Tests** — Basis, blockiert alles. Muss grün sein bevor Builder migriert werden.
+2. **Incident-Grouping** in phase_5e (nutzt Humanizer) + Tests.
+3. **Builder-Migration** (4 weitere) — können nach (1) parallel, je eigener Commit.
+4. **PR** gegen `main`, Vorher/Nachher im Body, alle Tests grün.
+
+## Deploy-Hinweis
+
+ShadowOps Auto-Deploy nur via **PR-Merge** (Direct-Push geblockt, Memory `project_shadowops-webhook-pattern`). Bot ist `Restart=always`. Nach Merge: Webhook → Pull → Restart. Kein manueller Eingriff nötig, aber Health-Watchdog (`shadowops-watchdog`) im Auge behalten.
+
+## Nicht im Scope (YAGNI)
+
+- Health-Endpoint auf der Runner-VM (10.8.0.10, `/opt/runner-health/`) ändern — die Rohdaten reichen, Übersetzung passiert im Bot.
+- Persistente Incident-History über Bot-Restart hinaus (in-memory reicht; SQLite-Ausbau optional später).
+- Neue Alert-Codes erfinden — nur bestehende übersetzen + sauberer Fallback.

--- a/src/cogs/phase_5e_health_aggregator.py
+++ b/src/cogs/phase_5e_health_aggregator.py
@@ -46,6 +46,15 @@ from integrations.health_schema_v1 import (
     HealthResponse,
     HealthSchemaError,
 )
+from utils.alert_humanizer import (
+    STATUS_COLOR,
+    STATUS_EMOJI,
+    Urgency,
+    humanize_alert,
+    humanize_transition,
+    runbook_for,
+    urgency_line,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -63,20 +72,9 @@ RETENTION_DAYS = 90
 DASHBOARD_CHANNEL_ID = 1479615549356114124  # 📊-dashboard
 CRITICAL_CHANNEL_ID = 1441655480840617994   # 🚨-critical
 
-# Status → Discord-Color
-STATUS_COLOR = {
-    "ok": 0x2ECC71,        # grün
-    "degraded": 0xF39C12,  # gelb-orange
-    "critical": 0xE74C3C,  # rot
-    "unreachable": 0x7F8C8D,  # grau
-}
-
-STATUS_EMOJI = {
-    "ok": "🟢",
-    "degraded": "🟡",
-    "critical": "🔴",
-    "unreachable": "⚫",
-}
+# STATUS_COLOR / STATUS_EMOJI sind ab jetzt Single-Source in
+# utils.alert_humanizer (Konsistenz-Anker, siehe Design-Doc 2026-05-28).
+# Re-Import oben — Werte 1:1 identisch zu den frueheren lokalen Kopien.
 
 
 @dataclass(frozen=True)
@@ -119,6 +117,22 @@ class PollResult:
         if self.response is not None:
             return self.response.status
         return "unreachable"
+
+
+@dataclass
+class OpenIncident:
+    """Ein offener Vorfall pro Host — bündelt aufeinanderfolgende Drifts.
+
+    Solange ein Host nicht auf ``ok`` zurückkehrt, editieren weitere Drifts die
+    bestehende Discord-Message (statt neue Posts), Verlauf als Timeline.
+    """
+
+    host: str
+    started_at: datetime
+    message_id: Optional[int]
+    transitions: list[tuple[int, str, str]]  # [(ts, prev, new), ...]
+    worst_status: str
+    manual_action_seen: bool = False  # für "selbst-erholt"-Heuristik (YAGNI: bleibt False)
 
 
 # ---------- SQLite-Persistenz ----------
@@ -271,18 +285,24 @@ def _build_status_embed(results: list[PollResult]) -> discord.Embed:
     for r in results:
         emoji = STATUS_EMOJI.get(r.status, "⚪")
         if r.response is not None:
-            crit = len(r.response.critical_alerts)
-            warn = len(r.response.warning_alerts)
             host_line = f"`{r.response.host}` ({r.response.role})"
             uptime_line = f"Uptime: {_format_uptime(r.response.uptime_seconds)}"
-            comps = ", ".join(r.response.components.keys()) or "—"
-            alert_line = f"Alerts: {crit} critical · {warn} warning"
-            value = f"{host_line}\n{uptime_line}\nKomponenten: {comps}\n{alert_line}"
+            # Wichtigste Alerts als Klartext (Humanizer) statt blosser Zaehler
+            alert_lines: list[str] = []
+            for a in r.response.critical_alerts[:2]:
+                alert_lines.append(f"🔴 {humanize_alert(a)}")
+            for a in r.response.warning_alerts[:2]:
+                alert_lines.append(f"🟡 {humanize_alert(a)}")
+            if alert_lines:
+                body = "\n".join(alert_lines)
+            else:
+                body = "Keine aktiven Alerts"
+            value = f"{host_line}\n{uptime_line}\n{body}"
         else:
             value = f"❌ {r.error or 'unbekannter Fehler'}"
 
         field_name = f"{emoji} {r.target.name} — {r.status.upper()}"
-        embed.add_field(name=field_name, value=value, inline=False)
+        embed.add_field(name=field_name, value=value[:1024], inline=False)
 
     embed.set_footer(text=f"Aktualisiert alle {EMBED_INTERVAL_MINUTES} Min · Schema v1")
     return embed
@@ -301,35 +321,104 @@ def _format_uptime(seconds: int) -> str:
     return f"{days}d {h}h"
 
 
-def _build_drift_embed(target: HealthTarget, prev: str, new: str, response: Optional[HealthResponse], error: Optional[str]) -> discord.Embed:
-    """Embed für Drift-Detail-Alert (status-Wechsel)."""
-    is_recovery = (prev in {"critical", "degraded", "unreachable"}) and (new == "ok")
-    if is_recovery:
-        title = f"✅ {target.name}: RECOVERED ({prev} → {new})"
-        color = STATUS_COLOR["ok"]
+def _alert_components(response: Optional[HealthResponse]) -> list[str]:
+    """Sammelt die Komponenten aller Alerts (fuer Runbook-Auswahl)."""
+    if response is None:
+        return []
+    comps: list[str] = []
+    for a in response.alerts:
+        if a.component and a.component not in comps:
+            comps.append(a.component)
+    return comps
+
+
+def _format_downtime(seconds: float) -> str:
+    """Sekunden → kurzer deutscher Dauer-Klartext, z.B. '2 Min', '1 Std 5 Min'."""
+    seconds = int(max(0, seconds))
+    if seconds < 60:
+        return f"{seconds} Sek"
+    if seconds < 3600:
+        return f"{seconds // 60} Min"
+    if seconds < 86400:
+        h, rem = divmod(seconds, 3600)
+        m = rem // 60
+        return f"{h} Std {m} Min" if m else f"{h} Std"
+    days, rem = divmod(seconds, 86400)
+    h = rem // 3600
+    return f"{days} Tg {h} Std" if h else f"{days} Tg"
+
+
+def _build_drift_embed(
+    target: HealthTarget,
+    prev: str,
+    new: str,
+    response: Optional[HealthResponse],
+    error: Optional[str],
+    *,
+    timeline: Optional[list[tuple[int, str, str]]] = None,
+    downtime_seconds: Optional[float] = None,
+    self_recovered: bool = False,
+) -> discord.Embed:
+    """Embed für Drift-Detail-Alert (status-Wechsel) — mensch-lesbar via Humanizer.
+
+    ``timeline`` (optional) listet bisherige Übergänge eines offenen Incidents
+    als ``[(ts, prev, new), ...]`` und wird als Verlauf gerendert.
+    ``downtime_seconds``/``self_recovered`` werden beim Recovery-Abschluss
+    gesetzt (Gesamt-Downtime + Selbst-Erholung).
+    """
+    info = humanize_transition(prev, new)
+    title = f"{info.emoji} {target.name} {info.headline}"
+    color = STATUS_COLOR["ok"] if info.is_recovery else STATUS_COLOR.get(new, 0x95A5A6)
+
+    # Beschreibung: Klartext-Kontext zur Lage
+    if info.is_recovery:
+        desc_parts = [f"{target.name} ({target.url}) ist wieder im grünen Bereich."]
+        if downtime_seconds is not None:
+            desc_parts.append(f"Gesamt-Ausfall: **{_format_downtime(downtime_seconds)}**.")
+        if self_recovered:
+            desc_parts.append("Selbst-erholt (keine manuelle Aktion erkannt).")
+        description = " ".join(desc_parts)
+    elif error:
+        description = f"{target.name} ({target.url}) — {error[:300]}"
     else:
-        title = f"{STATUS_EMOJI.get(new, '⚠️')} {target.name}: DRIFT ({prev} → {new})"
-        color = STATUS_COLOR.get(new, 0x95A5A6)
+        description = f"{target.name} ({target.url})"
 
     embed = discord.Embed(
-        title=title,
+        title=title[:256],
+        description=description[:4096],
         color=color,
         timestamp=datetime.now(timezone.utc),
     )
-    embed.add_field(name="URL", value=f"`{target.url}`", inline=False)
-    embed.add_field(name="Vorher", value=f"`{prev}`", inline=True)
-    embed.add_field(name="Jetzt", value=f"`{new}`", inline=True)
 
     if response is not None:
         if response.critical_alerts:
-            lines = [f"• `{a.code}` ({a.component}) — {a.message}" for a in response.critical_alerts[:5]]
-            embed.add_field(name="🔴 Critical Alerts", value="\n".join(lines)[:1024], inline=False)
+            lines = [f"🔴 {humanize_alert(a)}" for a in response.critical_alerts[:5]]
+            embed.add_field(name="Kritisch", value="\n".join(lines)[:1024], inline=False)
         if response.warning_alerts:
-            lines = [f"• `{a.code}` ({a.component}) — {a.message}" for a in response.warning_alerts[:5]]
-            embed.add_field(name="🟡 Warning Alerts", value="\n".join(lines)[:1024], inline=False)
+            lines = [f"🟡 {humanize_alert(a)}" for a in response.warning_alerts[:5]]
+            embed.add_field(name="Warnungen", value="\n".join(lines)[:1024], inline=False)
     elif error:
         embed.add_field(name="Fehler", value=f"```{error[:1000]}```", inline=False)
 
+    # Dringlichkeit (leeren String abfangen — kein Feld bei Urgency.NONE)
+    u_line = urgency_line(info.urgency)
+    runbook = runbook_for(target.role_hint, _alert_components(response))
+    action_lines: list[str] = []
+    if u_line:
+        action_lines.append(u_line)
+    if runbook is not None and not info.is_recovery:
+        action_lines.append(f"→ Runbook: {runbook}")
+    if action_lines:
+        embed.add_field(name="​", value="\n".join(action_lines)[:1024], inline=False)
+
+    # Verlauf (Incident-Timeline)
+    if timeline:
+        tl_lines = []
+        for ts, p, n in timeline[-6:]:
+            tl_lines.append(f"{STATUS_EMOJI.get(n, '⚪')} {p} → {n} · <t:{ts}:R>")
+        embed.add_field(name="Verlauf", value="\n".join(tl_lines)[:1024], inline=False)
+
+    embed.set_footer(text="Phase 5e · Health-Aggregator")
     return embed
 
 
@@ -354,7 +443,8 @@ def _build_trend_embed(events: list[tuple[str, str, str, int]]) -> discord.Embed
         lines = []
         for host, prev, new, ts in ranked:
             when = f"<t:{ts}:R>"
-            lines.append(f"• {STATUS_EMOJI.get(new, '⚪')} `{host}`: {prev} → **{new}** {when}")
+            info = humanize_transition(prev, new)
+            lines.append(f"• {info.emoji} `{host}`: **{info.headline}** {when}")
         embed.add_field(name="Top-Events", value="\n".join(lines), inline=False)
 
         # Pro-Host-Statistik
@@ -381,6 +471,8 @@ class Phase5eHealthAggregator(commands.Cog):
         self._last_status_per_host: dict[str, str] = {}
         self._latest_results: list[PollResult] = []
         self._dashboard_message: Optional[discord.Message] = None
+        # Incident-Grouping: offene Vorfälle pro Host (in-memory; Restart = leer)
+        self._open_incidents: dict[str, OpenIncident] = {}
         _init_db()
 
     async def cog_load(self) -> None:
@@ -418,6 +510,8 @@ class Phase5eHealthAggregator(commands.Cog):
     async def _before_poll(self) -> None:
         await self.bot.wait_until_ready()
 
+    _STATUS_SEVERITY = {"ok": 0, "degraded": 1, "critical": 2, "unreachable": 3}
+
     async def _handle_drifts(self, results: list[PollResult]) -> None:
         critical_channel = self.bot.get_channel(CRITICAL_CHANNEL_ID)
         for r in results:
@@ -435,11 +529,88 @@ class Phase5eHealthAggregator(commands.Cog):
             self.logger.info("[5e] DRIFT %s: %s → %s", host, previous, current)
             if critical_channel is None:
                 continue
-            try:
+
+            await self._handle_incident_drift(critical_channel, r, previous, current)
+
+    async def _handle_incident_drift(
+        self, channel, r: PollResult, previous: str, current: str
+    ) -> None:
+        """Bündelt aufeinanderfolgende Drifts eines Hosts zu einem Incident.
+
+        - Erster Drift weg von ``ok`` → Incident öffnen, Message posten.
+        - Weitere Drifts (Incident offen) → bestehende Message editieren, Timeline anhängen.
+        - Drift zurück auf ``ok`` → Recovery, finale Edit mit Downtime, Incident schließen.
+        """
+        host = r.target.name
+        now = datetime.now(timezone.utc)
+        ts = int(now.timestamp())
+        incident = self._open_incidents.get(host)
+
+        if current == "ok":
+            # Recovery — schließt einen offenen Incident ab (falls vorhanden)
+            if incident is None:
+                # kein offener Incident (z.B. Bot-Restart) → einfacher Recovery-Post
                 embed = _build_drift_embed(r.target, previous, current, r.response, r.error)
-                await critical_channel.send(embed=embed)
+                await self._post_or_edit_incident(channel, None, embed)
+                return
+            incident.transitions.append((ts, previous, current))
+            downtime = (now - incident.started_at).total_seconds()
+            embed = _build_drift_embed(
+                r.target, previous, current, r.response, r.error,
+                timeline=incident.transitions,
+                downtime_seconds=downtime,
+                self_recovered=not incident.manual_action_seen,
+            )
+            await self._post_or_edit_incident(channel, incident, embed)
+            del self._open_incidents[host]
+            return
+
+        # Drift in einen Nicht-ok-Status
+        if incident is None:
+            # Neuer Incident
+            incident = OpenIncident(
+                host=host,
+                started_at=now,
+                message_id=None,
+                transitions=[(ts, previous, current)],
+                worst_status=current,
+            )
+            self._open_incidents[host] = incident
+        else:
+            incident.transitions.append((ts, previous, current))
+            if self._STATUS_SEVERITY.get(current, 0) > self._STATUS_SEVERITY.get(incident.worst_status, 0):
+                incident.worst_status = current
+
+        embed = _build_drift_embed(
+            r.target, previous, current, r.response, r.error,
+            timeline=incident.transitions,
+        )
+        await self._post_or_edit_incident(channel, incident, embed)
+
+    async def _post_or_edit_incident(self, channel, incident: Optional[OpenIncident], embed: discord.Embed) -> None:
+        """Postet eine neue Incident-Message oder editiert die bestehende.
+
+        Defensive: schlägt ``message.edit`` fehl (Message gelöscht/404), wird neu
+        gepostet und die ``message_id`` aktualisiert.
+        """
+        # Bestehende Message editieren wenn möglich
+        if incident is not None and incident.message_id is not None:
+            try:
+                msg = channel.get_partial_message(incident.message_id)
+                await msg.edit(embed=embed)
+                return
             except discord.HTTPException as exc:
-                self.logger.error("[5e] drift-embed senden fehlgeschlagen: %s", exc)
+                self.logger.warning("[5e] incident-edit fehlgeschlagen (%s) → neu posten", exc)
+                incident.message_id = None
+
+        # Neu posten
+        try:
+            new_msg = await channel.send(embed=embed)
+        except discord.HTTPException as exc:
+            self.logger.error("[5e] incident-embed senden fehlgeschlagen: %s", exc)
+            return
+        if incident is not None and new_msg is not None:
+            incident.message_id = getattr(new_msg, "id", None)
 
     # ---- 5-Min-Status-Embed ----
 

--- a/src/cogs/phase_5e_health_aggregator.py
+++ b/src/cogs/phase_5e_health_aggregator.py
@@ -50,6 +50,7 @@ from utils.alert_humanizer import (
     STATUS_COLOR,
     STATUS_EMOJI,
     Urgency,
+    format_downtime,
     humanize_alert,
     humanize_transition,
     runbook_for,
@@ -332,22 +333,6 @@ def _alert_components(response: Optional[HealthResponse]) -> list[str]:
     return comps
 
 
-def _format_downtime(seconds: float) -> str:
-    """Sekunden → kurzer deutscher Dauer-Klartext, z.B. '2 Min', '1 Std 5 Min'."""
-    seconds = int(max(0, seconds))
-    if seconds < 60:
-        return f"{seconds} Sek"
-    if seconds < 3600:
-        return f"{seconds // 60} Min"
-    if seconds < 86400:
-        h, rem = divmod(seconds, 3600)
-        m = rem // 60
-        return f"{h} Std {m} Min" if m else f"{h} Std"
-    days, rem = divmod(seconds, 86400)
-    h = rem // 3600
-    return f"{days} Tg {h} Std" if h else f"{days} Tg"
-
-
 def _build_drift_embed(
     target: HealthTarget,
     prev: str,
@@ -374,7 +359,7 @@ def _build_drift_embed(
     if info.is_recovery:
         desc_parts = [f"{target.name} ({target.url}) ist wieder im grünen Bereich."]
         if downtime_seconds is not None:
-            desc_parts.append(f"Gesamt-Ausfall: **{_format_downtime(downtime_seconds)}**.")
+            desc_parts.append(f"Gesamt-Ausfall: **{format_downtime(downtime_seconds)}**.")
         if self_recovered:
             desc_parts.append("Selbst-erholt (keine manuelle Aktion erkannt).")
         description = " ".join(desc_parts)

--- a/src/integrations/deployment_manager.py
+++ b/src/integrations/deployment_manager.py
@@ -10,12 +10,48 @@ import subprocess
 import shutil
 import time
 import os
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Tuple
 from datetime import datetime, timezone
 from pathlib import Path
 import discord
 
+try:  # pragma: no cover - Import-Pfad haengt von pythonpath ab
+    from utils.alert_humanizer import format_downtime
+except ImportError:  # pragma: no cover
+    from src.utils.alert_humanizer import format_downtime  # type: ignore[no-redef]
+
 logger = logging.getLogger(__name__)
+
+
+# Marker, an denen ein gesammelter Deploy-Step als fehlgeschlagen erkannt wird.
+_STEP_FAIL_MARKERS = ("❌", "fehlgeschlagen", "failed", "error", "fehler", "abort")
+
+
+def _summarize_steps(steps: List[str]) -> Tuple[int, int, Optional[str]]:
+    """Fasst gesammelte Deploy-Steps zusammen.
+
+    Returns: (anzahl_ok, anzahl_gesamt, erster_fehlgeschlagener_step_oder_None).
+    Ein Step gilt als fehlgeschlagen, wenn er einen der _STEP_FAIL_MARKERS
+    (case-insensitiv) enthält.
+    """
+    total = len(steps)
+    failed_step: Optional[str] = None
+    ok = 0
+    for step in steps:
+        low = step.lower()
+        if any(m in low for m in _STEP_FAIL_MARKERS):
+            if failed_step is None:
+                failed_step = step
+        else:
+            ok += 1
+    return ok, total, failed_step
+
+
+def _format_deploy_duration(duration: float) -> str:
+    """Deploy-Dauer mit Kontext: kurze Deploys in Sekunden, lange via Klartext."""
+    if duration < 90:
+        return f"{duration:.1f}s"
+    return format_downtime(duration)
 
 
 class DeploymentManager:
@@ -735,19 +771,27 @@ class DeploymentManager:
         if not channel:
             return
 
+        steps = getattr(self, '_deploy_steps', {}).get(project_name, [])
+        ok, total, _ = _summarize_steps(steps)
+
+        # Klartext-Zusammenfassung statt blosser Erfolgsmeldung
+        if total > 0:
+            summary = f"**{project_name}** erfolgreich deployt — alle {total} Schritte ok."
+        else:
+            summary = f"**{project_name}** erfolgreich deployt."
+
         embed = discord.Embed(
-            title="✅ Deployment Successful",
-            description=f"**{project_name}** deployed successfully",
+            title=f"✅ Deployment erfolgreich: {project_name}",
+            description=summary,
             color=discord.Color.green(),
             timestamp=datetime.now(timezone.utc)
         )
 
         embed.add_field(name="Projekt", value=f"`{project_name}`", inline=True)
         embed.add_field(name="Branch", value=f"`{branch}`", inline=True)
-        embed.add_field(name="Dauer", value=f"{duration:.1f}s", inline=True)
+        embed.add_field(name="Dauer", value=_format_deploy_duration(duration), inline=True)
 
-        # Gesammelte Deploy-Steps als Timeline
-        steps = getattr(self, '_deploy_steps', {}).get(project_name, [])
+        # Gesammelte Deploy-Steps als Timeline (Detail, unter der Zusammenfassung)
         if steps:
             embed.add_field(name="Verlauf", value="\n".join(steps[-10:])[:1024], inline=False)
             self._deploy_steps.pop(project_name, None)  # Cleanup
@@ -771,16 +815,35 @@ class DeploymentManager:
         error = result.get('error', 'Unknown error')
         rolled_back = result.get('rolled_back', False)
 
+        steps = getattr(self, '_deploy_steps', {}).get(project_name, [])
+        ok, total, failed_step = _summarize_steps(steps)
+
+        # Klartext-Zusammenfassung: wie weit kam das Deployment?
+        if total > 0:
+            summary = f"**{project_name}** abgebrochen — {ok}/{total} Schritten ok"
+            if failed_step is not None:
+                # Zeitstempel-Prefix `HH:MM:SS` für die Kurzfassung entfernen
+                short = failed_step.split('` ', 1)[-1].strip('`').strip()
+                summary += f", fehlgeschlagen bei: **{short}**."
+            else:
+                summary += "."
+        else:
+            summary = f"**{project_name}** Deployment fehlgeschlagen."
+
         embed = discord.Embed(
-            title="❌ Deployment Failed",
-            description=f"**{project_name}** deployment failed",
+            title=f"❌ Deployment fehlgeschlagen: {project_name}",
+            description=summary,
             color=discord.Color.red(),
             timestamp=datetime.now(timezone.utc)
         )
 
         embed.add_field(name="Projekt", value=f"`{project_name}`", inline=True)
         embed.add_field(name="Branch", value=f"`{branch}`", inline=True)
-        embed.add_field(name="Dauer", value=f"{duration:.1f}s", inline=True)
+        embed.add_field(name="Dauer", value=_format_deploy_duration(duration), inline=True)
+
+        # Fehlgeschlagener Schritt klar hervorgehoben (vor der Roh-Fehlermeldung)
+        if failed_step is not None:
+            embed.add_field(name="⛔ Fehlgeschlagen bei", value=failed_step[:1024], inline=False)
 
         if len(error) > 400:
             error = error[:397] + "..."
@@ -789,8 +852,7 @@ class DeploymentManager:
         rollback_msg = "✅ Rollback erfolgreich" if rolled_back else "❌ Kein Rollback"
         embed.add_field(name="Rollback", value=rollback_msg, inline=True)
 
-        # Gesammelte Deploy-Steps als Timeline
-        steps = getattr(self, '_deploy_steps', {}).get(project_name, [])
+        # Gesammelte Deploy-Steps als vollständiger Verlauf (Detail)
         if steps:
             embed.add_field(name="Verlauf", value="\n".join(steps[-10:])[:1024], inline=False)
             self._deploy_steps.pop(project_name, None)

--- a/src/integrations/incident_manager.py
+++ b/src/integrations/incident_manager.py
@@ -13,6 +13,15 @@ from pathlib import Path
 from enum import Enum
 import discord
 
+try:  # pragma: no cover - Import-Pfad haengt von pythonpath ab
+    from utils.alert_humanizer import Urgency, format_downtime, urgency_line
+except ImportError:  # pragma: no cover
+    from src.utils.alert_humanizer import (  # type: ignore[no-redef]
+        Urgency,
+        format_downtime,
+        urgency_line,
+    )
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,6 +39,15 @@ class IncidentSeverity(Enum):
     MEDIUM = "medium"
     HIGH = "high"
     CRITICAL = "critical"
+
+
+# Severity-Enum -> Dringlichkeit (gemeinsamer Ton via alert_humanizer.urgency_line)
+_SEVERITY_URGENCY = {
+    IncidentSeverity.LOW: Urgency.LOW,
+    IncidentSeverity.MEDIUM: Urgency.MEDIUM,
+    IncidentSeverity.HIGH: Urgency.HIGH,
+    IncidentSeverity.CRITICAL: Urgency.CRITICAL,
+}
 
 
 class Incident:
@@ -363,9 +381,16 @@ class IncidentManager:
             inline=True
         )
 
+        # Schweregrad -> Dringlichkeits-Klartext (statt rohem Enum-Wert)
+        urgency = _SEVERITY_URGENCY.get(incident.severity, Urgency.MEDIUM)
+        u_line = urgency_line(urgency)
+        severity_value = incident.severity.value.upper()
+        if u_line:
+            # u_line hat die Form "→ Dringlichkeit: hoch · ..." — Prefix entfernen
+            severity_value = u_line.replace("→ Dringlichkeit: ", "").strip()
         embed.add_field(
-            name="⚠️ Schweregrad",
-            value=incident.severity.value.upper(),
+            name="⚠️ Dringlichkeit",
+            value=severity_value,
             inline=True
         )
 
@@ -383,20 +408,11 @@ class IncidentManager:
             inline=False
         )
 
-        # Duration
+        # Duration (Klartext via zentralem format_downtime)
         if incident.duration:
-            duration = incident.duration
-            hours = int(duration.total_seconds() // 3600)
-            minutes = int((duration.total_seconds() % 3600) // 60)
-
-            if hours > 0:
-                duration_str = f"{hours}h {minutes}m"
-            else:
-                duration_str = f"{minutes}m"
-
             embed.add_field(
                 name="⏱️ Dauer",
-                value=duration_str,
+                value=format_downtime(incident.duration.total_seconds()),
                 inline=True
             )
 

--- a/src/integrations/project_monitor.py
+++ b/src/integrations/project_monitor.py
@@ -24,6 +24,23 @@ try:  # pragma: no cover - Import-Pfad haengt von pythonpath ab (src/ vs. shadow
 except ImportError:  # pragma: no cover
     from src.utils.embeds import EmbedBuilder, Severity  # type: ignore[no-redef]
 
+try:  # pragma: no cover - Import-Pfad haengt von pythonpath ab
+    from utils.alert_humanizer import (
+        STATUS_COLOR,
+        format_downtime,
+        humanize_transition,
+        runbook_for,
+        urgency_line,
+    )
+except ImportError:  # pragma: no cover
+    from src.utils.alert_humanizer import (  # type: ignore[no-redef]
+        STATUS_COLOR,
+        format_downtime,
+        humanize_transition,
+        runbook_for,
+        urgency_line,
+    )
+
 logger = logging.getLogger('shadowops.project_monitor')
 
 
@@ -820,52 +837,81 @@ class ProjectMonitor:
         await self._send_dm_alerts(project, "online")
 
     def _create_incident_embed(self, project: ProjectStatus, error: str) -> discord.Embed:
-        """Create embed for incident alert"""
+        """Incident-Embed (Dienst nicht erreichbar) — mensch-lesbar via Humanizer.
+
+        Down = Health-Check schlägt fehl → Dienst antwortet nicht. Wird als
+        Übergang ok → unreachable modelliert ("nicht mehr erreichbar", CRITICAL).
+        """
+        info = humanize_transition("ok", "unreachable")
         embed = discord.Embed(
-            title=f"🔴 {project.name} is DOWN",
-            description=f"Health check failed for **{project.name}**",
-            color=discord.Color.red(),
-            timestamp=datetime.now(timezone.utc)
+            title=f"{info.emoji} {project.name} {info.headline}",
+            description=f"**{project.name}** ({project.url}) antwortet nicht mehr auf den Health-Check.",
+            color=STATUS_COLOR.get("unreachable", discord.Color.red().value),
+            timestamp=datetime.now(timezone.utc),
         )
 
-        embed.add_field(name="Project", value=project.name, inline=True)
-        embed.add_field(name="Status", value="🔴 Offline", inline=True)
-        embed.add_field(name="Consecutive Failures", value=str(project.consecutive_failures), inline=True)
+        # Wiederholte Fehlschläge in Klartext statt roher Zahl
+        fails = project.consecutive_failures
+        if fails > 1:
+            fail_ctx = f"{fails}× in Folge fehlgeschlagen — anhaltender Ausfall"
+        else:
+            fail_ctx = "erstmals fehlgeschlagen"
+        embed.add_field(name="Lage", value=fail_ctx, inline=False)
 
         # Truncate error if too long
         if len(error) > 500:
             error = error[:497] + "..."
-        embed.add_field(name="Error", value=f"```{error}```", inline=False)
+        embed.add_field(name="Fehler", value=f"```{error}```", inline=False)
 
         embed.add_field(
-            name="Uptime (before incident)",
+            name="Uptime (vor Ausfall)",
             value=f"{project.uptime_percentage:.2f}%",
-            inline=True
+            inline=True,
         )
+
+        # Dringlichkeit + optionales Runbook
+        action_lines: list[str] = []
+        u_line = urgency_line(info.urgency)
+        if u_line:
+            action_lines.append(u_line)
+        runbook = runbook_for("web-prod", [])
+        if runbook is not None:
+            action_lines.append(f"→ Runbook: {runbook}")
+        if action_lines:
+            embed.add_field(name="​", value="\n".join(action_lines)[:1024], inline=False)
 
         return embed
 
     def _create_recovery_embed(self, project: ProjectStatus) -> discord.Embed:
-        """Create embed for recovery alert"""
+        """Recovery-Embed (Dienst wieder erreichbar) — Klartext + Downtime."""
+        info = humanize_transition("unreachable", "ok")
+
+        # Downtime in Klartext (last_offline_time ist bei Recovery noch gesetzt)
+        downtime_str = None
+        if project.last_offline_time:
+            secs = (datetime.now(timezone.utc) - project.last_offline_time).total_seconds()
+            downtime_str = format_downtime(secs)
+
+        desc = f"**{project.name}** ({project.url}) ist {info.headline}."
+        if downtime_str:
+            desc += f" Ausfall-Dauer: **{downtime_str}**."
+
         embed = discord.Embed(
-            title=f"✅ {project.name} is BACK ONLINE",
-            description=f"**{project.name}** has recovered",
-            color=discord.Color.green(),
-            timestamp=datetime.now(timezone.utc)
+            title=f"{info.emoji} {project.name} wieder online",
+            description=desc,
+            color=STATUS_COLOR.get("ok", discord.Color.green().value),
+            timestamp=datetime.now(timezone.utc),
         )
 
-        embed.add_field(name="Project", value=project.name, inline=True)
-        embed.add_field(name="Status", value="🟢 Online", inline=True)
         embed.add_field(
-            name="Response Time",
+            name="Antwortzeit",
             value=f"{project.average_response_time:.0f}ms",
-            inline=True
+            inline=True,
         )
-
         embed.add_field(
-            name="Current Uptime",
+            name="Aktuelle Uptime",
             value=f"{project.uptime_percentage:.2f}%",
-            inline=True
+            inline=True,
         )
 
         return embed

--- a/src/utils/alert_humanizer.py
+++ b/src/utils/alert_humanizer.py
@@ -1,0 +1,394 @@
+"""Alert-Humanizer — Status-Telemetrie zu mensch-lesbarem Deutsch.
+
+Zentrales, dependency-freies, rein funktionales Modul (analog
+``integrations.health_schema_v1`` — nur stdlib + dataclasses + Enum,
+KEIN pydantic). Alle Embed-Builder rufen dieselben Uebersetzungs-Funktionen,
+damit Discord-Meldungen konsistent *was ist los / wie schlimm / was tun*
+beantworten statt Roh-Enums (``LOAD_CRITICAL``), Rohzahlen
+(``Load 1min=32.23 on 8 CPUs``) und Status-Tupel (``unreachable -> critical``)
+zu zeigen.
+
+Design-Doc: ``docs/2026-05-28-alert-humanizer-design.md``.
+
+Single-Source-Konvention (Konsistenz-Anker):
+    ``STATUS_EMOJI`` und ``STATUS_COLOR`` leben ab jetzt HIER. Der Aggregator
+    ``cogs/phase_5e_health_aggregator.py`` definiert sie aktuell noch selbst
+    (Zeilen ~67/74) — in einem Folge-Schritt (Builder-Migration) importiert er
+    sie von hier und entfernt seine lokalen Kopien (Deduplizierung). Die Werte
+    hier sind identisch zu den dortigen, inkl. des Aggregator-eigenen
+    ``"unreachable"``-Zustands (nicht Teil des Schema-v1-HealthStatus, aber im
+    Drift-Tracking als vierter Zustand verwendet).
+
+Robustheit:
+    Jede Funktion hat einen Fallback, der NIE Information verschluckt — ein
+    unbekannter Code oder eine unparsebare Metrik gibt den Rohwert durch,
+    niemals eine leere Zeile, niemals ein Crash.
+
+Lokalisierung:
+    Deutsch, Komma als Dezimaltrenner (32,2 statt 32.2), Umlaute Pflicht.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Optional, Protocol
+
+
+# ---------- Status-Konstanten (Single-Source, siehe Modul-Docstring) ----------
+
+# Status -> Discord-Color
+STATUS_COLOR: dict[str, int] = {
+    "ok": 0x2ECC71,        # gruen
+    "degraded": 0xF39C12,  # gelb-orange
+    "critical": 0xE74C3C,  # rot
+    "unreachable": 0x7F8C8D,  # grau
+}
+
+STATUS_EMOJI: dict[str, str] = {
+    "ok": "🟢",
+    "degraded": "🟡",
+    "critical": "🔴",
+    "unreachable": "⚫",
+}
+
+# Emoji fuer unbekannte/unerwartete Status-Werte
+_UNKNOWN_EMOJI = "⚪"
+
+
+# ---------- Dringlichkeit ----------
+
+class Urgency(Enum):
+    """Dringlichkeitsstufen fuer Alerts/Uebergaenge."""
+
+    NONE = 0
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+    CRITICAL = 4
+
+
+_URGENCY_LINES: dict[Urgency, str] = {
+    Urgency.NONE: "",
+    Urgency.LOW: "→ Dringlichkeit: niedrig · im Auge behalten",
+    Urgency.MEDIUM: "→ Dringlichkeit: mittel · demnächst prüfen",
+    Urgency.HIGH: "→ Dringlichkeit: hoch · bitte zeitnah prüfen",
+    Urgency.CRITICAL: "→ Dringlichkeit: kritisch · sofort eingreifen",
+}
+
+
+def urgency_line(urgency: Urgency) -> str:
+    """Dringlichkeit -> deutscher Handlungs-Hinweis.
+
+    ``NONE`` ergibt einen Leerstring (kein Handlungsbedarf). Unbekannte Werte
+    fallen sicher auf Leerstring zurueck.
+    """
+    return _URGENCY_LINES.get(urgency, "")
+
+
+# ---------- Status-Uebergaenge ----------
+
+@dataclass
+class TransitionInfo:
+    """Ergebnis von :func:`humanize_transition`."""
+
+    headline: str       # z.B. "ueberlastet (war kurz nicht erreichbar)"
+    urgency: Urgency
+    emoji: str
+    is_recovery: bool
+
+
+# Status-Rang fuer "wird besser / wird schlimmer"-Heuristik des Defaults.
+_STATUS_RANK: dict[str, int] = {
+    "ok": 0,
+    "degraded": 1,
+    "critical": 2,
+    "unreachable": 3,
+}
+
+# (prev, new) -> (headline, urgency, is_recovery)
+_TRANSITIONS: dict[tuple[str, str], tuple[str, Urgency, bool]] = {
+    # --- aus ok heraus (Verschlechterung) ---
+    ("ok", "degraded"): ("läuft eingeschränkt", Urgency.LOW, False),
+    ("ok", "critical"): ("kritisch überlastet", Urgency.HIGH, False),
+    ("ok", "unreachable"): ("nicht mehr erreichbar", Urgency.CRITICAL, False),
+
+    # --- aus degraded heraus ---
+    ("degraded", "ok"): ("wieder stabil", Urgency.NONE, True),
+    ("degraded", "critical"): ("verschlechtert sich (jetzt kritisch)", Urgency.HIGH, False),
+    ("degraded", "unreachable"): ("nicht mehr erreichbar", Urgency.CRITICAL, False),
+
+    # --- aus critical heraus ---
+    ("critical", "ok"): ("wieder stabil", Urgency.NONE, True),
+    ("critical", "degraded"): ("erholt sich (noch nicht stabil)", Urgency.MEDIUM, False),
+    ("critical", "unreachable"): ("nicht mehr erreichbar (war kritisch)", Urgency.CRITICAL, False),
+
+    # --- aus unreachable heraus (kommt zurueck) ---
+    ("unreachable", "ok"): ("wieder erreichbar und stabil", Urgency.NONE, True),
+    ("unreachable", "degraded"): ("wieder erreichbar (noch eingeschränkt)", Urgency.MEDIUM, False),
+    ("unreachable", "critical"): ("überlastet (war kurz nicht erreichbar)", Urgency.HIGH, False),
+}
+
+
+def humanize_transition(prev: str, new: str) -> TransitionInfo:
+    """Status-Uebergang -> Klartext-Headline + Dringlichkeit.
+
+    ``prev``/``new`` aus {ok, degraded, critical, unreachable}. Bekannte
+    Kombinationen werden aus :data:`_TRANSITIONS` aufgeloest; unerwartete
+    Kombinationen bekommen einen vernuenftigen Default anhand des Status-Rangs
+    (besser/schlechter/gleich), damit nie eine leere Headline entsteht.
+    """
+    emoji = STATUS_EMOJI.get(new, _UNKNOWN_EMOJI)
+
+    mapped = _TRANSITIONS.get((prev, new))
+    if mapped is not None:
+        headline, urgency, is_recovery = mapped
+        return TransitionInfo(headline=headline, urgency=urgency, emoji=emoji, is_recovery=is_recovery)
+
+    # Kein Uebergang (gleicher Status)
+    if prev == new:
+        return TransitionInfo(
+            headline=f"unverändert ({new})",
+            urgency=Urgency.NONE,
+            emoji=emoji,
+            is_recovery=False,
+        )
+
+    # Default-Heuristik anhand des Status-Rangs
+    prev_rank = _STATUS_RANK.get(prev)
+    new_rank = _STATUS_RANK.get(new)
+    if prev_rank is not None and new_rank is not None:
+        if new_rank < prev_rank:
+            # Verbesserung
+            is_recovery = new == "ok"
+            return TransitionInfo(
+                headline=f"erholt sich ({prev} → {new})",
+                urgency=Urgency.NONE if is_recovery else Urgency.MEDIUM,
+                emoji=emoji,
+                is_recovery=is_recovery,
+            )
+        # Verschlechterung
+        return TransitionInfo(
+            headline=f"verschlechtert sich ({prev} → {new})",
+            urgency=Urgency.HIGH,
+            emoji=emoji,
+            is_recovery=False,
+        )
+
+    # Voellig unbekannte Status-Werte -> nie leer, nie Crash
+    return TransitionInfo(
+        headline=f"Statuswechsel: {prev} → {new}",
+        urgency=Urgency.MEDIUM,
+        emoji=emoji,
+        is_recovery=False,
+    )
+
+
+# ---------- Metrik-Parser ----------
+
+def _de_decimal(value: float, digits: int = 1) -> str:
+    """Float -> deutscher Dezimalstring (Komma), z.B. 32.23 -> '32,2'."""
+    return f"{value:.{digits}f}".replace(".", ",")
+
+
+_LOAD_RE = re.compile(
+    r"Load\s+1min\s*=\s*([0-9]+(?:\.[0-9]+)?)\s+on\s+([0-9]+)\s+CPUs",
+    re.IGNORECASE,
+)
+
+# Schwellwert (Load/CPU), ab dem von "ueberlastet" gesprochen wird.
+_OVERLOAD_FACTOR = 1.5
+
+
+def parse_load(message: str) -> Optional[str]:
+    """``"Load 1min=32.23 on 8 CPUs"`` -> ``"CPU-Last 32,2 auf 8 Kernen — 4× überlastet"``.
+
+    Faktor = load/cpus (gerundet). Ab ~1,5x wird "X× überlastet" angehaengt,
+    darunter nur das Verhaeltnis. Regex-Match scheitert -> ``None``
+    (Aufrufer faellt dann auf die Rohmessage zurueck).
+    """
+    if not message:
+        return None
+    match = _LOAD_RE.search(message)
+    if match is None:
+        return None
+    try:
+        load = float(match.group(1))
+        cpus = int(match.group(2))
+    except (ValueError, TypeError):
+        return None
+    if cpus <= 0:
+        return None
+
+    base = f"CPU-Last {_de_decimal(load)} auf {cpus} Kernen"
+    factor = load / cpus
+    if factor >= _OVERLOAD_FACTOR:
+        return f"{base} — {round(factor)}× überlastet"
+    return base
+
+
+_DISK_RE = re.compile(
+    r"Disk\s+usage\s+([0-9]+(?:\.[0-9]+)?)\s*%\s+on\s+(\S+)",
+    re.IGNORECASE,
+)
+
+
+def parse_disk(message: str) -> Optional[str]:
+    """``"Disk usage 84.8% on /"`` -> ``"Platte zu 84,8 % voll (/)"``.
+
+    Regex-Match scheitert -> ``None`` (Aufrufer faellt auf Rohmessage zurueck).
+    """
+    if not message:
+        return None
+    match = _DISK_RE.search(message)
+    if match is None:
+        return None
+    try:
+        percent = float(match.group(1))
+    except (ValueError, TypeError):
+        return None
+    mount = match.group(2)
+    return f"Platte zu {_de_decimal(percent)} % voll ({mount})"
+
+
+_MEM_RE = re.compile(r"([0-9]+(?:\.[0-9]+)?)\s*%")
+
+
+def parse_memory(message: str) -> Optional[str]:
+    """``"Memory usage 87%"`` -> ``"Arbeitsspeicher zu 87 % belegt"``.
+
+    Nimmt den ersten Prozentwert in der Message. Kein Prozentwert -> ``None``.
+    """
+    if not message:
+        return None
+    match = _MEM_RE.search(message)
+    if match is None:
+        return None
+    raw = match.group(1)
+    # Ganzzahlige Prozente ohne ",0" ausgeben, sonst Dezimalkomma.
+    if "." in raw:
+        try:
+            pretty = _de_decimal(float(raw))
+        except (ValueError, TypeError):
+            pretty = raw
+    else:
+        pretty = raw
+    return f"Arbeitsspeicher zu {pretty} % belegt"
+
+
+def parse_service(message: str) -> Optional[str]:
+    """``"github-runner-1 inactive"`` -> ``"Dienst github-runner-1 läuft nicht"``.
+
+    Erstes Token (Service-Name) wird extrahiert; der Rest bleibt erhalten,
+    falls vorhanden. Leere Message -> ``None``.
+    """
+    if not message or not message.strip():
+        return None
+    parts = message.split()
+    service = parts[0]
+    return f"Dienst {service} läuft nicht"
+
+
+# ---------- Alert-Codes ----------
+
+@dataclass(frozen=True)
+class AlertSpec:
+    """Spezifikation pro bekanntem Alert-Code."""
+
+    label: str
+    parser: Optional[Callable[[str], Optional[str]]]
+
+
+# code -> AlertSpec. Der parser darf None liefern (-> Fallback auf Rohmessage).
+ALERT_LABELS: dict[str, AlertSpec] = {
+    "LOAD_CRITICAL": AlertSpec("CPU-Last kritisch", parse_load),
+    "LOAD_HIGH": AlertSpec("CPU-Last hoch", parse_load),
+    "DISK_HIGH": AlertSpec("Plattenplatz knapp", parse_disk),
+    "DISK_CRITICAL": AlertSpec("Plattenplatz kritisch", parse_disk),
+    "MEM_HIGH": AlertSpec("Arbeitsspeicher knapp", parse_memory),
+    "MEM_CRITICAL": AlertSpec("Arbeitsspeicher kritisch", parse_memory),
+    "MEMORY_HIGH": AlertSpec("Arbeitsspeicher knapp", parse_memory),
+    "MEMORY_CRITICAL": AlertSpec("Arbeitsspeicher kritisch", parse_memory),
+    "SERVICE_DOWN": AlertSpec("Dienst ausgefallen", parse_service),
+    "SERVICE_FAILED": AlertSpec("Dienst fehlgeschlagen", parse_service),
+}
+
+
+class _AlertLike(Protocol):
+    code: str
+    component: str
+    message: str
+
+
+def _title_case_code(code: str) -> str:
+    """``"WEIRD_NEW_CODE"`` -> ``"Weird New Code"``."""
+    return " ".join(part.capitalize() for part in code.replace("-", "_").split("_") if part)
+
+
+def humanize_alert(alert: _AlertLike) -> str:
+    """``HealthAlert`` (oder duck-typed code/component/message) -> eine lesbare Zeile.
+
+    Bekannte Codes (siehe :data:`ALERT_LABELS`) bekommen Klartext + Metrik-Kontext;
+    der zugehoerige Parser liefert den Kontext oder ``None`` -> Fallback auf die
+    Rohmessage. Unbekannte Codes fallen auf ``"<Title-Case-Code>: <message>"``
+    zurueck. Es geht NIE Information verloren und es wird NIE eine leere Zeile
+    zurueckgegeben.
+    """
+    code = str(getattr(alert, "code", "") or "UNKNOWN")
+    message = str(getattr(alert, "message", "") or "")
+
+    spec = ALERT_LABELS.get(code)
+    if spec is not None:
+        context: Optional[str] = None
+        if spec.parser is not None:
+            try:
+                context = spec.parser(message)
+            except Exception:  # pragma: no cover - Parser duerfen nie crashen lassen
+                context = None
+        if context:
+            return context
+        # Parser scheiterte -> bekanntes Label + Rohmessage (Info bleibt erhalten)
+        if message.strip():
+            return f"{spec.label}: {message}"
+        return spec.label
+
+    # Unbekannter Code -> Title-Case + Rohmessage
+    title = _title_case_code(code)
+    if message.strip():
+        return f"{title}: {message}"
+    return title
+
+
+# ---------- Runbooks ----------
+
+# role|component -> Runbook-Datei (relativ, im Repo unter docs/ops/ erwartet).
+RUNBOOKS: dict[str, str] = {
+    # Rollen
+    "ci-runner": "mayday-ci-runner.md",
+    "web-prod": "zerodox-web.md",
+    "web-dev": "zerodox-web.md",
+    # Komponenten
+    "disk": "disk-pressure.md",
+    "memory": "memory-pressure.md",
+    "load": "high-load.md",
+    "database": "database.md",
+    "redis": "redis.md",
+    "wireguard": "wireguard.md",
+    "github_runners": "mayday-ci-runner.md",
+}
+
+
+def runbook_for(role: str, components: list[str]) -> Optional[str]:
+    """Liefert den passendsten Runbook-Pfad — Rolle hat Vorrang vor Komponente.
+
+    Unbekannte Rolle UND keine bekannte Komponente -> ``None``.
+    """
+    rb = RUNBOOKS.get(role)
+    if rb is not None:
+        return rb
+    for component in components or []:
+        rb = RUNBOOKS.get(component)
+        if rb is not None:
+            return rb
+    return None

--- a/src/utils/alert_humanizer.py
+++ b/src/utils/alert_humanizer.py
@@ -87,6 +87,26 @@ def urgency_line(urgency: Urgency) -> str:
     return _URGENCY_LINES.get(urgency, "")
 
 
+def format_downtime(seconds: float) -> str:
+    """Sekunden -> kurzer deutscher Dauer-Klartext, z.B. '2 Min', '1 Std 5 Min'.
+
+    Zentral hier, damit alle Builder (phase_5e, project_monitor, incident_manager)
+    dieselbe Formatierung nutzen statt zu duplizieren. Negative Werte -> '0 Sek'.
+    """
+    seconds = int(max(0, seconds))
+    if seconds < 60:
+        return f"{seconds} Sek"
+    if seconds < 3600:
+        return f"{seconds // 60} Min"
+    if seconds < 86400:
+        h, rem = divmod(seconds, 3600)
+        m = rem // 60
+        return f"{h} Std {m} Min" if m else f"{h} Std"
+    days, rem = divmod(seconds, 86400)
+    h = rem // 3600
+    return f"{days} Tg {h} Std" if h else f"{days} Tg"
+
+
 # ---------- Status-Uebergaenge ----------
 
 @dataclass

--- a/src/utils/embeds.py
+++ b/src/utils/embeds.py
@@ -8,6 +8,11 @@ from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 from enum import Enum
 
+try:  # pragma: no cover - Import-Pfad haengt von pythonpath ab
+    from utils.alert_humanizer import Urgency, urgency_line
+except ImportError:  # pragma: no cover
+    from src.utils.alert_humanizer import Urgency, urgency_line  # type: ignore[no-redef]
+
 
 class Severity(Enum):
     """Alert Severity Levels"""
@@ -24,8 +29,25 @@ class Severity(Enum):
         self.label = label
 
 
+# Severity -> Urgency: gemeinsamer Handlungs-Ton (alert_humanizer.urgency_line).
+# INFO/SUCCESS/LOW haben keinen Handlungsbedarf (Urgency.NONE -> keine Zeile).
+_SEVERITY_TO_URGENCY = {
+    Severity.LOW: Urgency.NONE,
+    Severity.MEDIUM: Urgency.MEDIUM,
+    Severity.HIGH: Urgency.HIGH,
+    Severity.CRITICAL: Urgency.CRITICAL,
+    Severity.INFO: Urgency.NONE,
+    Severity.SUCCESS: Urgency.NONE,
+}
+
+
 class EmbedBuilder:
     """Helper-Klasse zum Erstellen von Discord Embeds"""
+
+    @staticmethod
+    def severity_to_urgency(severity: Severity) -> Urgency:
+        """Mappt eine Severity auf die gemeinsame Dringlichkeit (alert_humanizer)."""
+        return _SEVERITY_TO_URGENCY.get(severity, Urgency.MEDIUM)
 
     @staticmethod
     def create_alert(
@@ -36,6 +58,7 @@ class EmbedBuilder:
         footer: Optional[str] = None,
         project_tag: Optional[str] = None,
         project_color: Optional[int] = None,
+        add_urgency: bool = False,
     ) -> discord.Embed:
         """
         Erstellt ein Alert-Embed
@@ -48,6 +71,10 @@ class EmbedBuilder:
             footer: Footer-Text
             project_tag: Project-Tag (z.B. "[SECURITY]")
             project_color: Überschreibt severity-Farbe mit Project-Farbe
+            add_urgency: Hängt eine Dringlichkeits-Handlungszeile an (gemeinsamer
+                Ton via alert_humanizer.urgency_line). Default False — bestehende
+                Aufrufer bleiben unverändert. Bei Severity ohne Handlungsbedarf
+                (INFO/SUCCESS/LOW) wird keine Zeile angehängt.
 
         Returns:
             Discord Embed
@@ -60,9 +87,16 @@ class EmbedBuilder:
         # Farbe: Project-Color oder Severity-Color
         color = project_color if project_color else severity.color
 
+        # Dringlichkeits-Zeile (konsistenter Ton mit den Health-/Incident-Embeds)
+        full_description = description
+        if add_urgency:
+            u_line = urgency_line(EmbedBuilder.severity_to_urgency(severity))
+            if u_line:
+                full_description = f"{description}\n\n{u_line}" if description else u_line
+
         embed = discord.Embed(
             title=full_title,
-            description=description,
+            description=full_description,
             color=color,
             timestamp=datetime.now(timezone.utc)
         )

--- a/tests/unit/test_alert_humanizer.py
+++ b/tests/unit/test_alert_humanizer.py
@@ -1,0 +1,301 @@
+"""Unit-Tests fuer utils.alert_humanizer.
+
+Reine Funktionen — keine Discord-, Netzwerk- oder DB-Abhaengigkeit.
+Schwerpunkte (siehe docs/2026-05-28-alert-humanizer-design.md):
+  - Status-Uebergangs-Matrix (Teilmenge der 4x4)
+  - Bekannte Alert-Codes mit echten Prod-message-Strings
+  - Fallback-Pfade: unbekannter Code / unparsebare Metrik -> Rohwert bleibt
+  - Dezimal-Lokalisierung (32.23 -> "32,2")
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from integrations.health_schema_v1 import HealthAlert
+from utils.alert_humanizer import (
+    RUNBOOKS,
+    STATUS_COLOR,
+    STATUS_EMOJI,
+    TransitionInfo,
+    Urgency,
+    humanize_alert,
+    humanize_transition,
+    parse_disk,
+    parse_load,
+    runbook_for,
+    urgency_line,
+)
+
+
+# ---------- humanize_transition ----------
+
+def test_transition_unreachable_to_critical() -> None:
+    info = humanize_transition("unreachable", "critical")
+    assert isinstance(info, TransitionInfo)
+    assert info.headline == "überlastet (war kurz nicht erreichbar)"
+    assert info.urgency == Urgency.HIGH
+    assert info.is_recovery is False
+    assert info.emoji == STATUS_EMOJI["critical"]
+
+
+def test_transition_degraded_to_ok_is_recovery() -> None:
+    info = humanize_transition("degraded", "ok")
+    assert info.headline == "wieder stabil"
+    assert info.urgency == Urgency.NONE
+    assert info.is_recovery is True
+    assert info.emoji == STATUS_EMOJI["ok"]
+
+
+def test_transition_ok_to_unreachable_is_critical() -> None:
+    info = humanize_transition("ok", "unreachable")
+    assert info.headline == "nicht mehr erreichbar"
+    assert info.urgency == Urgency.CRITICAL
+    assert info.is_recovery is False
+
+
+def test_transition_critical_to_degraded_recovering() -> None:
+    info = humanize_transition("critical", "degraded")
+    assert info.urgency == Urgency.MEDIUM
+    assert info.is_recovery is False
+    assert "erholt" in info.headline.lower() or "stabil" in info.headline.lower()
+
+
+def test_transition_ok_to_critical_high_or_critical() -> None:
+    info = humanize_transition("ok", "critical")
+    assert info.urgency in (Urgency.HIGH, Urgency.CRITICAL)
+    assert info.is_recovery is False
+    assert info.headline  # nicht leer
+
+
+def test_transition_critical_to_ok_full_recovery() -> None:
+    info = humanize_transition("critical", "ok")
+    assert info.is_recovery is True
+    assert info.urgency == Urgency.NONE
+
+
+def test_transition_ok_to_degraded() -> None:
+    info = humanize_transition("ok", "degraded")
+    assert info.is_recovery is False
+    assert info.headline
+    assert info.urgency in (Urgency.LOW, Urgency.MEDIUM)
+
+
+def test_transition_same_status_no_change() -> None:
+    info = humanize_transition("ok", "ok")
+    assert info.is_recovery is False
+    assert info.headline
+
+
+def test_transition_unknown_combo_has_sane_default() -> None:
+    info = humanize_transition("foo", "bar")
+    assert isinstance(info, TransitionInfo)
+    assert info.headline  # nie leer
+    assert isinstance(info.urgency, Urgency)
+    assert isinstance(info.emoji, str) and info.emoji
+
+
+def test_transition_emoji_matches_status_map() -> None:
+    info = humanize_transition("ok", "degraded")
+    assert info.emoji == STATUS_EMOJI["degraded"]
+
+
+# ---------- humanize_alert: bekannte Codes ----------
+
+def _alert(code: str, message: str, component: str = "x", severity: str = "warning") -> HealthAlert:
+    return HealthAlert(code=code, severity=severity, component=component, message=message)
+
+
+def test_humanize_alert_load_critical() -> None:
+    line = humanize_alert(_alert("LOAD_CRITICAL", "Load 1min=32.23 on 8 CPUs", "load", "critical"))
+    assert "CPU-Last" in line
+    assert "32,2" in line  # Dezimalkomma
+    assert "8 Kernen" in line
+    assert "überlastet" in line
+    assert "32.2" not in line  # kein Punkt
+
+
+def test_humanize_alert_disk_high() -> None:
+    line = humanize_alert(_alert("DISK_HIGH", "Disk usage 84.8% on /", "disk"))
+    assert "Platte" in line
+    assert "84,8" in line
+    assert "/" in line
+    assert "84.8" not in line
+
+
+def test_humanize_alert_disk_critical() -> None:
+    line = humanize_alert(_alert("DISK_CRITICAL", "Disk usage 95.0% on /var", "disk", "critical"))
+    assert "Platte" in line
+    assert "95,0" in line
+    assert "/var" in line
+
+
+def test_humanize_alert_memory_high() -> None:
+    line = humanize_alert(_alert("MEMORY_HIGH", "Memory usage 87%", "memory"))
+    assert "Arbeitsspeicher" in line
+    assert "87" in line
+
+
+def test_humanize_alert_mem_short_code() -> None:
+    line = humanize_alert(_alert("MEM_CRITICAL", "Memory usage 96%", "memory", "critical"))
+    assert "Arbeitsspeicher" in line
+    assert "96" in line
+
+
+def test_humanize_alert_service_down() -> None:
+    line = humanize_alert(_alert("SERVICE_DOWN", "github-runner-1 inactive", "github_runners", "critical"))
+    assert "Dienst" in line
+    assert "läuft nicht" in line
+    # Service-Name aus der Message bleibt erhalten
+    assert "github-runner-1" in line
+
+
+def test_humanize_alert_service_failed() -> None:
+    line = humanize_alert(_alert("SERVICE_FAILED", "wg-quick@wg0 failed", "wireguard", "critical"))
+    assert "Dienst" in line
+    assert "wg-quick@wg0" in line
+
+
+# ---------- humanize_alert: Fallback ----------
+
+def test_humanize_alert_unknown_code_keeps_info() -> None:
+    line = humanize_alert(_alert("WEIRD_NEW_CODE", "etwas Ungewoehnliches passiert", "foo"))
+    assert "etwas Ungewoehnliches passiert" in line  # message nie verloren
+    assert line  # nie leer
+    # Title-Case-Variante des Codes
+    assert "Weird New Code" in line
+
+
+def test_humanize_alert_unknown_code_empty_message() -> None:
+    line = humanize_alert(_alert("MYSTERY_CODE", "", "foo"))
+    assert line.strip()  # nie leer, auch ohne message
+    assert "Mystery Code" in line
+
+
+def test_humanize_alert_known_code_unparsable_metric_falls_back() -> None:
+    # LOAD_CRITICAL, aber Message passt nicht zum Regex -> Rohmessage bleibt
+    line = humanize_alert(_alert("LOAD_CRITICAL", "irgendwas ohne Zahlen", "load", "critical"))
+    assert "irgendwas ohne Zahlen" in line
+    assert line
+
+
+def test_humanize_alert_disk_unparsable_falls_back() -> None:
+    line = humanize_alert(_alert("DISK_HIGH", "kein Prozentwert hier", "disk"))
+    assert "kein Prozentwert hier" in line
+    assert line
+
+
+def test_humanize_alert_duck_typed_object() -> None:
+    class Fake:
+        code = "LOAD_HIGH"
+        component = "load"
+        message = "Load 1min=12.0 on 8 CPUs"
+
+    line = humanize_alert(Fake())
+    assert "CPU-Last" in line
+    assert "12,0" in line
+
+
+# ---------- parse_load ----------
+
+def test_parse_load_overloaded() -> None:
+    out = parse_load("Load 1min=32.23 on 8 CPUs")
+    assert out is not None
+    assert "32,2" in out
+    assert "8 Kernen" in out
+    assert "überlastet" in out
+    # 32.23 / 8 = 4.03 -> 4x
+    assert "4" in out
+
+
+def test_parse_load_normal_ratio() -> None:
+    out = parse_load("Load 1min=2.0 on 8 CPUs")
+    assert out is not None
+    assert "2,0" in out
+    assert "8 Kernen" in out
+    # Faktor 0.25 -> nicht "ueberlastet"
+    assert "überlastet" not in out
+
+
+def test_parse_load_no_match_returns_none() -> None:
+    assert parse_load("kein Load hier") is None
+    assert parse_load("") is None
+
+
+def test_parse_load_decimal_localization() -> None:
+    out = parse_load("Load 1min=1.50 on 4 CPUs")
+    assert out is not None
+    assert "1,5" in out
+    assert "1.5" not in out
+
+
+# ---------- parse_disk ----------
+
+def test_parse_disk_basic() -> None:
+    out = parse_disk("Disk usage 84.8% on /")
+    assert out is not None
+    assert "84,8" in out
+    assert "voll" in out
+    assert "/" in out
+
+
+def test_parse_disk_other_mount() -> None:
+    out = parse_disk("Disk usage 91.2% on /var/lib/docker")
+    assert out is not None
+    assert "91,2" in out
+    assert "/var/lib/docker" in out
+
+
+def test_parse_disk_no_match_returns_none() -> None:
+    assert parse_disk("nichts brauchbares") is None
+    assert parse_disk("") is None
+
+
+# ---------- urgency_line ----------
+
+@pytest.mark.parametrize("urgency", list(Urgency))
+def test_urgency_line_never_empty(urgency: Urgency) -> None:
+    line = urgency_line(urgency)
+    assert isinstance(line, str)
+    if urgency == Urgency.NONE:
+        # NONE darf leer sein (kein Handlungsbedarf)
+        assert line == "" or line
+    else:
+        assert line.strip()
+
+
+def test_urgency_line_high_german_label() -> None:
+    line = urgency_line(Urgency.HIGH)
+    assert "hoch" in line.lower()
+
+
+def test_urgency_line_critical_german_label() -> None:
+    line = urgency_line(Urgency.CRITICAL)
+    assert "kritisch" in line.lower() or "sofort" in line.lower()
+
+
+# ---------- runbook_for ----------
+
+def test_runbook_for_ci_runner() -> None:
+    rb = runbook_for("ci-runner", [])
+    assert rb == RUNBOOKS["ci-runner"]
+    assert "mayday-ci-runner" in rb
+
+
+def test_runbook_for_unknown_role_returns_none() -> None:
+    assert runbook_for("nonexistent-role", []) is None
+
+
+def test_runbook_for_component_fallback() -> None:
+    # Wenn Rolle unbekannt, aber Komponente bekannt -> Runbook der Komponente
+    rb = runbook_for("unknown", ["disk"])
+    # Entweder None oder ein bekanntes Runbook, aber kein Crash
+    assert rb is None or isinstance(rb, str)
+
+
+# ---------- Konstanten-Konsistenz ----------
+
+def test_status_maps_cover_all_statuses() -> None:
+    for status in ("ok", "degraded", "critical", "unreachable"):
+        assert status in STATUS_EMOJI
+        assert status in STATUS_COLOR

--- a/tests/unit/test_deployment_manager_humanizer.py
+++ b/tests/unit/test_deployment_manager_humanizer.py
@@ -1,0 +1,123 @@
+"""Tests für die humanisierten Deploy-Embeds (Klartext-Zusammenfassung).
+
+Verifiziert: Success-/Failure-Embed fassen die Step-Liste zu Klartext zusammen
+(X/Y Schritten ok), heben den fehlgeschlagenen Schritt hervor und nutzen die
+zentrale Dauer-Formatierung — statt einer rohen 10er-Step-Liste als einzigem
+Signal.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.integrations.deployment_manager import (
+    DeploymentManager,
+    _summarize_steps,
+    _format_deploy_duration,
+)
+
+
+def _mgr_with_channel():
+    """DeploymentManager-Stub mit gemocktem Channel; gibt (mgr, channel) zurück."""
+    mgr = DeploymentManager.__new__(DeploymentManager)
+    mgr.logger = MagicMock()
+    mgr.deployment_channel_id = 12345
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    mgr.bot = MagicMock()
+    mgr.bot.get_channel = MagicMock(return_value=channel)
+    # _forward_deploy_to_external überspringen (kein externer Versand im Test)
+    mgr._forward_deploy_to_external = AsyncMock()
+    return mgr, channel
+
+
+def _sent_embed(channel):
+    return channel.send.call_args.kwargs["embed"]
+
+
+# ---------- Helper-Funktionen ----------
+
+def test_summarize_steps_all_ok():
+    steps = ["`10:00:00` Build ok", "`10:00:05` Migrate ok", "`10:00:10` Restart ok"]
+    ok, total, failed = _summarize_steps(steps)
+    assert ok == 3
+    assert total == 3
+    assert failed is None
+
+
+def test_summarize_steps_detects_failure():
+    steps = [
+        "`10:00:00` Build ok",
+        "`10:00:05` ❌ Migrate fehlgeschlagen",
+        "`10:00:10` Restart ok",
+    ]
+    ok, total, failed = _summarize_steps(steps)
+    assert total == 3
+    assert ok == 2
+    assert failed is not None
+    assert "Migrate" in failed
+
+
+def test_format_deploy_duration_short_vs_long():
+    # kurz -> Sekunden
+    assert _format_deploy_duration(12.3) == "12.3s"
+    # lang -> deutscher Klartext via format_downtime
+    long = _format_deploy_duration(150)
+    assert "Min" in long
+
+
+# ---------- Success-Embed ----------
+
+@pytest.mark.asyncio
+async def test_success_embed_summarizes_steps():
+    mgr, channel = _mgr_with_channel()
+    mgr._deploy_steps = {
+        "ZERODOX": ["`10:00:00` Build ok", "`10:00:05` Migrate ok", "`10:00:10` Restart ok"]
+    }
+
+    await mgr._send_deployment_success("ZERODOX", "main", 42.0, {})
+
+    embed = _sent_embed(channel)
+    assert "erfolgreich" in embed.title.lower()
+    # Klartext-Zusammenfassung statt blossem "deployed successfully"
+    assert "3 Schritte" in embed.description
+    assert "successfully" not in embed.description
+
+
+# ---------- Failure-Embed ----------
+
+@pytest.mark.asyncio
+async def test_failure_embed_highlights_failed_step():
+    mgr, channel = _mgr_with_channel()
+    mgr._deploy_steps = {
+        "ZERODOX": [
+            "`10:00:00` Build ok",
+            "`10:00:05` Migrate ok",
+            "`10:00:10` ❌ Health-Check fehlgeschlagen",
+        ]
+    }
+    result = {"error": "health endpoint returned 503", "rolled_back": True}
+
+    await mgr._send_deployment_failure("ZERODOX", "main", 30.0, result)
+
+    embed = _sent_embed(channel)
+    assert "fehlgeschlagen" in embed.title.lower()
+    # Zusammenfassung: 2/3 ok + fehlgeschlagener Schritt benannt
+    assert "2/3" in embed.description
+    assert "Health-Check" in embed.description
+    # Eigenes Hervorhebungs-Feld
+    field_names = [f.name for f in embed.fields]
+    assert any("Fehlgeschlagen bei" in n for n in field_names)
+
+
+@pytest.mark.asyncio
+async def test_failure_embed_without_steps_does_not_crash():
+    mgr, channel = _mgr_with_channel()
+    mgr._deploy_steps = {}
+    result = {"error": "boom", "rolled_back": False}
+
+    await mgr._send_deployment_failure("ZERODOX", "main", 5.0, result)
+
+    embed = _sent_embed(channel)
+    assert "fehlgeschlagen" in embed.title.lower()
+    assert embed.description  # nie leer

--- a/tests/unit/test_embeds.py
+++ b/tests/unit/test_embeds.py
@@ -1,0 +1,61 @@
+"""Tests für EmbedBuilder — Ton-Konsistenz mit dem Alert-Humanizer.
+
+create_alert kann optional eine Dringlichkeits-Handlungszeile anhängen
+(gemeinsamer Ton via alert_humanizer.urgency_line). Default-Verhalten bleibt
+unverändert (add_urgency=False), damit bestehende Aufrufer nicht brechen.
+"""
+from __future__ import annotations
+
+from src.utils.embeds import EmbedBuilder, Severity
+
+
+def test_severity_to_urgency_mapping():
+    # Vergleich über .name — EmbedBuilder kann je nach pythonpath ein anderes
+    # Urgency-Objekt geladen haben (utils.* vs. src.utils.*), Wert ist identisch.
+    assert EmbedBuilder.severity_to_urgency(Severity.CRITICAL).name == "CRITICAL"
+    assert EmbedBuilder.severity_to_urgency(Severity.HIGH).name == "HIGH"
+    assert EmbedBuilder.severity_to_urgency(Severity.MEDIUM).name == "MEDIUM"
+    # Kein Handlungsbedarf
+    assert EmbedBuilder.severity_to_urgency(Severity.INFO).name == "NONE"
+    assert EmbedBuilder.severity_to_urgency(Severity.SUCCESS).name == "NONE"
+    assert EmbedBuilder.severity_to_urgency(Severity.LOW).name == "NONE"
+
+
+def test_create_alert_default_has_no_urgency_line():
+    """Default (add_urgency=False) -> Beschreibung unverändert."""
+    embed = EmbedBuilder.create_alert("Titel", "Beschreibung", severity=Severity.CRITICAL)
+    assert embed.description == "Beschreibung"
+    assert "Dringlichkeit" not in embed.description
+
+
+def test_create_alert_with_urgency_appends_line():
+    embed = EmbedBuilder.create_alert(
+        "Titel", "Beschreibung", severity=Severity.HIGH, add_urgency=True
+    )
+    assert "Beschreibung" in embed.description
+    assert "Dringlichkeit" in embed.description
+    assert "hoch" in embed.description.lower()
+
+
+def test_create_alert_with_urgency_info_no_line():
+    """INFO -> Urgency.NONE -> keine Zeile, auch mit add_urgency=True."""
+    embed = EmbedBuilder.create_alert(
+        "Titel", "Beschreibung", severity=Severity.INFO, add_urgency=True
+    )
+    assert embed.description == "Beschreibung"
+
+
+def test_create_alert_still_builds_emoji_title_and_fields():
+    """Regression: Emoji-Titel, project_tag und Felder funktionieren weiter."""
+    embed = EmbedBuilder.create_alert(
+        "Titel",
+        "Beschreibung",
+        severity=Severity.CRITICAL,
+        fields=[{"name": "A", "value": "B", "inline": True}],
+        project_tag="🖥️ [SERVER]",
+    )
+    assert "[SERVER]" in embed.title
+    assert "🔴" in embed.title
+    assert embed.color.value == Severity.CRITICAL.color
+    assert len(embed.fields) == 1
+    assert embed.fields[0].name == "A"

--- a/tests/unit/test_incident_manager.py
+++ b/tests/unit/test_incident_manager.py
@@ -435,3 +435,48 @@ class TestAutoClose:
         assert incident.status == IncidentStatus.CLOSED
         manager._post_thread_update.assert_called_once()
         manager._update_incident_message.assert_called_once()
+
+
+class TestHumanizedIncidentEmbed:
+    """_create_incident_embed nutzt Dringlichkeits-Klartext + format_downtime."""
+
+    def _manager(self, tmp_path):
+        mock_config = _make_config(channels={'customer_alerts': 12345})
+        with patch('src.integrations.incident_manager.Path') as mock_path:
+            mock_path.return_value = tmp_path / 'incidents.json'
+            return IncidentManager(Mock(), mock_config)
+
+    def _incident(self, severity):
+        return Incident(
+            incident_id='inc-1',
+            title='ZERODOX nicht erreichbar',
+            description='Health-Check schlägt fehl',
+            severity=severity,
+            affected_projects=['ZERODOX'],
+            event_type='downtime',
+        )
+
+    def test_severity_becomes_urgency_klartext(self, tmp_path):
+        manager = self._manager(tmp_path)
+        embed = manager._create_incident_embed(self._incident(IncidentSeverity.CRITICAL))
+
+        # Feld heißt jetzt "Dringlichkeit", nicht "Schweregrad"
+        names = [f.name for f in embed.fields]
+        assert any('Dringlichkeit' in n for n in names)
+        # Rohwert "CRITICAL" ersetzt durch Klartext (kritisch + Handlungshinweis)
+        dring = next(f.value for f in embed.fields if 'Dringlichkeit' in f.name)
+        assert 'kritisch' in dring.lower()
+        assert 'CRITICAL' not in dring
+
+    def test_duration_uses_central_format(self, tmp_path):
+        manager = self._manager(tmp_path)
+        incident = self._incident(IncidentSeverity.HIGH)
+        # 90 Minuten Dauer erzwingen
+        incident.created_at = datetime.now(timezone.utc) - timedelta(minutes=90)
+        embed = manager._create_incident_embed(incident)
+
+        dauer = next((f.value for f in embed.fields if 'Dauer' in f.name), None)
+        assert dauer is not None
+        # format_downtime liefert deutschen Klartext "1 Std 30 Min", nicht "1h 30m"
+        assert 'Std' in dauer
+        assert 'h ' not in dauer

--- a/tests/unit/test_phase_5e_health_aggregator.py
+++ b/tests/unit/test_phase_5e_health_aggregator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -297,3 +297,142 @@ class TestDriftHandling:
         await cog._handle_drifts([result])  # darf nicht raisen
 
         cog.logger.error.assert_called_once()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Incident-Grouping (Modul 2): aufeinanderfolgende Drifts = 1 Message
+# ────────────────────────────────────────────────────────────────────────
+
+
+def _make_incident_channel():
+    """Channel-Mock mit send() → Message(id=...) und edit-fähiger partial message."""
+    sent_message = MagicMock(spec=discord.Message)
+    sent_message.id = 555000111
+
+    edited = MagicMock(spec=discord.Message)
+    edited.edit = AsyncMock()
+
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=sent_message)
+    channel.get_partial_message = MagicMock(return_value=edited)
+    return channel, sent_message, edited
+
+
+class TestIncidentGrouping:
+    @pytest.mark.asyncio
+    async def test_three_drifts_one_message_then_edits(self, cog, cog_module):
+        """3 aufeinanderfolgende Drifts desselben Hosts → 1 send + N edits."""
+        cog._last_status_per_host = {"Runner-VM": "ok"}
+        channel, sent_msg, edited = _make_incident_channel()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        # Drift 1: ok → unreachable (öffnet Incident, postet Message)
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="unreachable")])
+        # Drift 2: unreachable → critical (editiert bestehende Message)
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="critical")])
+        # Drift 3: critical → degraded (editiert bestehende Message)
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="degraded")])
+
+        # Genau EIN send, danach nur noch edits
+        channel.send.assert_called_once()
+        assert edited.edit.call_count == 2
+        channel.get_partial_message.assert_called_with(sent_msg.id)
+
+        incident = cog._open_incidents["Runner-VM"]
+        assert incident.message_id == sent_msg.id
+        assert len(incident.transitions) == 3
+        assert incident.worst_status == "unreachable"
+
+    @pytest.mark.asyncio
+    async def test_recovery_edit_shows_downtime_and_closes(self, cog, cog_module):
+        """Recovery → finale Edit mit Downtime, Incident wird geschlossen."""
+        cog._last_status_per_host = {"Runner-VM": "ok"}
+        channel, sent_msg, edited = _make_incident_channel()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        # Incident öffnen
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="critical")])
+        # started_at manuell zurückdatieren für messbare Downtime
+        cog._open_incidents["Runner-VM"].started_at = datetime.now(timezone.utc) - timedelta(minutes=7)
+
+        # Recovery: critical → ok
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="ok")])
+
+        # Recovery editiert die bestehende Message (kein zweiter send)
+        channel.send.assert_called_once()
+        edited.edit.assert_called_once()
+
+        # Finale Embed enthält Downtime-Klartext + Selbst-Erholung
+        final_embed = edited.edit.call_args.kwargs["embed"]
+        assert "Ausfall" in final_embed.description
+        assert "Min" in final_embed.description
+        assert "Selbst-erholt" in final_embed.description
+
+        # Incident geschlossen
+        assert "Runner-VM" not in cog._open_incidents
+
+    @pytest.mark.asyncio
+    async def test_two_hosts_two_incidents(self, cog, cog_module):
+        """Zwei verschiedene Hosts → zwei getrennte Incidents (2 sends)."""
+        cog._last_status_per_host = {"Runner-VM": "ok", "ZERODOX Production": "ok"}
+        channel, _sent, _edited = _make_incident_channel()
+        # jeder send liefert eine eigene Message-id
+        ids = iter([111, 222])
+
+        def _send(*args, **kwargs):
+            m = MagicMock(spec=discord.Message)
+            m.id = next(ids)
+            return m
+
+        channel.send = AsyncMock(side_effect=_send)
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog._handle_drifts([
+            _make_poll_result(cog_module, name="Runner-VM", status="critical"),
+            _make_poll_result(cog_module, name="ZERODOX Production", status="degraded"),
+        ])
+
+        assert channel.send.call_count == 2
+        assert set(cog._open_incidents.keys()) == {"Runner-VM", "ZERODOX Production"}
+        assert cog._open_incidents["Runner-VM"].message_id == 111
+        assert cog._open_incidents["ZERODOX Production"].message_id == 222
+
+    @pytest.mark.asyncio
+    async def test_edit_failure_falls_back_to_new_post(self, cog, cog_module):
+        """Wenn edit() 404 wirft (Message gelöscht), wird neu gepostet + id aktualisiert."""
+        cog._last_status_per_host = {"Runner-VM": "ok"}
+        cog.logger = MagicMock()
+
+        first_msg = MagicMock(spec=discord.Message)
+        first_msg.id = 100
+        repost_msg = MagicMock(spec=discord.Message)
+        repost_msg.id = 200
+
+        stale = MagicMock(spec=discord.Message)
+        stale.edit = AsyncMock(side_effect=discord.NotFound(MagicMock(status=404, reason="x"), "gone"))
+
+        channel = MagicMock()
+        channel.send = AsyncMock(side_effect=[first_msg, repost_msg])
+        channel.get_partial_message = MagicMock(return_value=stale)
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        # Drift 1 öffnet Incident (send → id 100)
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="critical")])
+        # Drift 2 versucht edit (404) → neu posten (send → id 200)
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="unreachable")])
+
+        assert channel.send.call_count == 2
+        stale.edit.assert_called_once()
+        assert cog._open_incidents["Runner-VM"].message_id == 200
+
+    @pytest.mark.asyncio
+    async def test_recovery_without_open_incident_posts_simple(self, cog, cog_module):
+        """Recovery ohne offenen Incident (z.B. nach Bot-Restart) → einfacher Post, kein Crash."""
+        cog._last_status_per_host = {"Runner-VM": "critical"}
+        channel, sent_msg, _edited = _make_incident_channel()
+        cog.bot.get_channel = MagicMock(return_value=channel)
+
+        await cog._handle_drifts([_make_poll_result(cog_module, name="Runner-VM", status="ok")])
+
+        channel.send.assert_called_once()
+        assert "Runner-VM" not in cog._open_incidents

--- a/tests/unit/test_project_monitor.py
+++ b/tests/unit/test_project_monitor.py
@@ -4,7 +4,7 @@ Unit Tests for Project Monitor
 
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import aiohttp
 
 from src.integrations.project_monitor import ProjectMonitor, ProjectStatus
@@ -386,3 +386,48 @@ class TestStatusRetrieval:
         assert len(all_statuses) == 2
         assert any(s['name'] == 'project1' and s['is_online'] for s in all_statuses)
         assert any(s['name'] == 'project2' and not s['is_online'] for s in all_statuses)
+
+
+class TestHumanizedEmbeds:
+    """Migrierte Incident-/Recovery-Embeds nutzen den Alert-Humanizer (Klartext)."""
+
+    def _monitor(self):
+        config = MagicMock()
+        config.projects = {}
+        config.customer_status_channel = 12345
+        return ProjectMonitor(Mock(), config)
+
+    def test_incident_embed_is_human_readable(self):
+        monitor = self._monitor()
+        status = ProjectStatus('ZERODOX', {'url': 'https://zerodox.de/health'})
+        status.update_online(100.0)
+        status.update_offline('Connection refused')
+        status.update_offline('Connection refused')  # 2x in Folge
+
+        embed = monitor._create_incident_embed(status, 'Connection refused')
+
+        # Kein Roh-Enum "DOWN" mehr, sondern Klartext-Headline
+        assert 'DOWN' not in embed.title
+        assert 'erreichbar' in embed.title.lower()
+        # Wiederholte Fehlschläge in Klartext statt nackter Zahl
+        field_text = "\n".join(f.value for f in embed.fields)
+        assert 'in Folge' in field_text
+        # Dringlichkeit vorhanden (unreachable -> CRITICAL)
+        assert 'Dringlichkeit' in field_text
+
+    def test_recovery_embed_shows_downtime_klartext(self):
+        monitor = self._monitor()
+        status = ProjectStatus('ZERODOX', {'url': 'https://zerodox.de/health'})
+        status.update_online(100.0)
+        status.update_offline('Error')
+        # Offline-Zeitpunkt 5 Min zurückdatieren für messbare Downtime
+        status.last_offline_time = datetime.now(timezone.utc) - timedelta(minutes=5)
+        status.update_online(120.0)
+
+        embed = monitor._create_recovery_embed(status)
+
+        assert 'BACK ONLINE' not in embed.title
+        assert 'online' in embed.title.lower()
+        # Downtime-Klartext in Beschreibung
+        assert 'Ausfall-Dauer' in embed.description
+        assert 'Min' in embed.description


### PR DESCRIPTION
## Worum geht's

Die Discord-Alerts (Runner-VM-Drift, Deploy, Incidents, Health) waren **Status-Telemetrie statt Mensch-lesbarer Meldungen**: Status-Enums (`DRIFT (unreachable → critical)`), Roh-Codes (`LOAD_CRITICAL`), Rohzahlen (`Load 1min=32.23 on 8 CPUs`) — ohne *was ist los / wie schlimm / was tun*. Drei zusammenhanglose Pings für einen selbst-erholten Vorfall.

## Vorher → Nachher (echtes Render, Runner-VM)

**Vorher:**
```
🔴 Runner-VM: DRIFT (unreachable → critical)
🔴 Critical Alerts
• LOAD_CRITICAL (load) — Load 1min=32.23 on 8 CPUs
🟡 Warning Alerts
• DISK_HIGH (disk) — Disk usage 84.8% on /
```

**Nachher:**
```
🔴 überlastet (war kurz nicht erreichbar)
CPU-Last 32,2 auf 8 Kernen — 4× überlastet
Platte zu 84,8 % voll (/)
→ Dringlichkeit: hoch · bitte zeitnah prüfen
Runbook: mayday-ci-runner.md
```
Recovery: `🟢 wieder stabil`. Unbekannte Codes fallen sauber auf `Title-Case: message` zurück (nie Info-Verlust).

## Was drin ist

1. **`src/utils/alert_humanizer.py`** (neu, dependency-frei, pure functions) — `humanize_transition` (Status→Klartext+Dringlichkeit), `humanize_alert` (Code→Label+Metrik-Kontext), `urgency_line`, `runbook_for`, `format_downtime`. Zentrale Übersetzungs-Schicht + `STATUS_EMOJI/COLOR` als Single-Source.
2. **Incident-Grouping** in `phase_5e_health_aggregator` — aufeinanderfolgende Drifts desselben Hosts = **eine** sich aktualisierende Nachricht (`message.edit`) mit Timeline; Recovery zeigt Gesamt-Downtime + „selbst-erholt". Statt N zusammenhangloser Pings.
3. **Alle 5 Builder migriert** auf dieselben Bausteine: `phase_5e`, `project_monitor`, `incident_manager`, `deployment_manager`, `EmbedBuilder.create_alert`.

## Tests

- **1194 passed, 38 skipped, 0 failed** (gesamte `tests/unit`)
- Neu: `test_alert_humanizer.py` (40 — inkl. Fallback-Pfade + Dezimal-Lokalisierung), Incident-Grouping (5), + Builder-Tests
- Keine bestehenden Tests mussten ans neue Format angepasst werden (rein additiv)

## Deploy

Nach Merge: ShadowOps-Auto-Deploy (Pull + Restart, `Restart=always`). Kein manueller Eingriff. Design-Doc: `docs/2026-05-28-alert-humanizer-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)