### PR TITLE
fix(webhook): Auto-Deploy entkoppeln — Background-Task statt synchron (#478)

### DIFF
--- a/src/integrations/github_integration/core.py
+++ b/src/integrations/github_integration/core.py
@@ -183,6 +183,9 @@ class GitHubIntegration(JulesWorkflowMixin,
         self.local_polling_task = None
         self._inflight_commits: Dict[str, float] = self._load_inflight_state()
         self._ci_polling_tasks: Dict[str, asyncio.Task] = {}
+        # #478: Hintergrund-Tasks fuer Auto-Deploy. Der Webhook-Handler darf nicht
+        # synchron auf den (minutenlangen) Deploy warten — sonst 504 (GitHub-Timeout).
+        self._deploy_tasks: set = set()
 
         # Enterprise Hardening: Concurrency Lock + AI Circuit Breaker
         self._patch_notes_lock = asyncio.Lock()

--- a/src/integrations/github_integration/event_handlers_mixin.py
+++ b/src/integrations/github_integration/event_handlers_mixin.py
@@ -142,13 +142,22 @@ class EventHandlersMixin:
                         f"🚀 PR merged to {target_branch}, triggering deployment "
                         f"(wait-for-CI: repo={repo_full_name}, sha={merge_commit_sha})"
                     )
-                    await self._trigger_deployment(
-                        repo_name,
-                        target_branch,
-                        merge_commit_sha,
-                        repo_full_name=repo_full_name,
-                        full_sha=full_merge_sha,
+                    # #478: Deploy als Background-Task starten, NICHT synchron awaiten.
+                    # Synchrones await liess den Webhook-Handler bis zum Deploy-Ende
+                    # blockieren → GitHub-10s-Timeout → 504 → Auto-Deploy galt als
+                    # fehlgeschlagen. Task referenziert halten (GC-Schutz), Aufraeumen
+                    # via done-Callback.
+                    deploy_task = asyncio.create_task(
+                        self._trigger_deployment(
+                            repo_name,
+                            target_branch,
+                            merge_commit_sha,
+                            repo_full_name=repo_full_name,
+                            full_sha=full_merge_sha,
+                        )
                     )
+                    self._deploy_tasks.add(deploy_task)
+                    deploy_task.add_done_callback(self._deploy_tasks.discard)
 
         except Exception as e:
             self.logger.error(f"❌ Error handling PR event: {e}", exc_info=True)

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -2,6 +2,7 @@
 Unit Tests for GitHub Integration
 """
 
+import asyncio
 import hashlib
 import hmac
 from unittest.mock import Mock, AsyncMock, MagicMock
@@ -425,6 +426,48 @@ class TestPullRequestHandling:
         kwargs = integration._trigger_deployment.call_args.kwargs
         assert kwargs['repo_full_name'] == 'Commandershadow9/ZERODOX'
         assert kwargs['full_sha'] == 'a' * 40
+
+    @pytest.mark.asyncio
+    async def test_pr_merge_does_not_block_on_deploy(self, mock_bot, enabled_config):
+        """#478: Der Merge-Handler darf NICHT synchron auf den (minutenlangen)
+        Deploy warten — sonst laeuft GitHubs 10s-Webhook-Timeout ab (504) und der
+        Auto-Deploy gilt als fehlgeschlagen. Deploy muss als Background-Task laufen,
+        der Handler kehrt sofort zurueck."""
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration._send_pr_notification = AsyncMock()
+
+        deploy_started = asyncio.Event()
+        deploy_release = asyncio.Event()
+
+        async def slow_deploy(*args, **kwargs):
+            deploy_started.set()
+            await deploy_release.wait()  # simuliert einen langlaufenden Deploy
+
+        integration._trigger_deployment = AsyncMock(side_effect=slow_deploy)
+
+        payload = {
+            'action': 'closed',
+            'repository': {'name': 'mayday-sim', 'full_name': 'Commandershadow9/mayday-sim'},
+            'pull_request': {
+                'number': 408,
+                'title': 'Security PR',
+                'user': {'login': 'developer'},
+                'html_url': 'https://github.com/Commandershadow9/mayday-sim/pull/408',
+                'head': {'ref': 'cmd/security'},
+                'base': {'ref': 'main'},
+                'merged': True,
+                'merge_commit_sha': 'b' * 40,
+            },
+        }
+
+        # Handler muss schnell zurueckkehren, obwohl der Deploy noch laeuft (kein 504)
+        await asyncio.wait_for(integration.handle_pull_request_event(payload), timeout=1.0)
+        # Deploy wurde als Hintergrund-Task gestartet und laeuft noch
+        await asyncio.wait_for(deploy_started.wait(), timeout=1.0)
+        assert not deploy_release.is_set()
+
+        deploy_release.set()  # Cleanup: Background-Task abschliessen lassen
+        await asyncio.sleep(0)
 
 
 class TestWelle910WaitForCI:


### PR DESCRIPTION
## Problem (#478 / #451)
Der GitHub-Webhook-Handler (`webhook_mixin.py:252`) ruft den Event-Handler **synchron** auf (`await handler(payload)`). Für PR-Merge-Events triggert `handle_pr_event` (`event_handlers_mixin.py:145`) den vollen Deploy mit `await self._trigger_deployment(...)` — git-pull → wait-for-CI → Build → Restart → Health, das dauert **Minuten**.

GitHubs Webhook-Timeout ist **10 Sekunden** → `pull_request/closed → 504 timed out` (in den Deliveries belegt) → Delivery „failed" → **kein verlässlicher Auto-Deploy** (Symptom #451: manueller Rebuild nötig). Live verifiziert: 4 frische mayday-sim-Merges lösten keinen Deploy aus, alle `pull_request/closed`-Deliveries 504.

## Fix
Deploy läuft jetzt als **referenzierter `asyncio`-Background-Task**:
```python
deploy_task = asyncio.create_task(self._trigger_deployment(...))
self._deploy_tasks.add(deploy_task)
deploy_task.add_done_callback(self._deploy_tasks.discard)
```
- Handler kehrt **sofort** zurück → Webhook antwortet 200 (kein 504).
- Deploy läuft mit voller Defense-in-Depth-Kette (Backup→CI-Wait→Build→Health→Rollback) im Hintergrund.
- Task referenziert gehalten (`_deploy_tasks`, GC-Schutz) + done-Callback-Cleanup. Standard-asyncio-Pattern, identisch zu `_ci_polling_tasks`.

## Tests
- **Neu (TDD):** `test_pr_merge_does_not_block_on_deploy` — Merge mit langlaufendem Deploy-Mock; Handler muss < 1s zurückkehren, Deploy läuft als Task weiter. Erst rot (Timeout), dann grün.
- Bestehende Merge-Tests bleiben grün (Mock-Call passiert synchron beim Coroutine-Erstellen).
- **`test_github_integration.py`: 32/32 grün.**

Verwandt: #458 (build-id = Restart-Timestamp statt git-SHA) wird separat in mayday-sim adressiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)