### PR TITLE
fix(patchnotes): Archivierung committet+pusht Deploy-Repo clean (#302)

### DIFF
--- a/.claude/rules/safety.md
+++ b/.claude/rules/safety.md
@@ -78,6 +78,7 @@ Bei Aenderungen an Shared-Services (Redis, PostgreSQL, Traefik) MUESSEN alle Kon
 - NIEMALS den `RuntimeError` Abort in `validate.py` bei `ai_result=None` entfernen — sonst Endlosschleife mit leeren DB-Einträgen (Vorfall 2026-04-14: 33 leere Einträge in 4h)
 - NIEMALS `discord_highlights` aus dem Schema in `_build_structured_wrapper` entfernen — `AIEngine.generate_structured_patch_notes()` returnt None ohne dieses Feld
 - Bei AIEngine-Calls: NICHT raten. Methoden sind: `generate_structured_patch_notes()`, `get_raw_ai_response()`, `query()` (existiert nur in Provider-Klassen, nicht in AIEngine)
+- **Release-Notes-Archivierung committet+pusht (seit 2026-06-02, #302):** `_archive_release_notes()` in `stages/distribute.py` schreibt `docs/release-history/v<version>.md` + setzt `release_notes.md` aufs Template zurück UND committet+pusht **genau diese zwei Dateien** via `_commit_and_push_archive()`. Grund: vorher blieb der Deploy-Checkout dirty → nächster Auto-Deploy-`git pull` brach ab (Vorfall mayday-sim PR #489). Regeln: NIEMALS `git add -A` (würde fremde uncommittete Changes im Deploy-Repo mitnehmen) — immer `git add -- <2 dateien>`. Git-Fehler dürfen die Pipeline NIE crashen (`_run_git_quiet` wirft nie, alles best-effort, Archiv liegt schon auf Platte). Direkter Push auf den Deploy-Branch triggert KEINEN Auto-Deploy (Block in `event_handlers_mixin.py`). Idempotent via `git diff --cached --quiet`.
 - Conventional Commit Hook auf allen 5 Projekten. Re-Deploy: `scripts/deploy-commit-hook.sh --all`
 
 ## Learning-System (agent_learning DB)

--- a/src/patch_notes/stages/distribute.py
+++ b/src/patch_notes/stages/distribute.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import subprocess
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import discord
@@ -745,14 +747,131 @@ archiviert und hier wieder geleert. Du fangst also frisch an fuer den naechsten 
 """
 
 
+def _run_git_quiet(repo_path: Path, args: list, timeout: int = 15) -> tuple[bool, str, str]:
+    """Führt ein git-Kommando still aus. Gibt (erfolg, stdout, stderr) zurück.
+
+    Wirft NIE — git darf die Patch-Notes-Pipeline nicht crashen. Bei jeder
+    Störung (Timeout, git fehlt, exit != 0) wird (False, '', <fehler>) geliefert.
+    """
+    try:
+        result = subprocess.run(
+            ['git', *args],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0, (result.stdout or '').strip(), (result.stderr or '').strip()
+    except Exception as e:  # noqa: BLE001 — defensive: git darf nie die Pipeline abbrechen
+        return False, '', str(e)
+
+
+# Bot-Identität für Archiv-Commits — via `git -c` pro Commit gesetzt, damit die
+# .git/config des Deploy-Repos NICHT dauerhaft verändert wird (kein Blame-Pollution).
+_GIT_AUTHOR_FLAGS = ['-c', 'user.email=shadowops@local', '-c', 'user.name=ShadowOps Bot']
+
+
+def _sanitize_git_error(err: str) -> str:
+    """Redigiert potenziell sensible Zeilen aus git-stderr vor dem Logging.
+
+    git kann bei Auth-Fehlern Credential-Helper-Output, Remote-URLs mit
+    eingebetteten Tokens oder SSH-Key-/.netrc-Pfade emittieren. CLAUDE.md verbietet
+    Secrets in Logs — daher Zeilen mit Auth-/URL-Markern komplett verwerfen.
+    """
+    if not err:
+        return ''
+    sensitive = (
+        'token', 'password', 'passwd', 'credential', 'authorization',
+        'ssh', 'netrc', '@', 'http://', 'https://', 'bearer', 'secret',
+    )
+    out = []
+    for line in err.splitlines():
+        low = line.lower()
+        out.append('[redigiert]' if any(m in low for m in sensitive) else line)
+    return ' | '.join(out)[:300]
+
+
+def _commit_and_push_archive(
+    base: Path, notes_path: Path, archive_file: Path, version: str, project: str
+) -> None:
+    """Committet + pusht NUR die beiden Archiv-Dateien (best-effort, #302).
+
+    Lässt das Deploy-Repo nach dem Archivieren clean zurück, damit der nächste
+    Auto-Deploy-`git pull` nicht an einem dirty Working-Tree scheitert (war die
+    Ursache von shadowops#302). Staget ausschließlich `release_notes.md` + die
+    neue Archiv-Datei (nie `git add -A`), damit fremde uncommittete Änderungen
+    im Deploy-Checkout nicht mitgenommen werden.
+
+    Defensive: jede git-Störung wird geloggt und geschluckt — das Archiv liegt
+    bereits auf Platte, ein fehlgeschlagener Push ist nicht kritisch (der nächste
+    Release-Lauf pusht den lokalen Commit nach). Ein direkter Push auf den
+    Deploy-Branch triggert KEINEN Auto-Deploy (hardcoded Block in
+    event_handlers_mixin.py).
+    """
+    try:
+        # 1. git-Repo-Guard — project_path ist nicht zwingend ein Repo
+        ok, _, _ = _run_git_quiet(base, ['rev-parse', '--git-dir'], timeout=5)
+        if not ok:
+            logger.debug(f"[v6] {base} ist kein git-Repo — Archiv nicht committed")
+            return
+
+        # 2. Detached-HEAD-Guard + aktuellen Branch ermitteln
+        ok, branch, _ = _run_git_quiet(base, ['symbolic-ref', '-q', '--short', 'HEAD'], timeout=5)
+        if not ok or not branch:
+            logger.debug("[v6] detached HEAD — Archiv nicht gepusht")
+            return
+
+        # 3. Nur die zwei Dateien stagen (relative Pfade, -- trennt Pathspecs von Refs)
+        try:
+            rel_notes = str(notes_path.relative_to(base))
+            rel_archive = str(archive_file.relative_to(base))
+        except ValueError:
+            logger.warning("[v6] Archiv-Pfade außerhalb des Repos — Commit übersprungen")
+            return
+        _run_git_quiet(base, ['add', '--', rel_notes, rel_archive])
+
+        # 4. Idempotenz: git diff --cached --quiet → rc 0 = NICHTS gestaged → fertig.
+        #    nothing_staged spiegelt genau diese (invertierte) --quiet-Semantik.
+        nothing_staged, _, _ = _run_git_quiet(
+            base, ['diff', '--cached', '--quiet', '--', rel_notes, rel_archive]
+        )
+        if nothing_staged:
+            logger.debug("[v6] Archiv bereits committed — nichts zu tun")
+            return
+
+        # 5. Commit — exakt die zwei Pfade, Bot-Identität via -c (keine config-Pollution).
+        ok, _, err = _run_git_quiet(
+            base,
+            ['commit', *_GIT_AUTHOR_FLAGS,
+             '-m', f'docs: archive release notes v{version}',
+             '--', rel_notes, rel_archive],
+            timeout=20,
+        )
+        if not ok:
+            logger.warning(f"[v6] Archiv-Commit fehlgeschlagen: {_sanitize_git_error(err)}")
+            return
+
+        # 6. Push — best-effort, Working-Tree ist auch ohne Push schon clean
+        ok, _, err = _run_git_quiet(base, ['push', 'origin', branch], timeout=30)
+        if not ok:
+            logger.warning(
+                f"[v6] Archiv-Push fehlgeschlagen (lokal committed): {_sanitize_git_error(err)}"
+            )
+            return
+        logger.info(f"[v6] {project}: Archiv v{version} committed + gepusht ({branch})")
+    except Exception as e:  # noqa: BLE001 — Defense-in-Depth: git crasht die Pipeline nie
+        logger.warning(f"[v6] Archiv-Commit/Push unerwartet fehlgeschlagen: {e}")
+
+
 def _archive_release_notes(ctx: PipelineContext) -> None:
     """Archiviert release_notes.md nach docs/release-history/v<version>.md
     und setzt das Template zurück in die Original-Datei.
 
     Idempotent: wenn die Datei nicht existiert oder nur Template enthält,
     passiert nichts. Läuft nur bei erfolgreichem Discord-Send (messages_sent > 0).
+    Nach dem Archivieren werden die beiden Dateien committed + gepusht, damit das
+    Deploy-Repo clean bleibt (#302).
     """
-    from pathlib import Path
     import re
 
     project_path = ctx.project_config.get('path', '')
@@ -781,7 +900,14 @@ def _archive_release_notes(ctx: PipelineContext) -> None:
     # HTML-Kommentare strippen — wenn nichts übrig: nur Template, nicht archivieren
     stripped = re.sub(r'<!--.*?-->', '', raw, flags=re.DOTALL).strip()
     if len(stripped) < 20:
-        logger.debug(f"[v6] release_notes.md enthält nur Template — kein Archiv nötig")
+        logger.debug("[v6] release_notes.md enthält nur Template — kein Archiv nötig")
+        return
+
+    # Version-Guard: ctx.version fließt in Dateiname + Commit-Message. versioning.py
+    # liefert zwar striktes SemVer, aber am Boundary defensiv gegen Pfad-Traversal
+    # (../) und Newline-Injection in der Commit-Message absichern (#302-Review).
+    if not re.match(r'^\d+\.\d+\.\d+([.\-+][0-9A-Za-z.\-]+)?$', str(ctx.version)):
+        logger.warning(f"[v6] Ungültige Version, Archiv übersprungen: {ctx.version!r}")
         return
 
     # Archiv-Pfad: docs/release-history/v<version>.md
@@ -802,5 +928,8 @@ def _archive_release_notes(ctx: PipelineContext) -> None:
             f"[v6] {ctx.project}: release_notes.md archiviert -> {archive_file.name} "
             f"(Template zurückgesetzt)"
         )
+        # Deploy-Repo clean halten: die zwei Archiv-Dateien committen + pushen (#302).
+        # Eigenes try/except — git darf den Archiv-Erfolgspfad nie crashen.
+        _commit_and_push_archive(base, notes_path, archive_file, ctx.version, ctx.project)
     except Exception as e:
         logger.warning(f"[v6] release_notes Archivierung fehlgeschlagen: {e}")

--- a/tests/unit/test_pn_distribute.py
+++ b/tests/unit/test_pn_distribute.py
@@ -1,5 +1,6 @@
 """Tests für Stufe 5: Distribute — Embeds, Sending, Rollback."""
 import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock
 from patch_notes.stages.distribute import (
     _build_full_embed, _build_summary_embed, _build_footer_text,
@@ -7,6 +8,7 @@ from patch_notes.stages.distribute import (
     _split_embed_for_sending, _format_change_line,
     _send_customer,
     distribute, retract_patch_notes,
+    _archive_release_notes,
 )
 from patch_notes.context import PipelineContext
 
@@ -379,3 +381,313 @@ def test_log_metrics_pipeline_total_time_fallback_to_metrics_dict(caplog):
     raw_json = metrics_records[-1].getMessage().split("METRICS|patch_notes_pipeline|", 1)[1]
     payload = _json.loads(raw_json)
     assert payload["pipeline_total_time_s"] == 12.3
+
+
+# ── _archive_release_notes: git commit + push (shadowops#302) ──
+#
+# Bug: Die Archivierung schrieb release_notes.md (Template-Reset) + das Archiv,
+# committete/pushte aber nie → Deploy-Repo blieb dirty → nächster git pull des
+# Auto-Deploys brach ab. Diese Tests pinnen das defensive commit+push-Verhalten.
+
+# Default-Antworten je git-Subkommando. diff --cached --quiet = rc 1 bedeutet
+# "es gibt gestagte Änderungen" → committen.
+_GIT_DEFAULTS = {
+    "rev-parse": (0, ".git\n", ""),
+    "symbolic-ref": (0, "main\n", ""),
+    "add": (0, "", ""),
+    "diff": (1, "", ""),
+    "config:user.email": (0, "bot@shadowops\n", ""),
+    "config:user.name": (0, "ShadowOps Bot\n", ""),
+    "commit": (0, "", ""),
+    "push": (0, "", ""),
+}
+
+
+def _git_responder(overrides=None):
+    """Fake für patch_notes.stages.distribute.subprocess.run.
+
+    Gibt (fake_run, calls) zurück. `calls` sammelt jede git-Argumentliste.
+    `overrides` (dict) ersetzt Default-Antworten pro Marker-Key.
+    """
+    overrides = overrides or {}
+    calls: list[list[str]] = []
+
+    def _key_for(cmd: list[str]) -> str:
+        sub = cmd[1] if len(cmd) > 1 else ""
+        if sub == "config":
+            return "config:" + (cmd[2] if len(cmd) > 2 else "")
+        return sub
+
+    def fake_run(cmd, **kwargs):
+        cmd = list(cmd)
+        calls.append(cmd)
+        key = _key_for(cmd)
+        rc, out, err = overrides.get(key, _GIT_DEFAULTS.get(key, (0, "", "")))
+        return SimpleNamespace(returncode=rc, stdout=out, stderr=err)
+
+    return fake_run, calls
+
+
+def _archive_ctx(tmp_path, **kwargs):
+    cfg = {"path": str(tmp_path), "patch_notes": {"type": "devops", "language": "de"}}
+    kwargs.setdefault("version", "1.2.3")
+    return _make_ctx(project_config=cfg, **kwargs)
+
+
+def _seed_release_notes(tmp_path, body="## Echtes Feature\nEin Eintrag mit deutlich mehr als zwanzig Zeichen Inhalt.\n"):
+    notes = tmp_path / "release_notes.md"
+    notes.write_text(f"<!-- template-kommentar -->\n\n{body}", encoding="utf-8")
+    return notes
+
+
+def _git_calls(calls, subcommand):
+    """Filtert calls auf ein git-Subkommando (cmd[1])."""
+    return [c for c in calls if len(c) > 1 and c[1] == subcommand]
+
+
+def test_archive_commits_only_two_files(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+
+    add_calls = _git_calls(calls, "add")
+    assert add_calls, "git add wurde nicht aufgerufen"
+    add = add_calls[0]
+    assert "--" in add, "Pathspec-Separator -- fehlt"
+    assert any("release_notes.md" in a for a in add)
+    assert any("v1.2.3.md" in a for a in add)
+
+
+def test_archive_never_uses_git_add_all(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+
+    for c in calls:
+        assert c[:3] != ["git", "add", "-A"], f"Verbotenes git add -A: {c}"
+
+
+def test_archive_git_failure_does_not_raise(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, _ = _git_responder(overrides={"commit": (1, "", "boom")})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    # darf nicht werfen; Archiv muss trotzdem auf Platte liegen
+    _archive_release_notes(ctx)
+    assert (tmp_path / "docs" / "release-history" / "v1.2.3.md").exists()
+
+
+def test_archive_subprocess_exception_does_not_raise(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+
+    def boom(cmd, **kwargs):
+        raise OSError("git not found")
+
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", boom)
+    _archive_release_notes(ctx)  # kein Crash
+    assert (tmp_path / "docs" / "release-history" / "v1.2.3.md").exists()
+
+
+def test_archive_not_a_git_repo_skips_quietly(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder(overrides={"rev-parse": (128, "", "not a git repo")})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert not _git_calls(calls, "commit"), "Commit trotz Nicht-Git-Repo"
+    assert not _git_calls(calls, "push")
+
+
+def test_archive_detached_head_skips_push(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder(overrides={"symbolic-ref": (1, "", "detached")})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert not _git_calls(calls, "push"), "Push trotz detached HEAD"
+    assert not _git_calls(calls, "commit"), "Commit trotz detached HEAD (early return fehlt)"
+
+
+def test_archive_commit_uses_bot_identity_via_c_flags(tmp_path, monkeypatch):
+    # Bot-Identität wird via `git -c` pro Commit gesetzt — NICHT in .git/config
+    # geschrieben (keine Identity-Pollution im Deploy-Repo).
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+
+    commit_calls = _git_calls(calls, "commit")
+    assert commit_calls, "Kein commit-Call"
+    flat = commit_calls[0]
+    assert "-c" in flat
+    assert "user.email=shadowops@local" in flat
+    assert "user.name=ShadowOps Bot" in flat
+    # NIEMALS persistentes git config user.* schreiben (4-arg config-set)
+    config_sets = [c for c in calls if len(c) >= 4 and c[1] == "config"]
+    assert not config_sets, f"Persistentes git config geschrieben: {config_sets}"
+
+
+def test_archive_idempotent_nothing_staged(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    # diff --cached --quiet rc 0 = nichts gestaged → kein commit
+    fake_run, calls = _git_responder(overrides={"diff": (0, "", "")})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert not _git_calls(calls, "commit"), "Commit trotz nichts-gestaged"
+
+
+def test_archive_push_failure_keeps_local_commit(tmp_path, monkeypatch, caplog):
+    import logging
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder(overrides={"push": (1, "", "no upstream")})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    with caplog.at_level(logging.WARNING, logger="shadowops"):
+        _archive_release_notes(ctx)
+
+    assert _git_calls(calls, "commit"), "Commit fehlt"
+    assert _git_calls(calls, "push"), "Push wurde nicht versucht"
+    # kein Raise; Warnung geloggt
+    assert any("push" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_archive_commit_message_contains_version(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+
+    commit_calls = _git_calls(calls, "commit")
+    assert commit_calls, "Kein commit-Call"
+    msg_idx = commit_calls[0].index("-m") + 1
+    # Exakte Conventional-Commit-Form pinnen (nicht nur Substring)
+    assert commit_calls[0][msg_idx] == "docs: archive release notes v1.2.3"
+
+
+def test_archive_template_only_skips_git_entirely(tmp_path, monkeypatch):
+    # release_notes.md enthält nur einen HTML-Kommentar → kein Archiv, kein git
+    notes = tmp_path / "release_notes.md"
+    notes.write_text("<!-- nur template, kein inhalt -->\n", encoding="utf-8")
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert calls == [], "git wurde trotz Template-only aufgerufen"
+
+
+def test_archive_commits_when_changes_staged(tmp_path, monkeypatch):
+    # Gegenrichtung zu test_archive_idempotent_nothing_staged (Mutation-Coverage):
+    # diff --cached --quiet rc 1 = es GIBT gestagte Änderungen → commit MUSS laufen.
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder(overrides={"diff": (1, "", "")})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert _git_calls(calls, "commit"), "Commit fehlt obwohl Änderungen gestaged sind"
+
+
+def test_archive_paths_outside_repo_skip(tmp_path, monkeypatch):
+    # relative_to(base) wirft ValueError → Commit wird übersprungen, kein Crash.
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    from pathlib import Path as _P
+    orig = _P.relative_to
+
+    def _raise(self, *a, **k):
+        raise ValueError("outside repo")
+
+    monkeypatch.setattr(_P, "relative_to", _raise)
+    _archive_release_notes(ctx)  # kein Crash
+    monkeypatch.setattr(_P, "relative_to", orig)
+
+    assert not _git_calls(calls, "add"), "add trotz Pfad außerhalb Repo"
+    assert not _git_calls(calls, "commit")
+
+
+def test_archive_git_timeout_does_not_raise(tmp_path, monkeypatch):
+    import subprocess as _sp
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+
+    def timeout_run(cmd, **kwargs):
+        raise _sp.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 30))
+
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", timeout_run)
+    _archive_release_notes(ctx)  # kein Crash trotz git-Timeout
+    assert (tmp_path / "docs" / "release-history" / "v1.2.3.md").exists()
+
+
+def test_archive_invalid_version_skips_entirely(tmp_path, monkeypatch):
+    # Pfad-Traversal/Newline in der Version → gar nicht archivieren, kein git.
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path, version="1.2.3/../../etc/passwd")
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert calls == [], "git lief trotz ungültiger Version"
+    assert not (tmp_path / "docs" / "release-history").exists(), "Archiv-Dir trotz ungültiger Version"
+
+
+def test_archive_newline_version_skips(tmp_path, monkeypatch):
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path, version="1.2.3\nmalicious")
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    _archive_release_notes(ctx)
+    assert calls == []
+
+
+def test_archive_push_error_stderr_is_sanitized(tmp_path, monkeypatch, caplog):
+    # HIGH-Fix: git-stderr mit Token/URL darf NICHT im Klartext geloggt werden.
+    import logging
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    leak = "remote: https://x-access-token:ghp_SECRET12345@github.com/o/r.git\nfatal: auth failed"
+    fake_run, _ = _git_responder(overrides={"push": (1, "", leak)})
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    with caplog.at_level(logging.WARNING, logger="shadowops"):
+        _archive_release_notes(ctx)
+
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "ghp_SECRET12345" not in msgs, "Token im Log geleakt!"
+    assert "x-access-token" not in msgs, "Auth-URL im Log geleakt!"
+    assert "github.com" not in msgs
+
+
+def test_archive_successful_push_logs_info(tmp_path, monkeypatch, caplog):
+    import logging
+    _seed_release_notes(tmp_path)
+    ctx = _archive_ctx(tmp_path)
+    fake_run, calls = _git_responder()
+    monkeypatch.setattr("patch_notes.stages.distribute.subprocess.run", fake_run)
+
+    with caplog.at_level(logging.INFO, logger="shadowops"):
+        _archive_release_notes(ctx)
+
+    assert _git_calls(calls, "push"), "Push fehlt im Happy-Path"
+    assert any("committed + gepusht" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Fixt #302.

## Problem
`_archive_release_notes()` (`stages/distribute.py`) archiviert `release_notes.md` → `docs/release-history/v<version>.md` + setzt das Template zurück, **committete/pushte diese Änderungen aber nie**. Der Deploy-Checkout (`/srv/leitstelle/app`) blieb dirty → der nächste Auto-Deploy-`git pull` brach mit „local changes would be overwritten" ab. Real aufgetreten beim mayday-sim-Deploy (PR #489 hing 25+ min).

## Fix
Drei module-level Helper, am Ende der Archivierung aufgerufen:
- **`_run_git_quiet(repo, args)`** — subprocess-git, wirft **nie** (best-effort, gibt `(ok, stdout, stderr)`).
- **`_sanitize_git_error(err)`** — redigiert Token/URL/SSH-Pfade aus git-stderr vor dem Logging.
- **`_commit_and_push_archive(...)`** — staget **exakt die zwei Archiv-Dateien** (nie `git add -A`), committet mit Bot-Identität via `git -c` (keine `.git/config`-Pollution), pusht best-effort.

**Guards:** git-Repo-Check · detached-HEAD · Idempotenz (`git diff --cached --quiet`) · Pfad-außerhalb-Repo · SemVer-Version-Validierung (Pfad-Traversal-/Newline-Schutz). Jede git-Störung wird geloggt und geschluckt — die Pipeline crasht nie (Defense-in-Depth). Direkter Push triggert **keinen** Auto-Deploy (Block in `event_handlers_mixin.py`).

## Entstehung (Multi-Agent)
1. **Understand+Design-Workflow** (3 parallele Explorer) — bestehende git-Helper, Test-Patterns, Edge-Cases → Implementierungsplan
2. **TDD** — Tests first, dann Implementierung
3. **Adversarialer Review** (3 Lenses: Korrektheit / Security / Test-Coverage) → Verdikt `fix_then_ship`; die 4 Must-Fixes (stderr-Sanitization, SemVer-Guard, Mutation-Coverage, fehlende Defensiv-Pfade) sind eingearbeitet. Die „critical" Race-Condition wurde nach Prüfung als false-positive verworfen (Push trifft Remote, lokaler Tree by-design clean, direct-push triggert keinen Deploy).

## Tests
18 neue Unit-Tests (TDD + Mutation-Coverage): nur-2-Dateien-stagen, kein `git add -A`, git-Fehler/Timeout/Exception ohne Crash, Nicht-Repo, detached HEAD, Idempotenz (beide Richtungen), `-c`-Identität, **stderr-Sanitization (Token bleibt aus Log)**, ungültige Version. **98/98** patch_notes-Tests grün, keine Regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)