### PR TITLE
feat(watchdogs): zentrale Discord-429-Resilienz via geteilter Send-Lib (#293)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -45,6 +45,7 @@ paths:
 | `bot-watchdog.sh` | Watchdog fuer shadowops-bot (Backward-Compat-Wrapper, seit 2026-05-17) |
 | `service-watchdog.sh` | Generischer Watchdog (HTTP- oder systemd-Mode), parametrisiert via Env-Vars |
 | `backup-restore-test.sh` | Wrapper um `~/ZERODOX/scripts/backup-test.sh` mit Discord-Alert |
+| `lib/discord-send.sh` | Geteilte `discord_post()`-Funktion mit 429-Resilienz (Jitter + Retry-After, #293). Gesourct von service-/disk-hygiene-/doku-drift-/memory-watchdog (Fallback-Guard hält altes Inline-Curl). `bot-watchdog.sh` bleibt unberührt (Backward-Compat). |
 
 ## Watchdog-Familie (seit 2026-05-17 — Defense-in-Depth gegen shadowops-bot-Down)
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ downloads/
 eggs/
 .eggs/
 lib/
+# Ausnahme: scripts/lib/ enthaelt versionierte geteilte Shell-Libs (discord-send.sh, #293)
+!scripts/lib/
+!scripts/lib/*
 lib64/
 parts/
 sdist/

--- a/scripts/disk-hygiene-watchdog.sh
+++ b/scripts/disk-hygiene-watchdog.sh
@@ -29,6 +29,14 @@ if [ -z "$WEBHOOK_URL" ]; then
 fi
 mkdir -p "$(dirname "$STATE_FILE")"
 
+# Geteilte Discord-Send-Lib mit 429-Resilienz (#293). Fallback = altes Inline-Curl.
+# shellcheck source=lib/discord-send.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/discord-send.sh" 2>/dev/null || true
+if ! declare -f discord_post >/dev/null 2>&1; then
+  discord_post() { curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H 'Content-Type: application/json' --data "$2" --max-time 10 "$1" 2>/dev/null || echo 000; }
+fi
+
 now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 now_ts=$(date +%s)
 disk_pct() { df --output=pcent "$MOUNT" | tail -1 | tr -dc '0-9'; }
@@ -46,8 +54,7 @@ send_alert() {  # color title desc fields_json
     '{username:"ShadowOps Disk-Hygiene Watchdog",
       embeds:[{title:$t,description:$d,color:$c,fields:$f,
       footer:{text:"disk-hygiene-watchdog auf VPS (10.8.0.1)"},timestamp:$ts}]}')
-  http=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
-    --data "$payload" --max-time 10 "$WEBHOOK_URL" 2>/dev/null || echo 000)
+  http=$(discord_post "$WEBHOOK_URL" "$payload")
   [ "$http" = "204" ] || [ "$http" = "200" ]
 }
 

--- a/scripts/doku-drift-watchdog.sh
+++ b/scripts/doku-drift-watchdog.sh
@@ -29,6 +29,14 @@ mkdir -p "$(dirname "$STATE_FILE")"
 now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 now_ts=$(date +%s)
 
+# Geteilte Discord-Send-Lib mit 429-Resilienz (#293). Fallback = altes Inline-Curl.
+# shellcheck source=lib/discord-send.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/discord-send.sh" 2>/dev/null || true
+if ! declare -f discord_post >/dev/null 2>&1; then
+  discord_post() { curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H 'Content-Type: application/json' --data "$2" --max-time 10 "$1" 2>/dev/null || echo 000; }
+fi
+
 drift_lines=()
 
 # (a) Container-Host-Ports, die in keiner Port-Map-Datei stehen.
@@ -66,8 +74,7 @@ send_alert() {  # title desc
     '{username:"ShadowOps Doku-Drift Watchdog",
       embeds:[{title:$t,description:$d,color:16776960,
       footer:{text:"doku-drift-watchdog auf VPS (10.8.0.1)"},timestamp:$ts}]}')
-  http=$(curl -sS -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" \
-    --data "$payload" --max-time 10 "$WEBHOOK_URL" 2>/dev/null || echo 000)
+  http=$(discord_post "$WEBHOOK_URL" "$payload")
   [ "$http" = "204" ] || [ "$http" = "200" ]
 }
 

--- a/scripts/ki-cost-watchdog.py
+++ b/scripts/ki-cost-watchdog.py
@@ -36,7 +36,9 @@ KRITISCH (Codex-Kumulativ-Falle):
 
 import json
 import os
+import random
 import sys
+import time
 from datetime import datetime, timezone
 from glob import glob
 from urllib import request, error
@@ -351,8 +353,12 @@ def fmt_tokens(n) -> str:
     return str(n)
 
 
-def send_discord(webhook, payload) -> bool:
-    data = json.dumps(payload).encode("utf-8")
+def _send_once(webhook, data):
+    """Ein POST-Versuch. Returns (code, retry_after_seconds_or_None).
+
+    code=None signalisiert einen Netzwerk-/URL-Fehler (kein HTTP-Status).
+    retry_after ist nur bei HTTP 429 gesetzt.
+    """
     req = request.Request(
         webhook,
         data=data,
@@ -361,18 +367,50 @@ def send_discord(webhook, payload) -> bool:
     )
     try:
         with request.urlopen(req, timeout=10) as resp:
-            code = resp.getcode()
+            return resp.getcode(), None
+    except error.HTTPError as exc:
+        retry_after = None
+        if exc.code == 429:
+            try:
+                retry_after = float((exc.headers.get("Retry-After") or "1").strip())
+            except (TypeError, ValueError, AttributeError):
+                retry_after = 1.0
+        return exc.code, retry_after
+    except (error.URLError, OSError, ValueError) as exc:
+        print(f"[ki-cost-watchdog] WARN: Discord-Send fehlgeschlagen: {exc}", file=sys.stderr)
+        return None, None
+
+
+def send_discord(webhook, payload) -> bool:
+    """Sendet den Embed mit 429-Resilienz (#293) — Python-Pendant zur geteilten
+    Bash-Lib scripts/lib/discord-send.sh.
+
+    - Kleiner Jitter (0..KICOST_MAX_JITTER_MS, default 400ms) VOR dem Send entzerrt
+      gleichzeitige Multi-Service-Alarme ueber denselben Webhook.
+    - Bei HTTP 429: respektiert Retry-After (gedeckelt auf DISCORD_RETRY_CAP=10s)
+      und versucht GENAU 1 Retry. Andere Fehler: kein Retry.
+    """
+    data = json.dumps(payload).encode("utf-8")
+
+    max_jitter_ms = int(os.environ.get("KICOST_MAX_JITTER_MS", "400") or 0)
+    if max_jitter_ms > 0:
+        time.sleep(random.uniform(0, max_jitter_ms / 1000.0))
+
+    retry_cap = float(os.environ.get("DISCORD_RETRY_CAP", "10") or 10)
+    for attempt in (1, 2):
+        code, retry_after = _send_once(webhook, data)
         if code in (200, 204):
             print(f"[ki-cost-watchdog] Discord-Send OK (HTTP {code})")
             return True
-        print(f"[ki-cost-watchdog] WARN: Discord HTTP {code}", file=sys.stderr)
+        if attempt == 1 and code == 429:
+            wait = min(retry_after if retry_after is not None else 1.0, retry_cap)
+            print(f"[ki-cost-watchdog] HTTP 429 — warte {wait:g}s, 1 Retry", file=sys.stderr)
+            time.sleep(wait)
+            continue
+        if code is not None:
+            print(f"[ki-cost-watchdog] WARN: Discord HTTP {code}", file=sys.stderr)
         return False
-    except error.HTTPError as exc:
-        print(f"[ki-cost-watchdog] WARN: Discord HTTPError {exc.code}", file=sys.stderr)
-        return False
-    except (error.URLError, OSError, ValueError) as exc:
-        print(f"[ki-cost-watchdog] WARN: Discord-Send fehlgeschlagen: {exc}", file=sys.stderr)
-        return False
+    return False
 
 
 def build_payload(day, claude, codex, total_cost, total_tokens, avg, anomaly):

--- a/scripts/lib/discord-send.sh
+++ b/scripts/lib/discord-send.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# discord-send.sh — geteilter Discord-Webhook-Sender mit 429-Resilienz (#293).
+#
+# WARUM: Bei einem Multi-Service-Ausfall feuern mehrere Watchdogs ueber DENSELBEN
+# Webhook (SHADOWOPS_WATCHDOG_WEBHOOK) gleichzeitig -> Discord antwortet mit HTTP
+# 429 (Rate-Limit). Bisher behandelte kein Watchdog 429 -> einzelne Alarme gingen
+# genau im kritischsten Moment still verloren. Diese Lib zentralisiert das Senden
+# mit Jitter + Retry-After-Handling.
+#
+# NUTZUNG (sourcebar):
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/discord-send.sh"
+#   http=$(discord_post "$WEBHOOK_URL" "$payload")   # echo't finalen HTTP-Code
+#   # Returncode: 0 bei 2xx, sonst 1
+#
+# VERHALTEN:
+#   - Kleiner zufaelliger Jitter (0..DISCORD_MAX_JITTER_MS ms, default 400) VOR dem
+#     Send entzerrt gleichzeitige Alarme (Boot-Offsets helfen nur zeitversetzt).
+#   - HTTP 429: respektiert den Retry-After-Header (Sekunden, gedeckelt auf
+#     DISCORD_RETRY_CAP=10 s), wartet + GENAU 1 Retry. Andere Codes: kein Retry.
+#   - Echo't den finalen HTTP-Code ("204"/"429"/"000" bei curl-Fehler) auf stdout.
+#
+# ENV-Overrides: DISCORD_MAX_JITTER_MS, DISCORD_RETRY_CAP, DISCORD_SEND_TIMEOUT.
+#
+# Idempotent sourcebar (Guard) — keine Seiteneffekte beim Sourcen.
+
+[ -n "${_DISCORD_SEND_SH_LOADED:-}" ] && return 0
+_DISCORD_SEND_SH_LOADED=1
+
+DISCORD_RETRY_CAP="${DISCORD_RETRY_CAP:-10}"
+DISCORD_MAX_JITTER_MS="${DISCORD_MAX_JITTER_MS:-400}"
+DISCORD_SEND_TIMEOUT="${DISCORD_SEND_TIMEOUT:-10}"
+
+# Schlaeft die uebergebene Anzahl Millisekunden (best-effort, kein Crash).
+_discord_sleep_ms() {
+    local ms="$1"
+    [ "${ms:-0}" -gt 0 ] 2>/dev/null || return 0
+    sleep "$(awk -v m="$ms" 'BEGIN{printf "%.3f", m/1000}')" 2>/dev/null || true
+}
+
+# discord_post <webhook-url> <json-payload>
+# Echo't den finalen HTTP-Code, Returncode 0 bei 2xx.
+discord_post() {
+    local webhook="$1" payload="$2"
+    if [ -z "$webhook" ]; then echo "000"; return 1; fi
+
+    # Jitter vor dem ersten Send (entzerrt gleichzeitige Multi-Service-Alarme).
+    if [ "${DISCORD_MAX_JITTER_MS:-0}" -gt 0 ] 2>/dev/null; then
+        _discord_sleep_ms "$(( RANDOM % (DISCORD_MAX_JITTER_MS + 1) ))"
+    fi
+
+    local attempt resp http retry_after
+    for attempt in 1 2; do
+        # Header (-D -) auf stdout, Body verworfen; HTTP-Code via -w angehaengt.
+        resp=$(curl -sS -D - -o /dev/null -w $'\nHTTPCODE=%{http_code}' \
+            -X POST -H "Content-Type: application/json" \
+            --data "$payload" --max-time "$DISCORD_SEND_TIMEOUT" \
+            "$webhook" 2>/dev/null) || resp=$'\nHTTPCODE=000'
+        http=$(printf '%s\n' "$resp" | sed -n 's/.*HTTPCODE=//p' | tail -1 | tr -dc '0-9')
+        [ -z "$http" ] && http="000"
+
+        # Nur beim ersten Versuch + nur bei 429 wird ein Retry versucht.
+        if [ "$attempt" -eq 1 ] && [ "$http" = "429" ]; then
+            retry_after=$(printf '%s\n' "$resp" | grep -i '^retry-after:' | tail -1 | tr -dc '0-9.')
+            [ -z "$retry_after" ] && retry_after="1"
+            # Auf Cap deckeln, damit ein boeser Header den Watchdog nicht haengt.
+            retry_after=$(awk -v r="$retry_after" -v c="$DISCORD_RETRY_CAP" 'BEGIN{print (r+0>c+0)?c:r}')
+            echo "[discord-send] HTTP 429 — warte ${retry_after}s, 1 Retry" >&2
+            sleep "$retry_after" 2>/dev/null || sleep 1
+            continue
+        fi
+        break
+    done
+
+    echo "$http"
+    case "$http" in
+        2*) return 0 ;;
+        *) return 1 ;;
+    esac
+}

--- a/scripts/memory-watchdog.sh
+++ b/scripts/memory-watchdog.sh
@@ -43,6 +43,14 @@ fi
 
 mkdir -p "$(dirname "$STATE_FILE")"
 
+# Geteilte Discord-Send-Lib mit 429-Resilienz (#293). Fallback = altes Inline-Curl.
+# shellcheck source=lib/discord-send.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/discord-send.sh" 2>/dev/null || true
+if ! declare -f discord_post >/dev/null 2>&1; then
+  discord_post() { curl -sS -o /dev/null -w '%{http_code}' -X POST \
+    -H 'Content-Type: application/json' --data "$2" --max-time 10 "$1" 2>/dev/null || echo 000; }
+fi
+
 # ─── State lesen (Defaults) ───────────────────────────────
 if [ -f "$STATE_FILE" ]; then
   last_state=$(jq -r '.last_state // "ok"' "$STATE_FILE" 2>/dev/null || echo "ok")
@@ -147,9 +155,7 @@ send_alert() {
   )
 
   local http
-  http=$(curl -sS -o /dev/null -w "%{http_code}" \
-    -X POST -H "Content-Type: application/json" \
-    --data "$payload" --max-time 10 "$WEBHOOK_URL" 2>/dev/null || echo "000")
+  http=$(discord_post "$WEBHOOK_URL" "$payload")
   if [ "$http" = "204" ] || [ "$http" = "200" ]; then
     echo "[memory-watchdog] Alert gesendet (HTTP $http)"
     return 0

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -49,6 +49,15 @@ SERVICE_NAME="${WATCHDOG_SERVICE_NAME:-shadowops-bot}"
 HEALTH_URL="${WATCHDOG_HEALTH_URL:-${SHADOWOPS_HEALTH_URL:-http://127.0.0.1:8766/health}}"
 WEBHOOK_URL="${WATCHDOG_WEBHOOK:-${SHADOWOPS_WATCHDOG_WEBHOOK:-}}"
 CURL_TIMEOUT_S="${WATCHDOG_TIMEOUT_S:-${SHADOWOPS_WATCHDOG_TIMEOUT:-10}}"
+
+# Geteilte Discord-Send-Lib mit 429-Resilienz (#293). Fallback haelt das alte
+# Inline-Curl-Verhalten, falls die Lib bei kaputtem Deploy fehlt (Resilienz first).
+# shellcheck source=lib/discord-send.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/discord-send.sh" 2>/dev/null || true
+if ! declare -f discord_post >/dev/null 2>&1; then
+    discord_post() { curl -sS -o /dev/null -w '%{http_code}' -X POST \
+        -H 'Content-Type: application/json' --data "$2" --max-time 10 "$1" 2>/dev/null || echo 000; }
+fi
 # REQUIRE_BOT_READY: shadowops-bot liefert bot_ready im Health-JSON.
 # Generische Services (ZERODOX, GuildScout) haben das nicht — Default OFF
 # für non-shadowops Services. Explizit setzbar via Env.
@@ -118,18 +127,13 @@ EOF
 )
 
     local http_code
-    http_code=$(curl -s -o /tmp/watchdog_resp.json -w "%{http_code}" \
-        --max-time 15 \
-        -H "Content-Type: application/json" \
-        -X POST -d "$payload" \
-        "$WEBHOOK_URL" || echo "000")
+    http_code=$(discord_post "$WEBHOOK_URL" "$payload")
 
     if [[ "$http_code" =~ ^2 ]]; then
         echo "[watchdog:$SERVICE_NAME] Discord-Alert gesendet (HTTP $http_code)"
         return 0
     else
         echo "[watchdog:$SERVICE_NAME] ERROR: Discord-Webhook fehlgeschlagen (HTTP $http_code)"
-        cat /tmp/watchdog_resp.json 2>/dev/null | head -2
         return 1
     fi
 }

--- a/tests/unit/test_discord_send.py
+++ b/tests/unit/test_discord_send.py
@@ -1,0 +1,106 @@
+"""Tests fuer scripts/lib/discord-send.sh — 429-Resilienz (#293).
+
+Startet einen Stub-HTTP-Server und ruft die gesourcte Bash-Funktion discord_post
+ueber `bash -c` auf. Verifiziert:
+  - 429 dann 204  -> genau 1 Retry, finaler Code 204, Exit 0
+  - immer 500      -> KEIN Retry (nur 429 wird wiederholt), Exit != 0
+  - immer 429      -> genau 1 Retry (2 Requests gesamt), Exit != 0
+  - leerer Webhook -> "000", Exit != 0, kein Request
+
+Jitter ist via DISCORD_MAX_JITTER_MS=0 deaktiviert, Retry-After=0 haelt die Tests
+schnell.
+"""
+
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "discord-send.sh"
+
+# Request-Zaehler pro Pfad (ueber alle Handler-Instanzen geteilt).
+_COUNTS: dict[str, int] = {}
+_LOCK = threading.Lock()
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):  # Test-Output ruhig halten
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        if length:
+            self.rfile.read(length)
+        with _LOCK:
+            _COUNTS[self.path] = _COUNTS.get(self.path, 0) + 1
+            n = _COUNTS[self.path]
+
+        if self.path == "/retry-once":
+            if n == 1:
+                self.send_response(429)
+                self.send_header("Retry-After", "0")
+                self.end_headers()
+            else:
+                self.send_response(204)
+                self.end_headers()
+        elif self.path == "/always-500":
+            self.send_response(500)
+            self.end_headers()
+        elif self.path == "/always-429":
+            self.send_response(429)
+            self.send_header("Retry-After", "0")
+            self.end_headers()
+        else:
+            self.send_response(204)
+            self.end_headers()
+
+
+@pytest.fixture()
+def server():
+    _COUNTS.clear()
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    host, port = srv.server_address
+    yield f"http://{host}:{port}"
+    srv.shutdown()
+
+
+def _discord_post(url: str):
+    """Ruft discord_post via bash auf; gibt (stdout_code, returncode) zurueck."""
+    cmd = (
+        f'DISCORD_MAX_JITTER_MS=0 DISCORD_RETRY_CAP=2 '
+        f'source "{_LIB}"; discord_post "{url}" \'{{"content":"x"}}\''
+    )
+    res = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, timeout=30)
+    return res.stdout.strip(), res.returncode
+
+
+def test_429_dann_204_genau_ein_retry(server):
+    code, rc = _discord_post(f"{server}/retry-once")
+    assert code == "204"
+    assert rc == 0
+    assert _COUNTS["/retry-once"] == 2  # erster 429 + ein Retry
+
+
+def test_500_kein_retry(server):
+    code, rc = _discord_post(f"{server}/always-500")
+    assert code == "500"
+    assert rc != 0
+    assert _COUNTS["/always-500"] == 1  # KEIN Retry bei Nicht-429
+
+
+def test_429_dauerhaft_genau_ein_retry(server):
+    code, rc = _discord_post(f"{server}/always-429")
+    assert code == "429"
+    assert rc != 0
+    assert _COUNTS["/always-429"] == 2  # erster Versuch + genau 1 Retry
+
+
+def test_leerer_webhook_kein_request():
+    cmd = f'source "{_LIB}"; discord_post "" \'{{"content":"x"}}\''
+    res = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, timeout=10)
+    assert res.stdout.strip() == "000"
+    assert res.returncode != 0

--- a/tests/unit/test_ki_cost_send.py
+++ b/tests/unit/test_ki_cost_send.py
@@ -1,0 +1,86 @@
+"""Test fuer ki-cost-watchdog.py send_discord — 429-Resilienz (#293).
+
+Python-Pendant zur Bash-Lib scripts/lib/discord-send.sh: bei HTTP 429 genau 1
+Retry (Retry-After-respektierend), bei anderen Fehlern kein Retry. urllib wird
+gemockt; Jitter via KICOST_MAX_JITTER_MS=0 deaktiviert.
+"""
+
+import importlib.util
+from email.message import Message
+from pathlib import Path
+from urllib import error
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ki-cost-watchdog.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("ki_cost_watchdog_send", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Resp:
+    def __init__(self, code):
+        self._code = code
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def getcode(self):
+        return self._code
+
+
+def _http_error_429(retry_after="0"):
+    h = Message()
+    h["Retry-After"] = retry_after
+    return error.HTTPError("http://x", 429, "Too Many Requests", h, None)
+
+
+def test_429_dann_erfolg_genau_ein_retry(monkeypatch):
+    mod = _load()
+    monkeypatch.setenv("KICOST_MAX_JITTER_MS", "0")
+    monkeypatch.setenv("DISCORD_RETRY_CAP", "2")
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=10):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error_429("0")
+        return _Resp(204)
+
+    monkeypatch.setattr(mod.request, "urlopen", fake_urlopen)
+    assert mod.send_discord("http://x", {"content": "x"}) is True
+    assert calls["n"] == 2  # erster 429 + genau 1 Retry
+
+
+def test_500_kein_retry(monkeypatch):
+    mod = _load()
+    monkeypatch.setenv("KICOST_MAX_JITTER_MS", "0")
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=10):
+        calls["n"] += 1
+        raise error.HTTPError("http://x", 500, "err", Message(), None)
+
+    monkeypatch.setattr(mod.request, "urlopen", fake_urlopen)
+    assert mod.send_discord("http://x", {"content": "x"}) is False
+    assert calls["n"] == 1  # KEIN Retry bei Nicht-429
+
+
+def test_dauerhaft_429_genau_ein_retry(monkeypatch):
+    mod = _load()
+    monkeypatch.setenv("KICOST_MAX_JITTER_MS", "0")
+    monkeypatch.setenv("DISCORD_RETRY_CAP", "1")
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=10):
+        calls["n"] += 1
+        raise _http_error_429("0")
+
+    monkeypatch.setattr(mod.request, "urlopen", fake_urlopen)
+    assert mod.send_discord("http://x", {"content": "x"}) is False
+    assert calls["n"] == 2  # erster Versuch + genau 1 Retry


### PR DESCRIPTION
## Problem
Bei einem Multi-Service-Ausfall feuern mehrere Watchdogs ueber **denselben** Webhook gleichzeitig → Discord **HTTP 429**. Bisher behandelte kein Watchdog 429 → einzelne Alarme gingen genau im kritischsten Moment **still verloren**.

## Loesung
**Neu `scripts/lib/discord-send.sh`** — geteilte `discord_post(webhook, payload)`:
- Kleiner Jitter (0–400 ms) **vor** dem Send → entzerrt gleichzeitige Alarme (Boot-Offsets helfen nur zeitversetzt)
- Bei HTTP 429: respektiert `Retry-After` (gedeckelt auf 10 s) + **genau 1 Retry**; andere Codes kein Retry
- Echo't finalen HTTP-Code, Returncode 0 bei 2xx

Eingeklinkt in `service-watchdog.sh`, `disk-hygiene-`, `doku-drift-`, `memory-watchdog.sh` — jeweils mit **Fallback-Guard**: fehlt die Lib (kaputtes Deploy), wird `discord_post` als altes Inline-Curl definiert → die Resilienz wird **nie gesenkt**.

`ki-cost-watchdog.py`: Python-Pendant (Jitter + 429-Retry) in `send_discord`.

`bot-watchdog.sh` **bewusst unberuehrt** (Backward-Compat-Source-of-Truth, safety.md).

## Tests
- `test_discord_send.py` (4): 429→204 (1 Retry), 500 (kein Retry), Dauer-429 (1 Retry), leerer Webhook
- `test_ki_cost_send.py` (3): dieselben Faelle fuer die Python-Variante (urllib gemockt)
- Regression `test_service_watchdog_jq_filter.py` 8/8 gruen, alle Scripts `bash -n` sauber

Closes #293