### PR TITLE
fix(ki-cost): Cache-Read/Write korrekt bepreisen (0.1x/1.25x Input) (#292)

### DIFF
--- a/deploy/shadowops-watchdog.env.example
+++ b/deploy/shadowops-watchdog.env.example
@@ -18,3 +18,17 @@ SHADOWOPS_WATCHDOG_WEBHOOK=https://discord.com/api/webhooks/CHANNEL_ID/WEBHOOK_T
 # SHADOWOPS_HEALTH_URL=http://127.0.0.1:8766/health
 # SHADOWOPS_WATCHDOG_TIMEOUT=10
 # SHADOWOPS_WATCHDOG_STATE=/home/cmdshadow/shadowops-bot/data/watchdog_state.json
+
+# === KI-COST-WATCHDOG — Token-Preise (USD pro 1M Token) ===
+# Defaults sind im Script hinterlegt; nur setzen, wenn die Anthropic/OpenAI-Preise
+# abweichen. Cache-Read/Write leiten sich per Default aus dem Input-Preis ab
+# (Read ~0.1x, Write ~1.25x) — explizit setzbar ueber die _CACHE_*-Keys (#292).
+# KICOST_WEBHOOK=                                   # Fallback: SHADOWOPS_WATCHDOG_WEBHOOK
+# PRICE_CLAUDE_OPUS_IN=15                            # PRICE_CLAUDE_OPUS_OUT=75
+# PRICE_CLAUDE_OPUS_CACHE_READ=1.5                   # Default 0.1x Input
+# PRICE_CLAUDE_OPUS_CACHE_WRITE=18.75                # Default 1.25x Input
+# PRICE_CLAUDE_SONNET_IN=3                           # PRICE_CLAUDE_SONNET_OUT=15
+# PRICE_CLAUDE_SONNET_CACHE_READ=0.3                 # Default 0.1x Input
+# PRICE_CLAUDE_SONNET_CACHE_WRITE=3.75               # Default 1.25x Input
+# PRICE_CODEX_IN=2.5                                 # PRICE_CODEX_OUT=10
+# KICOST_ANOMALY_FACTOR=2.5                          # Alarm-Schwelle vs. 7-Tage-Schnitt

--- a/scripts/ki-cost-watchdog.py
+++ b/scripts/ki-cost-watchdog.py
@@ -25,6 +25,14 @@ ENV-Overrides:
   PRICE_CLAUDE_OPUS_IN/OUT      USD pro 1M Token (default 15 / 75)
   PRICE_CLAUDE_SONNET_IN/OUT    USD pro 1M Token (default 3 / 15)
   PRICE_CODEX_IN/OUT            USD pro 1M Token (default 2.5 / 10)
+  PRICE_<BUCKET>_CACHE_READ     USD pro 1M Cache-Read-Token (default 0.1x Input)
+  PRICE_<BUCKET>_CACHE_WRITE    USD pro 1M Cache-Write-Token (default 1.25x Input)
+
+CACHE-PRICING (#292):
+  Anthropic berechnet Cache-Reads real ~0.1x und Cache-Writes ~1.25x des
+  Input-Preises. Frueher wurden alle drei Input-Kategorien voll gewertet, was die
+  notionalen Kosten ueberschaetzt hat. Die Token-ZAHL bleibt unveraendert (das
+  Anomalie-Signal ist davon unberuehrt) — nur die USD-Kosten sind jetzt korrekt.
 
 KRITISCH (Codex-Kumulativ-Falle):
   payload.info.total_token_usage ist KUMULATIV pro Session-Datei (waechst ueber
@@ -69,11 +77,49 @@ def _price(name, default):
         return float(default)
 
 
+# Cache-Multiplikatoren (Anthropic): Cache-Read ~0.1x, Cache-Write ~1.25x Input.
+CACHE_READ_FACTOR = 0.1
+CACHE_WRITE_FACTOR = 1.25
+
+
+def _bucket_prices(prefix, def_in, def_out):
+    """Preis-Bucket: Input/Output + abgeleitete Cache-Read/Write-Preise (USD/1M).
+
+    Cache-Preise leiten sich per Default aus dem (ggf. via ENV ueberschriebenen)
+    Input-Preis ab, lassen sich aber separat ueber PRICE_<prefix>_CACHE_READ /
+    PRICE_<prefix>_CACHE_WRITE setzen.
+    """
+    p_in = _price(f"PRICE_{prefix}_IN", def_in)
+    p_out = _price(f"PRICE_{prefix}_OUT", def_out)
+    return {
+        "in": p_in,
+        "out": p_out,
+        "cache_write": _price(f"PRICE_{prefix}_CACHE_WRITE", round(p_in * CACHE_WRITE_FACTOR, 6)),
+        "cache_read": _price(f"PRICE_{prefix}_CACHE_READ", round(p_in * CACHE_READ_FACTOR, 6)),
+    }
+
+
 PRICES = {
-    "claude_opus": (_price("PRICE_CLAUDE_OPUS_IN", 15.0), _price("PRICE_CLAUDE_OPUS_OUT", 75.0)),
-    "claude_sonnet": (_price("PRICE_CLAUDE_SONNET_IN", 3.0), _price("PRICE_CLAUDE_SONNET_OUT", 15.0)),
-    "codex": (_price("PRICE_CODEX_IN", 2.5), _price("PRICE_CODEX_OUT", 10.0)),
+    "claude_opus": _bucket_prices("CLAUDE_OPUS", 15.0, 75.0),
+    "claude_sonnet": _bucket_prices("CLAUDE_SONNET", 3.0, 15.0),
+    "codex": _bucket_prices("CODEX", 2.5, 10.0),
 }
+
+
+def compute_cost(bucket, input_tokens, cache_write_tokens, cache_read_tokens, output_tokens):
+    """USD-Kosten einer Token-Aufteilung in einem Preis-Bucket.
+
+    Input/Cache-Write/Cache-Read/Output werden je mit ihrem eigenen Preis
+    gewertet (Cache-Read ~0.1x, Cache-Write ~1.25x Input). Die Token-ZAHLEN beim
+    Aufrufer bleiben unveraendert — nur die Kosten spiegeln den Cache-Rabatt.
+    """
+    p = PRICES[bucket]
+    return (
+        int(input_tokens) * p["in"]
+        + int(cache_write_tokens) * p["cache_write"]
+        + int(cache_read_tokens) * p["cache_read"]
+        + int(output_tokens) * p["out"]
+    ) / 1_000_000
 
 
 def model_bucket(model: str) -> str:
@@ -189,15 +235,15 @@ def collect_claude(day: str):
 
                         model = (msg or {}).get("model") or obj.get("model") or ""
 
-                        in_tok = (
-                            int(usage.get("input_tokens") or 0)
-                            + int(usage.get("cache_creation_input_tokens") or 0)
-                            + int(usage.get("cache_read_input_tokens") or 0)
-                        )
+                        reg_in = int(usage.get("input_tokens") or 0)
+                        cache_write = int(usage.get("cache_creation_input_tokens") or 0)
+                        cache_read = int(usage.get("cache_read_input_tokens") or 0)
+                        # Token-ZAHL = volle Input-Summe (Anomalie-Signal bleibt korrekt)
+                        in_tok = reg_in + cache_write + cache_read
                         out_tok = int(usage.get("output_tokens") or 0)
                         bucket = model_bucket(model)
-                        p_in, p_out = PRICES[bucket]
-                        cost = in_tok / 1_000_000 * p_in + out_tok / 1_000_000 * p_out
+                        # Kosten: Cache-Read 0.1x, Cache-Write 1.25x Input (statt alles voll)
+                        cost = compute_cost(bucket, reg_in, cache_write, cache_read, out_tok)
 
                         agg["tokens_in"] += in_tok
                         agg["tokens_out"] += out_tok
@@ -223,7 +269,10 @@ def collect_codex(day: str):
     Tag-Zuordnung: timestamp des Max-Eintrags, Fallback Dateipfad YYYY/MM/DD.
     """
     agg = {"tokens_in": 0, "tokens_out": 0, "cost": 0.0, "sessions": 0}
-    p_in, p_out = PRICES["codex"]
+    # Codex-Cache (cached_input_tokens) bleibt vorerst zum Input-Preis gewertet
+    # (Issue #292 betrifft die Anthropic-Cache-Rabatte; Codex-Rabatt = Folge-Thema).
+    _cp = PRICES["codex"]
+    p_in, p_out = _cp["in"], _cp["out"]
 
     try:
         files = glob(os.path.join(CODEX_BASE, "*", "*", "*", "rollout-*.jsonl"))

--- a/tests/unit/test_ki_cost_watchdog.py
+++ b/tests/unit/test_ki_cost_watchdog.py
@@ -1,0 +1,93 @@
+"""Tests fuer scripts/ki-cost-watchdog.py — korrektes Cache-Token-Pricing (#292).
+
+Anthropic bepreist Cache-Reads real ~0.1x des Input-Preises und Cache-Writes
+~1.25x. Bisher wurden alle drei Input-Kategorien (input + cache_creation +
+cache_read) zum vollen Input-Preis summiert, was die notionalen Kosten massiv
+ueberschaetzt. Diese Tests fixieren das korrigierte Verhalten.
+
+Geladen wird das Script (Dateiname mit Bindestrich) per importlib — pro Aufruf
+frisch, damit ENV-Preis-Overrides beim Modul-Import greifen.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ki-cost-watchdog.py"
+
+
+def _load():
+    """Laedt ki-cost-watchdog.py frisch als Modul (PRICES wird beim Import gebaut)."""
+    spec = importlib.util.spec_from_file_location("ki_cost_watchdog", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_reiner_input_voller_preis():
+    mod = _load()
+    # 1M reine Input-Token Opus = $15.00
+    assert round(mod.compute_cost("claude_opus", 1_000_000, 0, 0, 0), 2) == 15.00
+
+
+def test_cache_read_ist_billiger_als_input():
+    mod = _load()
+    full = mod.compute_cost("claude_opus", 1_000_000, 0, 0, 0)
+    cread = mod.compute_cost("claude_opus", 0, 0, 1_000_000, 0)
+    # Cache-Read = 0.1x Input → $1.50
+    assert round(cread, 2) == 1.50
+    assert cread < full
+
+
+def test_cache_write_ist_teurer_als_input():
+    mod = _load()
+    # Cache-Write = 1.25x Input → $18.75
+    assert round(mod.compute_cost("claude_opus", 0, 1_000_000, 0, 0), 2) == 18.75
+
+
+def test_output_normal_bepreist():
+    mod = _load()
+    assert round(mod.compute_cost("claude_opus", 0, 0, 0, 1_000_000), 2) == 75.00
+
+
+def test_sonnet_cache_read():
+    mod = _load()
+    # Sonnet Input $3 → Cache-Read 0.1x = $0.30
+    assert round(mod.compute_cost("claude_sonnet", 0, 0, 1_000_000, 0), 2) == 0.30
+
+
+def test_env_override_cache_read(monkeypatch):
+    monkeypatch.setenv("PRICE_CLAUDE_OPUS_CACHE_READ", "0.5")
+    mod = _load()
+    assert round(mod.compute_cost("claude_opus", 0, 0, 1_000_000, 0), 2) == 0.50
+
+
+def test_collect_claude_wendet_cache_discount_an(tmp_path, monkeypatch):
+    """collect_claude: Token-ZAHL bleibt voll, aber Kosten spiegeln den Cache-Rabatt."""
+    day = "2026-06-02"
+    proj = tmp_path / "projects" / "p"
+    proj.mkdir(parents=True)
+    line = {
+        "timestamp": f"{day}T10:00:00Z",
+        "message": {
+            "id": "msg1",
+            "model": "claude-opus-4",
+            "usage": {
+                "input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 1_000_000,
+                "output_tokens": 0,
+            },
+        },
+    }
+    (proj / "s.jsonl").write_text(json.dumps(line) + "\n", encoding="utf-8")
+
+    monkeypatch.setenv("KICOST_DAY", day)
+    mod = _load()
+    monkeypatch.setattr(mod, "CLAUDE_GLOBS", [str(tmp_path / "projects" / "**" / "*.jsonl")])
+
+    agg = mod.collect_claude(day)
+    # Token-Zahl unveraendert (Anomalie-Signal bleibt korrekt)
+    assert agg["tokens_in"] == 1_000_000
+    # Kosten = 0.1x Opus-Input statt voller $15
+    assert round(agg["cost"], 2) == 1.50


### PR DESCRIPTION
## Was
`ki-cost-watchdog.py` summierte bisher `input_tokens` + `cache_creation_input_tokens` + `cache_read_input_tokens` alle zum **vollen** Input-Preis. Anthropic berechnet Cache-Reads real ~**0.1×** und Cache-Writes ~**1.25×** des Input-Preises.

## Wirkung (Trockenlauf, selber Tag)
- Notionale Tageskosten: **$2509 → $717.68** (realistischer)
- Token-**Zahl** unveraendert (336M) → das Anomalie-Signal bleibt korrekt
- `anomaly=False` gegen den (noch alt bepreisten) 7-Tage-Schnitt — kein Fehlalarm

## Aenderungen
- Neue `compute_cost(bucket, input, cache_write, cache_read, output)` — jede Kategorie eigener Preis
- Cache-Preise per Default aus Input abgeleitet, ueberschreibbar via `PRICE_<BUCKET>_CACHE_READ` / `_CACHE_WRITE`
- Env-Template (`deploy/shadowops-watchdog.env.example`) um die neuen Keys ergaenzt
- Codex-`cached_input` bleibt bewusst zum Input-Preis (Issue betrifft Anthropic-Cache; Codex = Folge-Thema)
- **7 Unit-Tests** (`tests/unit/test_ki_cost_watchdog.py`) — alle gruen

Closes #292