### PR TITLE
docs: github: section in config.example.yaml + GITHUB_TOKEN undokumentiert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Read-Only ACL auf `scripts/` und `deploy/` für `keydev` ist gesetzt (`getfacl` 
 - **Async-First:** discord.py + aiohttp — neue I/O ist `async`.
 - **Fehler-Handling:** Niemals leere `except:`. Mindestens loggen + re-raise oder klar entscheiden.
 - **Logging:** `from src.utils.logger import get_logger` — niemals `print()`.
-- **Secrets:** AUSSCHLIESSLICH via Env-Vars (DISCORD_BOT_TOKEN, OPENAI_API_KEY, ANTHROPIC_API_KEY). Niemals in Code, niemals in `config.yaml`.
+- **Secrets:** AUSSCHLIESSLICH via Env-Vars (DISCORD_BOT_TOKEN, OPENAI_API_KEY, ANTHROPIC_API_KEY, GITHUB_TOKEN). Niemals in Code, niemals in `config.yaml`.
 - **Tests:** Neue Module brauchen Tests in `tests/unit/test_<module>.py`. Fixtures in `conftest.py` wiederverwenden.
 - **Conventional Commits:** `fix:`, `feat:`, `refactor:`, `perf:`, `docs:`, `chore:`.
 
@@ -188,6 +188,7 @@ chmod 600 config/config.yaml
 #   export DISCORD_BOT_TOKEN="..."
 #   export OPENAI_API_KEY="..."
 #   export ANTHROPIC_API_KEY="..."
+#   export GITHUB_TOKEN="..."        # Optional: GitHub-Integration + Webhook-Auto-Create
 
 # Lokal testen
 python3 src/bot.py

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ export DISCORD_BOT_TOKEN="DEIN_BOT_TOKEN_HIER"
 # Optional:
 # export ANTHROPIC_API_KEY="DEIN_ANTHROPIC_KEY"
 # export OPENAI_API_KEY="DEIN_OPENAI_KEY"
+# export GITHUB_TOKEN="DEIN_GITHUB_TOKEN"   # Benoetigt fuer GitHub-Integration (Webhooks, Auto-Deploy)
 ```
 
 ### 3. Systemd Service aktivieren

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -221,6 +221,25 @@ jules_workflow:
   role_ping_on_escalation: "@Shadow"
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║ GITHUB INTEGRATION                                                        ║
+# ║ Empfaengt Push/PR/Release-Webhooks, triggert Auto-Deploy nach PR-Merge.  ║
+# ║ Token: Env-Var GITHUB_TOKEN oder github.token in dieser Datei.           ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+github:
+  enabled: false                    # Master-Switch (Webhook-Server + Polling)
+  token: ""                         # Env: GITHUB_TOKEN — benoetigt fuer Webhook-Auto-Create + gh API
+  webhook_secret: ""                # HMAC-SHA256 Secret (in GitHub Webhook-Settings setzen)
+  webhook_port: 8080                # Port fuer eingehende GitHub-Webhooks
+  auto_deploy: false                # PR-Merge auf deploy_branches triggert Auto-Deploy
+  deploy_branches:
+    - main
+    - master
+  auto_create_webhooks: false       # Legt Webhooks in konfigurierten Repos automatisch an
+  webhook_public_url: ""            # Oeffentliche URL fuer Auto-Create (z.B. http://1.2.3.4:8080)
+  local_polling_enabled: true       # Pollt Repos lokal auf neue Commits (Fallback zu Webhooks)
+  local_polling_interval: 60        # Polling-Intervall in Sekunden
+
+# ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║ PROJECTS (Überwachte Projekte)                                           ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 projects:


### PR DESCRIPTION
## Aenderungen

Drei Dateien korrigiert — kein Logik-Code beruehrt.

### Problem

`github_integration/core.py` liest beim Start einen vollstaendigen `github:` Config-Block
(`enabled`, `token`, `webhook_secret`, `webhook_port`, `auto_deploy`, `deploy_branches`, ...).
Dieser Block fehlte komplett in `config.example.yaml`. Ein Neu-Nutzer oder KI-Tool, das nur die
Config-Vorlage kennt, konnte die GitHub-Integration nicht aktivieren ohne vorher `docs/reference/api.md`
zu lesen.

Dasselbe gilt fuer `GITHUB_TOKEN`: die Env-Var wird in `src/utils/config.py:181`,
`src/integrations/github_integration/webhook_mixin.py:292` und
`src/integrations/auto_fix_manager.py:984` referenziert — stand aber weder in der README-Setup-Sektion
noch in der CLAUDE.md-Secrets-Liste.

### Korrekturen

| # | Datei | Aenderung |
|---|-------|-----------|
| 1 | `config/config.example.yaml` | `github:` Sektion ergaenzt (nach `jules_workflow:`, vor `projects:`). Keys: `enabled`, `token` (mit Env-Var-Hinweis), `webhook_secret`, `webhook_port`, `auto_deploy`, `deploy_branches`, `auto_create_webhooks`, `webhook_public_url`, `local_polling_enabled`, `local_polling_interval`. Alle Defaults entsprechen `core.py`. |
| 2 | `README.md` | `GITHUB_TOKEN` als optionale Env-Var im Quick-Start-Block (Abschnitt "Bot installieren") ergaenzt. |
| 3 | `CLAUDE.md` | `GITHUB_TOKEN` in Coding-Conventions Secrets-Zeile ergaenzt. Dasselbe in den Setup-Commands als Kommentar. |

### Geprueft

- Alle neuen Schluessel in `config.example.yaml` gegen `src/integrations/github_integration/core.py:79-97` verifiziert
- Default-Werte stimmen mit Code-Defaults ueberein
- Kein Logik-Code geaendert
- DO-NOT-TOUCH.md respektiert

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fdtw9QpMnmfyLnYfZmNWHW)_