### PR TITLE
fix(secops): Test-Isolation-Guard gegen echte Prod-Issues aus Tests (3b+3c)

### DIFF
--- a/src/integrations/security_engine/scan_agent.py
+++ b/src/integrations/security_engine/scan_agent.py
@@ -205,10 +205,13 @@ def build_jules_issue_body(finding) -> str:
 
 1. **Scope strikt halten** — nur die in "Betroffene Dateien" genannten Dateien anfassen
 2. **Kein Refactoring** — auch wenn du "besseren" Code siehst
-3. **PR-Body muss `Fixes #N` enthalten** (mit diesem Issue-Number)
-4. **Reagiere NICHT mit "Acknowledged" auf Review-Kommentare** — das hat in der Vergangenheit zu Review-Loops geführt
-5. Du wirst automatisch von Claude Opus reviewt (strukturiert: Blockers/Suggestions/Nits)
-6. Bei Approval → Shadow merged manuell. Max 5 Review-Iterationen, sonst Human-Eskalation.
+3. **Keine Werkstatt-/Scratch-Dateien committen** — `find_deps.*`, `fix_*.py`, `audit*.json`, `debug_*` o.ä. gehören NICHT in den PR (werden vom CI-Scope-Guard abgelehnt)
+4. **Keine Test-Dateien ändern**, außer der Fix erfordert es zwingend — dann im PR-Body begründen. Tests nicht "grün tricksen"
+5. **Lock-Dateien nur mit echtem Install:** Falls `npm install`/`pip install` in deiner Sandbox fehlschlägt (z.B. private Dependency ohne Zugang), ändere `package-lock.json`/Lockfiles NICHT blind — markiere den PR stattdessen als `blocked` und beschreibe das Problem
+6. **PR-Body muss `Fixes #N` enthalten** (mit diesem Issue-Number)
+7. **Reagiere NICHT mit "Acknowledged" auf Review-Kommentare** — das hat in der Vergangenheit zu Review-Loops geführt
+8. Du wirst automatisch von Claude Opus reviewt (strukturiert: Blockers/Suggestions/Nits)
+9. Bei Approval → Shadow merged manuell. Max 5 Review-Iterationen, sonst Human-Eskalation.
 
 ---
 *Auto-created by ShadowOps SecOps Workflow · Finding ID: {finding_id}*
@@ -2201,6 +2204,18 @@ von der ShadowOps Review-Pipeline reviewt — halte den Scope eng."""
         )
         if existing:
             return existing.get('github_issue_url') or None
+
+        # Test-Isolation (Vorfall 2026-05-29): In Unit-Tests NIEMALS echte
+        # gh-Subprocesse. Sonst erzeugen Test-Fixtures (z.B. "Dependency XYZ
+        # hat CVE-2026-1234.") echte Production-Issues auf einer Maschine mit
+        # authentifiziertem gh CLI (VPS/Runner) — genau so entstanden #1069 +
+        # #1070 + der fehlgeleitete Jules-Task PR #1075. pytest setzt
+        # PYTEST_CURRENT_TEST bei jedem Test; in Production ist sie nie gesetzt.
+        if os.environ.get('PYTEST_CURRENT_TEST'):
+            logger.warning(
+                "[scan-agent] PYTEST-Umgebung erkannt — ueberspringe echte "
+                "GitHub-Issue-Erstellung fuer '%s' (Test-Isolation).", title[:60])
+            return None
 
         try:
             search = title[:60].replace('[', '').replace(']', '').replace('"', '')

--- a/tests/unit/test_scan_agent_routing_249.py
+++ b/tests/unit/test_scan_agent_routing_249.py
@@ -5,7 +5,7 @@
 - Bot-Code-Findings (npm_audit, code_security, etc.) gehen weiter normal durch.
 """
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -107,16 +107,13 @@ class TestNonHostOsContinuesNormally:
             'severity': 'high',
         }
         # _find_similar_open_finding_by_fingerprint MUSS gerufen werden
-        # (= wir sind ueber den Host-OS-Check hinaus). Wir mocken die
-        # naechste subprocess-Stufe weg, indem `gh issue list` einfach
-        # nichts findet → Funktion versucht gh issue create, aber der
-        # subprocess-Call ist nicht gemockt → Exception, return None.
-        # Der Test prueft: Fingerprint-Check WURDE gerufen.
-        try:
-            await agent._create_github_issue(finding)
-        except Exception:
-            pass  # subprocess-Calls sind nicht gemockt, das ist hier OK
+        # (= wir sind ueber den Host-OS-Check hinaus). Danach greift der
+        # PYTEST_CURRENT_TEST-Guard → return None ohne echten gh-Subprocess
+        # (Test-Isolation, Vorfall #1069/#1070). Der Test prueft beides:
+        # Fingerprint-Check wurde gerufen UND kein echtes Issue erstellt.
+        result = await agent._create_github_issue(finding)
         agent._find_similar_open_finding_by_fingerprint.assert_called_once()
+        assert result is None  # Guard verhindert echte Issue-Erstellung in Tests
 
     async def test_code_security_continues_past_routing(self):
         agent = _make_minimal_agent()
@@ -128,11 +125,33 @@ class TestNonHostOsContinuesNormally:
             'severity': 'high',
             'affected_files': ['web/src/auth.ts'],
         }
-        try:
-            await agent._create_github_issue(finding)
-        except Exception:
-            pass
+        result = await agent._create_github_issue(finding)
         agent._find_similar_open_finding_by_fingerprint.assert_called_once()
+        assert result is None  # Guard verhindert echte Issue-Erstellung in Tests
+
+
+class TestPytestIssueIsolation:
+    """Vorfall 2026-05-29: Test-Fixtures (z.B. 'Dependency XYZ hat
+    CVE-2026-1234.') erzeugten echte Production-Issues #1069/#1070 — weil
+    _create_github_issue den gh-Subprocess ungemockt aufrief und auf einer
+    Maschine mit authentifiziertem gh CLI lief. Der PYTEST_CURRENT_TEST-Guard
+    verhindert in Tests JEDEN echten gh-Subprocess."""
+
+    async def test_guard_skips_real_gh_subprocess_in_pytest(self):
+        agent = _make_minimal_agent()
+        finding = {
+            'category': 'code_security',
+            'affected_project': 'zerodox',
+            'title': 'SQL Injection in query builder',
+            'description': 'Nutzereingabe wird unescaped in SQL konkateniert.',
+            'severity': 'high',
+            'affected_files': ['web/src/db.ts'],
+        }
+        with patch('asyncio.create_subprocess_exec') as mock_exec:
+            result = await agent._create_github_issue(finding)
+        assert result is None
+        # KEIN gh-Subprocess (weder issue list noch issue create) in pytest.
+        mock_exec.assert_not_called()
 
 
 class TestHostOsCategoriesConstant:


### PR DESCRIPTION
## Root-Cause (Vorfall 2026-05-29)

Test-Fixtures in `test_scan_agent_routing_249.py` (z.B. `"Dependency XYZ hat CVE-2026-1234."`) riefen `_create_github_issue` mit **ungemocktem `gh`-Subprocess** auf. Auf einer Maschine mit authentifiziertem `gh` CLI (VPS/Runner) entstanden dadurch **echte ZERODOX-Issues #1069 + #1070** — wortgleich zu den Fixtures. Und weil das #1070-Fixture `affected_files` gesetzt hatte, wurde es sogar an Jules delegiert → der fehlgeleitete **PR #1075** (Scratch-Müll + Test-Tampering + blinde Lock-Edits).

## Fix

**3b — Test-Isolation:**
- `_create_github_issue`: `PYTEST_CURRENT_TEST`-Guard nach dem Fingerprint-Check, vor jedem `gh`-Subprocess. In Production nie gesetzt, in jedem pytest-Test aktiv → Tests können keine echten Issues mehr erstellen.
- Tests umgestellt: verifizieren explizit `result is None` + dass kein `gh`-Subprocess läuft (statt sich auf „ungemockt → Exception" zu verlassen). Neuer `TestPytestIssueIsolation`.

**3c — Jules-Issue-Template geschärft** (`build_jules_issue_body`):
- Keine Scratch-/Werkstatt-Dateien (`find_deps.*`, `fix_*.py`, `audit*.json`)
- Keine Test-Dateien ändern außer zwingend + begründet (kein Grün-Tricksen)
- Lock-Dateien nur mit echtem Install; sonst PR als `blocked` markieren — genau Jules' Fehler in PR #1075

## Tests
`69 scan_agent-Tests grün` (`.venv/bin/python -m pytest tests/unit/test_scan_agent*.py`).

## Deploy-Hinweis
Bot-Restart (`systemctl --user restart shadowops-bot`) erfolgt nach Merge + Abstimmung — kein Auto-Deploy in diesem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)