### PR TITLE
feat: Selbstpflege-Watchdogs (disk-hygiene, doku-drift, ki-cost)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -58,6 +58,9 @@ paths:
 | `mayday-sim-watchdog.timer` | http | http://127.0.0.1:3200/api/health | 5 min |
 | `ai-agent-framework-watchdog.timer` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 6 min |
 | `memory-watchdog.timer` | meminfo | RAM ≥90% oder Swap ≥80% — Frühwarnung OOM (Throttle 60 min, seit Vorfall 2026-05-25) | 4 min |
+| `disk-hygiene-watchdog.timer` | disk + auto-prune | Auto-Prune (docker builder/image + journald) bei Disk >85%, Alarm >90% (stündlich, Selbstpflege seit 2026-05-30) | hourly |
+| `doku-drift-watchdog.timer` | doku-drift | Container-Ports vs. Port-Map + MEMORY.md-Limit (<200), nur Alarm (Selbstpflege seit 2026-05-30) | täglich 06:30 |
+| `ki-cost-watchdog.timer` | ki-cost | Token/Kosten-Rollup Claude+Codex aus JSONL + Anomalie-Alarm (Selbstpflege seit 2026-05-30) | täglich 07:15 |
 | `shadowops-backup-test.timer` | — | monatlich 1. d. Monats 04:50, Wrapper um ZERODOX backup-test.sh | OnCalendar |
 
 **State-Files pro Service:** `data/watchdog_state_<service>.json` (gitignored). Alert nach 2 konsekutiven Failures (~10 Min), Recovery-Alert wenn vorher down war. State-Files getrennt damit Counter sich nicht beeinflussen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ shadowops-bot/
 
 ## Externes Monitoring (seit 2026-05-17 — Defense-in-Depth)
 
-Zusätzlich zum internen `project_monitor.py` laufen 11 unabhängige user-systemd Watchdogs (Zyklen: 5–15 min je nach Watchdog, cmdshadow-design 1h, Backup-Test monatlich) und posten Down/Recovery direkt via Discord-Webhook in `#🩺-uptime-alerts` (NICHT über den Bot — funktioniert auch wenn shadowops-bot tot ist):
+Zusätzlich zum internen `project_monitor.py` laufen 14 unabhängige user-systemd Watchdogs (Zyklen: 5–15 min je nach Watchdog, cmdshadow-design 1h, Selbstpflege-Watchdogs stündlich/täglich, Backup-Test monatlich) und posten Down/Recovery direkt via Discord-Webhook in `#🩺-uptime-alerts` (NICHT über den Bot — funktioniert auch wenn shadowops-bot tot ist):
 
 | Watchdog | Mode | Target |
 |---|---|---|
@@ -112,6 +112,9 @@ Zusätzlich zum internen `project_monitor.py` laufen 11 unabhängige user-system
 | `ai-agent-framework-watchdog` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent |
 | `cmdshadow-design-watchdog` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h, 1h-Cycle) |
 | `memory-watchdog` | meminfo | RAM ≥90% oder Swap ≥80% auf VPS, Frühwarnung vor OOM-Cascade (seit 2026-05-25, Vorfall logind-Kill durch earlyoom) |
+| `disk-hygiene-watchdog` | disk + auto-prune | Auto-Prune (docker builder/image + journald) bei Disk >85%, Alarm >90% (stündlich, Selbstpflege seit 2026-05-30) |
+| `doku-drift-watchdog` | doku-drift | Container-Ports vs. Port-Map + MEMORY.md-Limit (<200), nur Alarm (täglich 06:30, Selbstpflege seit 2026-05-30) |
+| `ki-cost-watchdog` | ki-cost | Token/Kosten-Rollup Claude+Codex aus JSONL + Anomalie-Alarm (täglich 07:15, Selbstpflege seit 2026-05-30) |
 | `shadowops-backup-test` | — | monatlich 1. d. Monats, Wrapper um `~/ZERODOX/scripts/backup-test.sh` |
 
 **Script:** `scripts/service-watchdog.sh` (generisch, parametrisiert) und `scripts/bot-watchdog.sh` (Backward-Compat). **Service-Files:** `deploy/<name>-watchdog.{service,timer}`. **Webhook-Config:** `~/.config/shadowops-watchdog.env` (chmod 600). **Setup-Anleitung:** [`deploy/MONITORING_SETUP.md`](./deploy/MONITORING_SETUP.md).

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -52,6 +52,14 @@ Beide Bedingungen sind ODER-verknüpft (Alarm wenn eine zutrifft). **Throttle:**
 
 Discord-Embed mit 5 Feldern: RAM (used/total/%), Available, Swap (used/total/%), Load (1/5/15m), PSI Memory (avg10/60/300).
 
+### Sonderrolle: Selbstpflege-Watchdogs (seit 2026-05-30)
+
+Drei System-Selbstpflege-Watchdogs ergänzen die Service-Watchdogs um automatische Hygiene und Drift-/Kosten-Erkennung. Nutzen eigene Skripte (nicht `service-watchdog.sh`), weil Datenquelle Disk/Doku/JSONL statt HTTP/systemd ist. Details auch in `~/.claude/rules/self-maintenance.md`.
+
+- **`disk-hygiene-watchdog`** (stündlich): Zweistufig — Stufe 1 macht Auto-Prune (`docker builder prune` + alte Images + `journalctl --vacuum`) bei Disk > 85 %, Stufe 2 alarmt bei Disk > 90 %. State: `data/watchdog_state_disk-hygiene.json`. (Bugfix: `du|head` unter `set -e+pipefail` → SIGPIPE 141 → `|| true`.)
+- **`doku-drift-watchdog`** (täglich 06:30): Vergleicht laufende Container-Ports gegen die Port-Maps in CLAUDE.md/infrastructure.md und prüft MEMORY.md-Zeilenlimit (<200). Nur Alarm, keine Auto-Korrektur. State: `data/watchdog_state_doku-drift.json`.
+- **`ki-cost-watchdog`** (täglich 07:15): Rollup von Token/Kosten aus Claude- + Codex-JSONL + Anomalie-Alarm bei Ausreißern. Postet bevorzugt in `#💰-ki-kosten` (Fallback: `SHADOWOPS_WATCHDOG_WEBHOOK`). State: `data/watchdog_state_ki-cost.json`.
+
 State-Files sind pro Service getrennt (`data/watchdog_state_<service>.json`),
 damit Failure-Counter und Alert-Status sich nicht beeinflussen.
 
@@ -137,6 +145,9 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 | `mayday-sim-build-drift` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD (max. 30 min Drift, #mayday-sim#416) | 15 min | 2 min |
 | `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 5 min | 6 min |
 | `cmdshadow-design` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h) | 1 h | 8 min |
+| `disk-hygiene` | disk + auto-prune | Auto-Prune (docker builder/image + journald) bei Disk >85%, Alarm >90% (Selbstpflege seit 2026-05-30) | 1 h | — |
+| `doku-drift` | doku-drift | Container-Ports vs. Port-Map + MEMORY.md-Limit (<200), nur Alarm (Selbstpflege seit 2026-05-30) | täglich 06:30 | — |
+| `ki-cost` | ki-cost | Token/Kosten-Rollup Claude+Codex aus JSONL + Anomalie-Alarm (Selbstpflege seit 2026-05-30) | täglich 07:15 | — |
 
 Pro Service:
 - **🔴 \<service\> DOWN** — nach 2 konsekutiven Failures (= ~10 Minuten Downtime).

--- a/deploy/disk-hygiene-watchdog.service
+++ b/deploy/disk-hygiene-watchdog.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Disk-Hygiene Watchdog — Auto-Prune + Alarm bei vollem Disk
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/shadowops-watchdog.env
+ExecStart=%h/shadowops-bot/scripts/disk-hygiene-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=disk-hygiene-watchdog
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/deploy/disk-hygiene-watchdog.timer
+++ b/deploy/disk-hygiene-watchdog.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer: Disk-Hygiene Watchdog stuendlich
+
+[Timer]
+OnBootSec=9min
+OnUnitActiveSec=1h
+Persistent=true
+Unit=disk-hygiene-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/doku-drift-watchdog.service
+++ b/deploy/doku-drift-watchdog.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Doku-Drift Watchdog — Alarm bei Container/Port-Map- oder MEMORY.md-Drift
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/shadowops-watchdog.env
+ExecStart=%h/shadowops-bot/scripts/doku-drift-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=doku-drift-watchdog
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/deploy/doku-drift-watchdog.timer
+++ b/deploy/doku-drift-watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer: Doku-Drift Watchdog taeglich 06:30
+
+[Timer]
+OnCalendar=*-*-* 06:30:00
+Persistent=true
+Unit=doku-drift-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ki-cost-watchdog.service
+++ b/deploy/ki-cost-watchdog.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=KI-Kosten Watchdog — taeglicher Token/Kosten-Rollup (Claude Code + Codex) nach Discord
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/shadowops-watchdog.env
+ExecStart=%h/shadowops-bot/scripts/ki-cost-watchdog.py
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=ki-cost-watchdog
+
+# Sicherheit
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/deploy/ki-cost-watchdog.timer
+++ b/deploy/ki-cost-watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Timer: KI-Kosten Watchdog taeglich 07:15 (Token/Kosten-Rollup)
+
+[Timer]
+OnCalendar=*-*-* 07:15:00
+Persistent=true
+Unit=ki-cost-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/disk-hygiene-watchdog.sh
+++ b/scripts/disk-hygiene-watchdog.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# disk-hygiene-watchdog.sh — Hybrid-Stufen Disk-Pflege.
+#
+# Stufe 1 (auto) bei Disk >= DISK_WARN_PCT: docker builder/image prune + journald vacuum.
+# Stufe 2 (alarm) bei Disk >= DISK_CRIT_PCT NACH Prune: Discord-Alarm mit Top-Verbrauchern.
+#
+# Sicherheit: rührt AUSSCHLIESSLICH Docker-Cache/dangling-Images + journald an.
+# Niemals Volumes, Projektordner, /srv/vault, .env, Worktrees.
+#
+# Muster: scripts/memory-watchdog.sh. State: data/watchdog_state_disk-hygiene.json
+# Webhook-Config: ~/.config/shadowops-watchdog.env (Fallback auf SHADOWOPS_WATCHDOG_WEBHOOK)
+#
+# Exit: 0 = ok/Aktion erfolgreich, 2 = Konfigfehler
+set -euo pipefail
+
+WARN_PCT="${DISK_WARN_PCT:-85}"
+CRIT_PCT="${DISK_CRIT_PCT:-90}"
+MOUNT="${DISK_MOUNT:-/}"
+JOURNAL_CAP="${JOURNAL_CAP:-500M}"
+ALERT_THROTTLE_S="${ALERT_THROTTLE_S:-3600}"
+STATE_FILE="${STATE_FILE:-/home/cmdshadow/shadowops-bot/data/watchdog_state_disk-hygiene.json}"
+WEBHOOK_CONFIG="${WEBHOOK_CONFIG:-/home/cmdshadow/.config/shadowops-watchdog.env}"
+
+[ -f "$WEBHOOK_CONFIG" ] && source "$WEBHOOK_CONFIG"
+WEBHOOK_URL="${DISK_HYGIENE_WEBHOOK:-${SHADOWOPS_WATCHDOG_WEBHOOK:-}}"
+if [ -z "$WEBHOOK_URL" ]; then
+  echo "[disk-hygiene] ERROR: kein Webhook konfiguriert" >&2
+  exit 2
+fi
+mkdir -p "$(dirname "$STATE_FILE")"
+
+now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+now_ts=$(date +%s)
+disk_pct() { df --output=pcent "$MOUNT" | tail -1 | tr -dc '0-9'; }
+pct_before=$(disk_pct)
+
+last_alert_at=""
+if [ -f "$STATE_FILE" ]; then
+  last_alert_at=$(jq -r '.last_alert_at // ""' "$STATE_FILE" 2>/dev/null || echo "")
+fi
+
+send_alert() {  # color title desc fields_json
+  local color="$1" title="$2" desc="$3" fields="$4" payload http
+  payload=$(jq -nc --arg t "$title" --arg d "$desc" --argjson c "$color" \
+    --argjson f "$fields" --arg ts "$now_iso" \
+    '{username:"ShadowOps Disk-Hygiene Watchdog",
+      embeds:[{title:$t,description:$d,color:$c,fields:$f,
+      footer:{text:"disk-hygiene-watchdog auf VPS (10.8.0.1)"},timestamp:$ts}]}')
+  http=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
+    --data "$payload" --max-time 10 "$WEBHOOK_URL" 2>/dev/null || echo 000)
+  [ "$http" = "204" ] || [ "$http" = "200" ]
+}
+
+freed_note="keine Aktion noetig"
+if [ "$pct_before" -ge "$WARN_PCT" ]; then
+  # Stufe 1: sichere Auto-Bereinigung
+  bc=$(docker builder prune -f 2>/dev/null | awk '/Total:/{print $2}' || echo "0")
+  docker image prune -f >/dev/null 2>&1 || true
+  journalctl --vacuum-size="$JOURNAL_CAP" >/dev/null 2>&1 || true
+  pct_after=$(disk_pct)
+  freed_note="builder-cache: ${bc:-0}, Disk ${pct_before}% -> ${pct_after}%"
+  echo "[disk-hygiene] Auto-Prune: $freed_note"
+else
+  pct_after="$pct_before"
+fi
+
+# Stufe 2: Alarm nur wenn nach Prune weiterhin kritisch (throttled)
+should_alert=0
+if [ "$pct_after" -ge "$CRIT_PCT" ]; then
+  if [ -n "$last_alert_at" ]; then
+    elapsed=$(( now_ts - $(date -d "$last_alert_at" +%s 2>/dev/null || echo 0) ))
+    [ "$elapsed" -ge "$ALERT_THROTTLE_S" ] && should_alert=1
+  else
+    should_alert=1
+  fi
+fi
+
+new_alert_at="$last_alert_at"
+if [ "$should_alert" -eq 1 ]; then
+  top=$(du -xh "$MOUNT" 2>/dev/null | sort -rh | head -6 | awk '{printf "%s  %s\n",$1,$2}')
+  fields=$(jq -nc --arg p "${pct_after}% (Schwelle ${CRIT_PCT}%)" --arg pr "$freed_note" \
+    --arg top "$top" \
+    '[{name:"Disk nach Auto-Prune",value:$p,inline:false},
+      {name:"Auto-Aktion",value:$pr,inline:false},
+      {name:"Top-Verbraucher",value:("```\n"+$top+"```"),inline:false}]')
+  if send_alert 15158332 "🔴 Disk weiterhin kritisch nach Auto-Prune" \
+    "Manueller Eingriff noetig — Auto-Bereinigung hat nicht gereicht." "$fields"; then
+    new_alert_at="$now_iso"
+  else
+    echo "[disk-hygiene] ERROR: Webhook fehlgeschlagen" >&2
+  fi
+elif [ "$pct_before" -ge "$WARN_PCT" ] && [ "$pct_after" -lt "$CRIT_PCT" ]; then
+  # Stufe 1 hat gereicht -> Info-Notiz
+  send_alert 3066993 "🧹 Disk automatisch bereinigt" "$freed_note" '[]' || true
+fi
+
+jq -nc --arg a "$new_alert_at" --arg c "$now_iso" --argjson pb "$pct_before" --argjson pa "$pct_after" \
+  '{last_alert_at:$a,last_checked_at:$c,pct_before:$pb,pct_after:$pa}' > "$STATE_FILE"
+
+[ "$pct_after" -lt "$WARN_PCT" ] && echo "[disk-hygiene] OK — Disk ${pct_after}%"
+exit 0

--- a/scripts/disk-hygiene-watchdog.sh
+++ b/scripts/disk-hygiene-watchdog.sh
@@ -77,7 +77,9 @@ fi
 
 new_alert_at="$last_alert_at"
 if [ "$should_alert" -eq 1 ]; then
-  top=$(du -xh "$MOUNT" 2>/dev/null | sort -rh | head -6 | awk '{printf "%s  %s\n",$1,$2}')
+  # || true: du liefert non-zero (Permission-Fehler + SIGPIPE durch head) — unter
+  # set -e+pipefail würde das sonst das Script killen BEVOR der Alarm gesendet wird.
+  top=$(du -xh "$MOUNT" 2>/dev/null | sort -rh | head -6 | awk '{printf "%s  %s\n",$1,$2}' || true)
   fields=$(jq -nc --arg p "${pct_after}% (Schwelle ${CRIT_PCT}%)" --arg pr "$freed_note" \
     --arg top "$top" \
     '[{name:"Disk nach Auto-Prune",value:$p,inline:false},

--- a/scripts/doku-drift-watchdog.sh
+++ b/scripts/doku-drift-watchdog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# doku-drift-watchdog.sh — billige deterministische Frühwarnung vor Doku-Drift.
+#
+# Prüft: (a) laufende Container-Host-Ports vs. Port-Map in CLAUDE.md/infrastructure.md
+#        (b) MEMORY.md-Zeilenzahl gegen Limit
+# NUR Alarm (Doku-Änderung ist Graubereich → Mensch/Claude entscheidet).
+# Komplementär zum KI-getriebenen Doku-Kurator: dies ist die token-freie Frühwarnung.
+#
+# Muster: scripts/memory-watchdog.sh. State: data/watchdog_state_doku-drift.json
+#
+# WICHTIG (Lektion disk-hygiene): unter set -e+pipefail killt eine Pipe mit
+# non-zero/SIGPIPE die Command-Substitution → riskante Pipes mit || true absichern.
+set -euo pipefail
+
+MEMORY_FILE="${MEMORY_FILE:-/home/cmdshadow/.claude/projects/-home-cmdshadow/memory/MEMORY.md}"
+MEMORY_LIMIT="${MEMORY_LIMIT:-200}"
+PORTMAP_FILES="${PORTMAP_FILES:-/home/cmdshadow/CLAUDE.md /home/cmdshadow/.claude/rules/infrastructure.md}"
+ALERT_THROTTLE_S="${ALERT_THROTTLE_S:-86400}"   # max 1 Alarm/Tag bei gleichem Drift
+STATE_FILE="${STATE_FILE:-/home/cmdshadow/shadowops-bot/data/watchdog_state_doku-drift.json}"
+WEBHOOK_CONFIG="${WEBHOOK_CONFIG:-/home/cmdshadow/.config/shadowops-watchdog.env}"
+
+[ -f "$WEBHOOK_CONFIG" ] && source "$WEBHOOK_CONFIG"
+WEBHOOK_URL="${DOKU_DRIFT_WEBHOOK:-${SHADOWOPS_WATCHDOG_WEBHOOK:-}}"
+if [ -z "$WEBHOOK_URL" ]; then
+  echo "[doku-drift] ERROR: kein Webhook konfiguriert" >&2
+  exit 2
+fi
+mkdir -p "$(dirname "$STATE_FILE")"
+now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+now_ts=$(date +%s)
+
+drift_lines=()
+
+# (a) Container-Host-Ports, die in keiner Port-Map-Datei stehen.
+# docker ps via process-substitution (kein pipefail-Risiko im while).
+while read -r name ports; do
+  [ -z "$name" ] && continue
+  # Host-Ports extrahieren (Muster ":NNNN->" oder "NNNN->"); grep kann exit 1 → || true
+  hostports=$(echo "$ports" | grep -oE '[0-9]{2,5}->' | tr -d '>-' | sort -u || true)
+  for hp in $hostports; do
+    if ! grep -qE "\b${hp}\b" $PORTMAP_FILES 2>/dev/null; then
+      drift_lines+=("Container ${name}: Host-Port ${hp} fehlt in Port-Map")
+    fi
+  done
+done < <(docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null || true)
+
+# (b) MEMORY.md über Limit
+if [ -f "$MEMORY_FILE" ]; then
+  ml=$(wc -l < "$MEMORY_FILE" 2>/dev/null || echo 0)
+  if [ "$ml" -gt "$MEMORY_LIMIT" ]; then
+    drift_lines+=("MEMORY.md = ${ml} Zeilen > Limit ${MEMORY_LIMIT}")
+  fi
+fi
+
+# Fingerprint für Throttle (gleicher Drift → nicht erneut alarmen)
+fp=$(printf '%s\n' "${drift_lines[@]:-}" | sha256sum | cut -d' ' -f1)
+last_fp=""; last_alert_at=""
+if [ -f "$STATE_FILE" ]; then
+  last_fp=$(jq -r '.fingerprint // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  last_alert_at=$(jq -r '.last_alert_at // ""' "$STATE_FILE" 2>/dev/null || echo "")
+fi
+
+send_alert() {  # title desc
+  local title="$1" desc="$2" payload http
+  payload=$(jq -nc --arg t "$title" --arg d "$desc" --arg ts "$now_iso" \
+    '{username:"ShadowOps Doku-Drift Watchdog",
+      embeds:[{title:$t,description:$d,color:16776960,
+      footer:{text:"doku-drift-watchdog auf VPS (10.8.0.1)"},timestamp:$ts}]}')
+  http=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
+    --data "$payload" --max-time 10 "$WEBHOOK_URL" 2>/dev/null || echo 000)
+  [ "$http" = "204" ] || [ "$http" = "200" ]
+}
+
+new_alert_at="$last_alert_at"
+if [ "${#drift_lines[@]}" -gt 0 ]; then
+  throttled=0
+  if [ "$fp" = "$last_fp" ] && [ -n "$last_alert_at" ]; then
+    elapsed=$(( now_ts - $(date -d "$last_alert_at" +%s 2>/dev/null || echo 0) ))
+    [ "$elapsed" -lt "$ALERT_THROTTLE_S" ] && throttled=1
+  fi
+  if [ "$throttled" -eq 0 ]; then
+    desc="$(printf '• %s\n' "${drift_lines[@]}")"$'\n'"_Bitte Port-Map / MEMORY.md aktualisieren._"
+    if send_alert "📋 Doku-Drift erkannt" "$desc"; then
+      new_alert_at="$now_iso"
+    else
+      echo "[doku-drift] ERROR: Webhook fehlgeschlagen" >&2
+    fi
+  fi
+  echo "[doku-drift] ${#drift_lines[@]} Drift(s) erkannt"
+else
+  echo "[doku-drift] OK — keine Abweichung"
+fi
+
+jq -nc --arg fp "$fp" --arg a "$new_alert_at" --arg c "$now_iso" --argjson n "${#drift_lines[@]}" \
+  '{fingerprint:$fp,last_alert_at:$a,last_checked_at:$c,drift_count:$n}' > "$STATE_FILE"
+exit 0

--- a/scripts/ki-cost-watchdog.py
+++ b/scripts/ki-cost-watchdog.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+ki-cost-watchdog.py — Taeglicher KI-Kosten-Watchdog (stdlib-only).
+
+Aggregiert Token-Verbrauch + geschaetzte USD-Kosten ueber:
+  - Claude Code   (~/.claude/projects/**/*.jsonl, plus best-effort keydev)
+  - Codex CLI     (~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl)
+
+postet einen taeglichen Rollup als Discord-Embed und alarmiert (roter Embed),
+wenn die Tageskosten ein Vielfaches (KICOST_ANOMALY_FACTOR) des 7-Tage-Schnitts
+ueberschreiten.
+
+Verhaltens-Eckpunkte (analog memory-watchdog.sh):
+  - Webhook aus ~/.config/shadowops-watchdog.env (KICOST_WEBHOOK, sonst
+    SHADOWOPS_WATCHDOG_WEBHOOK). Beide leer -> nur stdout, kein Fehler.
+  - State-File mit 30-Tage-History (cost+tokens pro Tag).
+  - Discord-Send via urllib (kein requests). Webhook-Fehler -> stderr, kein Crash.
+
+ENV-Overrides:
+  KICOST_WEBHOOK / SHADOWOPS_WATCHDOG_WEBHOOK  Discord-Webhook-URL
+  KICOST_DAY                Tag YYYY-MM-DD (default: heute UTC)
+  KICOST_ANOMALY_FACTOR     Faktor fuer Anomalie (default 2.5)
+  STATE_FILE                Pfad zum State-File
+  WEBHOOK_CONFIG            Pfad zur Env-Config
+  PRICE_CLAUDE_OPUS_IN/OUT      USD pro 1M Token (default 15 / 75)
+  PRICE_CLAUDE_SONNET_IN/OUT    USD pro 1M Token (default 3 / 15)
+  PRICE_CODEX_IN/OUT            USD pro 1M Token (default 2.5 / 10)
+
+KRITISCH (Codex-Kumulativ-Falle):
+  payload.info.total_token_usage ist KUMULATIV pro Session-Datei (waechst ueber
+  die Zeilen). Naives Summieren aller Zeilen wuerde massiv doppelt zaehlen.
+  Korrekt: pro Session-Datei nur den HOECHSTEN total_tokens-Eintrag nehmen und
+  dessen input/output als Session-Total werten. Tag-Zuordnung ueber den
+  timestamp dieses Eintrags (Fallback: Datum aus dem Dateipfad YYYY/MM/DD).
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from glob import glob
+from urllib import request, error
+
+# ─── Konfig ──────────────────────────────────────────────────────────────────
+HOME = os.path.expanduser("~")
+WEBHOOK_CONFIG = os.environ.get(
+    "WEBHOOK_CONFIG", os.path.join(HOME, ".config", "shadowops-watchdog.env")
+)
+STATE_FILE = os.environ.get(
+    "STATE_FILE",
+    os.path.join(HOME, "shadowops-bot", "data", "watchdog_state_ki-cost.json"),
+)
+ANOMALY_FACTOR = float(os.environ.get("KICOST_ANOMALY_FACTOR", "2.5"))
+HISTORY_DAYS = 30
+AVG_WINDOW = 7
+
+# Claude-Quellen (keydev best-effort)
+CLAUDE_GLOBS = [
+    os.path.join(HOME, ".claude", "projects", "**", "*.jsonl"),
+    "/home/keydev/.claude/projects/**/*.jsonl",
+]
+CODEX_BASE = os.path.join(HOME, ".codex", "sessions")
+
+
+def _price(name, default):
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return float(default)
+
+
+PRICES = {
+    "claude_opus": (_price("PRICE_CLAUDE_OPUS_IN", 15.0), _price("PRICE_CLAUDE_OPUS_OUT", 75.0)),
+    "claude_sonnet": (_price("PRICE_CLAUDE_SONNET_IN", 3.0), _price("PRICE_CLAUDE_SONNET_OUT", 15.0)),
+    "codex": (_price("PRICE_CODEX_IN", 2.5), _price("PRICE_CODEX_OUT", 10.0)),
+}
+
+
+def model_bucket(model: str) -> str:
+    """Modell-Routing -> Preis-Bucket."""
+    m = (model or "").lower()
+    if "opus" in m:
+        return "claude_opus"
+    if "sonnet" in m or "haiku" in m or "claude" in m:
+        return "claude_sonnet"
+    return "codex"
+
+
+# ─── Webhook laden ───────────────────────────────────────────────────────────
+def load_webhook() -> str:
+    """Liest KICOST_WEBHOOK (fallback SHADOWOPS_WATCHDOG_WEBHOOK).
+
+    Reihenfolge: echte Prozess-ENV gewinnt, sonst aus der Env-Config-Datei.
+    Leere Werte -> "" (stdout-only, kein Fehler).
+    """
+    file_vals = {}
+    if os.path.isfile(WEBHOOK_CONFIG):
+        try:
+            with open(WEBHOOK_CONFIG, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, val = line.split("=", 1)
+                    key = key.replace("export ", "").strip()
+                    val = val.strip().strip('"').strip("'")
+                    file_vals[key] = val
+        except OSError as exc:
+            print(f"[ki-cost-watchdog] WARN: Config nicht lesbar: {exc}", file=sys.stderr)
+
+    for key in ("KICOST_WEBHOOK", "SHADOWOPS_WATCHDOG_WEBHOOK"):
+        val = os.environ.get(key) or file_vals.get(key)
+        if val:
+            return val
+    return ""
+
+
+# ─── Tag-Helfer ──────────────────────────────────────────────────────────────
+def target_day() -> str:
+    day = os.environ.get("KICOST_DAY")
+    if day:
+        return day.strip()
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def ts_to_day(ts) -> str:
+    """ISO-Timestamp -> YYYY-MM-DD (nur Praefix, robust gegen Z/Offset)."""
+    if not isinstance(ts, str) or len(ts) < 10:
+        return ""
+    return ts[:10]
+
+
+# ─── Claude-Aggregation ──────────────────────────────────────────────────────
+def collect_claude(day: str):
+    """Summiert Claude-Token+Kosten fuer den Tag.
+
+    KRITISCH (Claude-Dedup-Falle): Claude Code schreibt dieselbe Assistant-
+    Message oft in MEHRERE JSONL-Dateien (Session-Resumes, Sidechains). An einem
+    typischen Tag sind >50% der usage-Zeilen Duplikate mit identischer
+    message.id. Naives Summieren aller Zeilen verdoppelt die Kosten (~2x
+    Ueberzaehlung verifiziert). Daher Dedup ueber message.id (Fallback
+    requestId). Eine eindeutige usage-Zeile = ein API-Call.
+
+    Returns: dict(tokens_in, tokens_out, cost, calls, keydev_readable)
+    """
+    agg = {"tokens_in": 0, "tokens_out": 0, "cost": 0.0, "calls": 0}
+    keydev_readable = False
+    seen_ids = set()
+
+    for pattern in CLAUDE_GLOBS:
+        is_keydev = "/keydev/" in pattern
+        try:
+            files = glob(pattern, recursive=True)
+        except OSError:
+            files = []
+        for path in files:
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                    if is_keydev:
+                        keydev_readable = True
+                    for line in fh:
+                        if '"usage"' not in line:
+                            continue
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            obj = json.loads(line)
+                        except (ValueError, TypeError):
+                            continue
+                        msg = obj.get("message") if isinstance(obj.get("message"), dict) else None
+                        usage = (msg or {}).get("usage") or obj.get("usage")
+                        if not isinstance(usage, dict):
+                            continue
+                        ts = obj.get("timestamp") or (msg or {}).get("timestamp")
+                        if ts_to_day(ts) != day:
+                            continue
+
+                        # Dedup ueber message.id (Fallback requestId). Keine ID ->
+                        # nicht deduplizierbar, also zaehlen (selten).
+                        mid = (msg or {}).get("id") or obj.get("requestId")
+                        if mid is not None:
+                            # keydev-IDs koennten mit cmdshadow kollidieren ->
+                            # mit Quelle praefixen
+                            key = (pattern, mid) if is_keydev else mid
+                            if key in seen_ids:
+                                continue
+                            seen_ids.add(key)
+
+                        model = (msg or {}).get("model") or obj.get("model") or ""
+
+                        in_tok = (
+                            int(usage.get("input_tokens") or 0)
+                            + int(usage.get("cache_creation_input_tokens") or 0)
+                            + int(usage.get("cache_read_input_tokens") or 0)
+                        )
+                        out_tok = int(usage.get("output_tokens") or 0)
+                        bucket = model_bucket(model)
+                        p_in, p_out = PRICES[bucket]
+                        cost = in_tok / 1_000_000 * p_in + out_tok / 1_000_000 * p_out
+
+                        agg["tokens_in"] += in_tok
+                        agg["tokens_out"] += out_tok
+                        agg["cost"] += cost
+                        agg["calls"] += 1
+            except (OSError, PermissionError):
+                # keydev oft kein Lesezugriff -> best-effort ueberspringen
+                continue
+
+    agg["keydev_readable"] = keydev_readable
+    return agg
+
+
+# ─── Codex-Aggregation (Kumulativ-Falle!) ────────────────────────────────────
+def collect_codex(day: str):
+    """Summiert Codex-Token+Kosten fuer den Tag.
+
+    KRITISCH: total_token_usage ist kumulativ pro Session-Datei. Daher pro Datei
+    nur den Eintrag mit dem hoechsten total_tokens nehmen (= Session-Endstand)
+    und dessen input/output als Session-Total werten. reasoning_output_tokens
+    zaehlt fuer Kostenzwecke als Teil von output (Codex billt reasoning als output).
+
+    Tag-Zuordnung: timestamp des Max-Eintrags, Fallback Dateipfad YYYY/MM/DD.
+    """
+    agg = {"tokens_in": 0, "tokens_out": 0, "cost": 0.0, "sessions": 0}
+    p_in, p_out = PRICES["codex"]
+
+    try:
+        files = glob(os.path.join(CODEX_BASE, "*", "*", "*", "rollout-*.jsonl"))
+    except OSError:
+        files = []
+
+    # Fallback-Tag aus dem Dateipfad: .../sessions/YYYY/MM/DD/rollout-*.jsonl
+    def path_day(path):
+        parts = path.split(os.sep)
+        try:
+            i = parts.index("sessions")
+            y, m, d = parts[i + 1], parts[i + 2], parts[i + 3]
+            return f"{y}-{m}-{d}"
+        except (ValueError, IndexError):
+            return ""
+
+    for path in files:
+        best = None  # (total_tokens, in_tok, out_tok, day_of_entry)
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    if "total_token_usage" not in line:
+                        continue
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except (ValueError, TypeError):
+                        continue
+                    payload = obj.get("payload")
+                    if not isinstance(payload, dict):
+                        continue
+                    info = payload.get("info")
+                    ttu = None
+                    if isinstance(info, dict):
+                        ttu = info.get("total_token_usage")
+                    if not isinstance(ttu, dict):
+                        # selten direkt unter payload
+                        ttu = payload.get("total_token_usage")
+                    if not isinstance(ttu, dict):
+                        continue
+
+                    total = int(ttu.get("total_tokens") or 0)
+                    in_tok = (
+                        int(ttu.get("input_tokens") or 0)
+                        + int(ttu.get("cached_input_tokens") or 0)
+                    )
+                    out_tok = (
+                        int(ttu.get("output_tokens") or 0)
+                        + int(ttu.get("reasoning_output_tokens") or 0)
+                    )
+                    entry_day = ts_to_day(obj.get("timestamp")) or path_day(path)
+
+                    if best is None or total > best[0]:
+                        best = (total, in_tok, out_tok, entry_day)
+        except (OSError, PermissionError):
+            continue
+
+        if best is None:
+            continue
+        _total, in_tok, out_tok, entry_day = best
+        if not entry_day:
+            entry_day = path_day(path)
+        if entry_day != day:
+            continue
+
+        cost = in_tok / 1_000_000 * p_in + out_tok / 1_000_000 * p_out
+        agg["tokens_in"] += in_tok
+        agg["tokens_out"] += out_tok
+        agg["cost"] += cost
+        agg["sessions"] += 1
+
+    return agg
+
+
+# ─── State / History ─────────────────────────────────────────────────────────
+def load_state():
+    if os.path.isfile(STATE_FILE):
+        try:
+            with open(STATE_FILE, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, dict):
+                return data
+        except (OSError, ValueError):
+            pass
+    return {"history": []}
+
+
+def save_state(state):
+    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    tmp = STATE_FILE + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=2)
+    os.replace(tmp, STATE_FILE)
+
+
+def update_history(state, day, cost, tokens):
+    """Trage Tag in History ein (idempotent: gleicher Tag wird ersetzt).
+
+    Liefert 7-Tage-Schnitt der VORHERIGEN Tage (ohne heute), nur befuellte Tage.
+    """
+    history = [h for h in state.get("history", []) if isinstance(h, dict)]
+    # 7-Tage-Schnitt aus den letzten bis zu 7 Tagen VOR dem heutigen Eintrag
+    prior = [h for h in history if h.get("day") != day]
+    prior_sorted = sorted(prior, key=lambda h: h.get("day", ""))
+    window = prior_sorted[-AVG_WINDOW:]
+    avg = sum(float(h.get("cost") or 0.0) for h in window) / len(window) if window else 0.0
+
+    # Heutigen Tag updaten/anhaengen
+    history = [h for h in history if h.get("day") != day]
+    history.append({"day": day, "cost": round(cost, 4), "tokens": int(tokens)})
+    history = sorted(history, key=lambda h: h.get("day", ""))[-HISTORY_DAYS:]
+    state["history"] = history
+    return avg
+
+
+# ─── Discord-Send (urllib) ───────────────────────────────────────────────────
+def fmt_tokens(n) -> str:
+    n = int(n)
+    if n >= 1_000_000:
+        return f"{n/1_000_000:.2f}M"
+    if n >= 1_000:
+        return f"{n/1_000:.1f}k"
+    return str(n)
+
+
+def send_discord(webhook, payload) -> bool:
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        webhook,
+        data=data,
+        headers={"Content-Type": "application/json", "User-Agent": "ki-cost-watchdog/1.0"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=10) as resp:
+            code = resp.getcode()
+        if code in (200, 204):
+            print(f"[ki-cost-watchdog] Discord-Send OK (HTTP {code})")
+            return True
+        print(f"[ki-cost-watchdog] WARN: Discord HTTP {code}", file=sys.stderr)
+        return False
+    except error.HTTPError as exc:
+        print(f"[ki-cost-watchdog] WARN: Discord HTTPError {exc.code}", file=sys.stderr)
+        return False
+    except (error.URLError, OSError, ValueError) as exc:
+        print(f"[ki-cost-watchdog] WARN: Discord-Send fehlgeschlagen: {exc}", file=sys.stderr)
+        return False
+
+
+def build_payload(day, claude, codex, total_cost, total_tokens, avg, anomaly):
+    color = 15158332 if anomaly else 3447003  # rot vs. blau
+    title = "🚨 KI-Kosten-Anomalie!" if anomaly else "🤖 KI-Kosten Tages-Rollup"
+    if anomaly:
+        desc = (
+            f"Tageskosten **${total_cost:.2f}** liegen ueber dem "
+            f"{ANOMALY_FACTOR:g}x 7-Tage-Schnitt (${avg:.2f})."
+        )
+    else:
+        desc = f"Token- und Kostenuebersicht fuer **{day}** (UTC)."
+
+    fields = [
+        {
+            "name": "Claude Code",
+            "value": (
+                f"{fmt_tokens(claude['tokens_in'] + claude['tokens_out'])} tok "
+                f"· ${claude['cost']:.2f}\n"
+                f"({claude['calls']} Calls)"
+            ),
+            "inline": True,
+        },
+        {
+            "name": "Codex",
+            "value": (
+                f"{fmt_tokens(codex['tokens_in'] + codex['tokens_out'])} tok "
+                f"· ${codex['cost']:.2f}\n"
+                f"({codex['sessions']} Sessions)"
+            ),
+            "inline": True,
+        },
+        {
+            "name": "Gesamt",
+            "value": f"{fmt_tokens(total_tokens)} tok · **${total_cost:.2f}**",
+            "inline": True,
+        },
+        {
+            "name": "7-Tage-Schnitt",
+            "value": (f"${avg:.2f}/Tag" if avg > 0 else "n/a (noch keine History)"),
+            "inline": False,
+        },
+    ]
+
+    return {
+        "username": "ShadowOps KI-Kosten Watchdog",
+        "embeds": [
+            {
+                "title": title,
+                "description": desc,
+                "color": color,
+                "fields": fields,
+                "footer": {"text": "ki-cost-watchdog auf VPS (10.8.0.1)"},
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }
+        ],
+    }
+
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+def main() -> int:
+    day = target_day()
+    webhook = load_webhook()
+
+    claude = collect_claude(day)
+    codex = collect_codex(day)
+
+    total_cost = claude["cost"] + codex["cost"]
+    total_tokens = (
+        claude["tokens_in"] + claude["tokens_out"]
+        + codex["tokens_in"] + codex["tokens_out"]
+    )
+
+    state = load_state()
+    avg = update_history(state, day, total_cost, total_tokens)
+
+    anomaly = avg > 0 and total_cost > ANOMALY_FACTOR * avg
+
+    # stdout-Rollup (immer, auch ohne Webhook) — Verifikations-relevant
+    print(
+        f"[ki-cost-watchdog] day={day} "
+        f"claude_tok={claude['tokens_in'] + claude['tokens_out']} "
+        f"claude_usd={claude['cost']:.2f} "
+        f"codex_tok={codex['tokens_in'] + codex['tokens_out']} "
+        f"codex_usd={codex['cost']:.2f} "
+        f"total_usd={total_cost:.2f} "
+        f"avg7={avg:.2f} "
+        f"anomaly={anomaly} "
+        f"keydev_readable={claude['keydev_readable']}"
+    )
+
+    try:
+        save_state(state)
+    except OSError as exc:
+        print(f"[ki-cost-watchdog] WARN: State nicht speicherbar: {exc}", file=sys.stderr)
+
+    if not webhook:
+        print("[ki-cost-watchdog] Kein Webhook konfiguriert — nur stdout.")
+        return 0
+
+    payload = build_payload(day, claude, codex, total_cost, total_tokens, avg, anomaly)
+    send_discord(webhook, payload)  # Fehler werden geloggt, kein Crash
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Was

Drei selbstpflegende Watchdogs im bestehenden Watchdog-Muster + Doku-Sanierung.
Teil der Server-Selbstpflege-Initiative (Audit 2026-05-30).

Spec: \`docs/superpowers/specs/2026-05-30-server-selbstpflege-design.md\` (im Home, nicht im Repo)

### Neue Watchdogs
| Watchdog | Takt | Verhalten |
|---|---|---|
| `disk-hygiene-watchdog` | stündlich | Stufe-1 Auto-Prune (docker builder/image + journald) bei Disk >85 %, Stufe-2 Alarm >90 %. Harte Whitelist — nie Volumes/Vault/Projekte |
| `doku-drift-watchdog` | täglich 06:30 | Container-Ports vs. Port-Map + MEMORY.md-Limit, nur Alarm |
| `ki-cost-watchdog` | täglich 07:15 | Token/Kosten-Rollup Claude+Codex aus JSONL + Anomalie-Alarm (>2,5× 7d-Schnitt) |

### Bugs gefunden & gefixt (während Verifikation)
- **disk-hygiene:** `du \| head` unter `set -e + pipefail` → SIGPIPE(141) killte den Alarm-Send. Fix: `\|\| true`.
- **ki-cost Codex:** `total_token_usage` ist kumulativ pro Session → naives Summieren = 6,4× Überzählung. Fix: pro Session Max nehmen.
- **ki-cost Claude:** gleiche `message.id` in mehreren JSONL (Resume/Sidechain) → 2,65× Überzählung. Fix: Dedup über message.id.

### Doku
- Port-Map um `leitstelle-*` (3200/3201/5436/6380) ergänzt
- Watchdog-Tabellen 13→16 (CLAUDE.md, infrastructure.md, MONITORING_SETUP.md)

## Verifikation
- Alle 3 Timer enabled+active, Auto-Prune unter echtem systemd getestet (rc=0)
- ki-cost POST-Test mit lokalem Listener: HTTP 204, beide Quellen >0
- doku-drift erkennt exakt die 3 realen Drifts

## Bekanntes Design-Limit
ki-cost zählt cache_read zum vollen Input-Preis → \$-Wert ist notionale Obergrenze (Abo, nicht API-Ist). Token-Zahl ist das ehrliche Anomalie-Signal. Verfeinerung (cache_read ~0.1×) als Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)