### PR TITLE
feat(ops): Watchdog-Units-IaC sync-Skript (#294)

### DIFF
--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -63,6 +63,51 @@ Drei System-Selbstpflege-Watchdogs ergänzen die Service-Watchdogs um automatisc
 State-Files sind pro Service getrennt (`data/watchdog_state_<service>.json`),
 damit Failure-Counter und Alert-Status sich nicht beeinflussen.
 
+## Deklarative Aktivierung via `sync-watchdog-units.sh` (kanonisch, seit #294)
+
+**Empfohlener Weg, um Watchdog-Units zu aktivieren.** Statt jede Unit manuell
+zu verlinken und per `systemctl --user enable` einzeln zu aktivieren (siehe
+Abschnitt 3 — bleibt als Referenz/Fallback erhalten), spiegelt
+`scripts/sync-watchdog-units.sh` **alle** `deploy/*-watchdog.{service,timer}`
+idempotent als Symlinks ins user-systemd-Verzeichnis und aktiviert die Timer.
+Das macht die Aktivierung deklarativ (IaC) und erkennt Drift.
+
+```bash
+# 1. Vorschau — zeigt geplante Aktionen, ändert NICHTS (kein Symlink, kein systemctl)
+~/shadowops-bot/scripts/sync-watchdog-units.sh --dry-run
+
+# 2. Anwenden — Symlinks setzen/korrigieren + daemon-reload + Timer enable --now
+~/shadowops-bot/scripts/sync-watchdog-units.sh
+
+# 3. Drift-Check (z.B. für CI/Cron) — Exit 1, wenn Orphans existieren
+~/shadowops-bot/scripts/sync-watchdog-units.sh --strict --dry-run
+```
+
+**Eigenschaften:**
+- **Idempotent:** Korrekter Symlink → skip. Falscher/fehlender → neu setzen.
+  `daemon-reload` läuft nur bei tatsächlichen Änderungen.
+- **Orphan-Erkennung:** Units im Ziel-Verzeichnis, die auf
+  `*-watchdog.{service,timer}` matchen, aber kein Pendant in `deploy/` haben,
+  werden gemeldet (mit Hinweis ob reguläre Datei oder Symlink). Standard:
+  **nur Report, kein Löschen.**
+  - **Bekannter Orphan:** `audit-watchdog.{service,timer}` läuft live als
+    reguläre Datei in `~/.config/systemd/user/` OHNE deploy/-Pendant. Das Skript
+    meldet ihn als Orphan. (Folge-Entscheidung: entweder Units nach `deploy/`
+    übernehmen → in IaC aufnehmen, oder bewusst außerhalb belassen.)
+- **`--prune`:** Entfernt verwaiste **Symlinks** (niemals reguläre Dateien).
+- **`--prune --force`:** Entfernt zusätzlich verwaiste **reguläre Dateien**
+  (mit lautem Warnhinweis — vorsichtig nutzen).
+- **`--strict`:** Exit-Code 1 bei Orphans (für ein Drift-Gate in CI/Cron).
+- **Ziel-Verzeichnis** überschreibbar via `WATCHDOG_UNIT_DIR` (Default
+  `~/.config/systemd/user`) — wird in Tests auf ein tmp-Verzeichnis gesetzt.
+
+**Sicherheit:** Im `--dry-run` werden **keine** systemd-Calls ausgeführt; alle
+`systemctl --user`-Aufrufe tragen dann das `(dry-run)`-Präfix. Test-Coverage:
+`tests/unit/test_sync_watchdog_units.py`.
+
+> Webhook-Config (`~/.config/shadowops-watchdog.env`) wird vom Skript **nicht**
+> angefasst — die muss wie unten beschrieben einmalig angelegt werden.
+
 ## Erst-Einrichtung (einmalig)
 
 ### 1. Discord-Webhook erstellen
@@ -94,7 +139,12 @@ nano ~/.config/shadowops-watchdog.env
 chmod 600 ~/.config/shadowops-watchdog.env
 ```
 
-### 3. systemd-Reload
+### 3. systemd-Reload (manuell — Referenz/Fallback)
+
+> **Hinweis:** Der kanonische Weg ist `sync-watchdog-units.sh` (siehe Abschnitt
+> "Deklarative Aktivierung" oben). Die folgende manuelle Liste bleibt als
+> Referenz/Fallback erhalten — sie muss bei jeder neuen Unit von Hand gepflegt
+> werden, das Skript erledigt das automatisch.
 
 ```bash
 systemctl --user daemon-reload

--- a/scripts/sync-watchdog-units.sh
+++ b/scripts/sync-watchdog-units.sh
@@ -30,6 +30,13 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DEPLOY_DIR="${REPO_ROOT}/deploy"
 UNIT_DIR="${WATCHDOG_UNIT_DIR:-${HOME}/.config/systemd/user}"
 
+# Safety-Guard: ein leeres oder "/"-UNIT_DIR würde den prune-rm in einem
+# gefährlichen Verzeichnis laufen lassen → hart abbrechen.
+if [[ -z "${UNIT_DIR}" || "${UNIT_DIR}" == "/" ]]; then
+    echo "FEHLER: UNIT_DIR ungültig (leer oder /)" >&2
+    exit 1
+fi
+
 # ---------- Flags ----------
 DRY_RUN=0
 PRUNE=0
@@ -65,6 +72,11 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+# --force wirkt nur zusammen mit --prune (entfernt verwaiste reguläre Dateien).
+if [[ "${FORCE}" -eq 1 && "${PRUNE}" -eq 0 ]]; then
+    echo "[sync-watchdog] WARN: --force ohne --prune hat keine Wirkung"
+fi
 
 # ---------- Logging-Helper ----------
 log()    { echo "[sync-watchdog] $*"; }
@@ -154,24 +166,25 @@ for unit in "${SOURCE_UNITS[@]}"; do
             ln -sfn "${src}" "${dst}"
         fi
         SYNCED=$((SYNCED + 1)); CHANGED=1
+        [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
     elif [[ -e "${dst}" ]]; then
-        # Reguläre Datei am Ziel-Pfad — NICHT blind überschreiben.
+        # Reguläre Datei am Ziel-Pfad — NICHT blind überschreiben UND NICHT
+        # aktivieren (würde eine Out-of-IaC-Unit ge-enabled → kein Timer-Append).
         log "WARN: ${unit} existiert als REGULÄRE Datei im Ziel — wird NICHT durch Symlink ersetzt."
         log "      → Manuell prüfen/entfernen, dann erneut syncen. (Datei: ${dst})"
         SKIPPED=$((SKIPPED + 1))
-        [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
     else
         action "Symlink anlegen:    ${unit} → ${src}"
         if [[ "${DRY_RUN}" -eq 0 ]]; then
             ln -sfn "${src}" "${dst}"
         fi
         SYNCED=$((SYNCED + 1)); CHANGED=1
+        [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
     fi
-
-    [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
 done
 
-# Doppelte Timer-Einträge (skip+append) deduplizieren.
+# Doppelte Timer-Einträge defensiv deduplizieren (sollte nach dem Fix nicht mehr
+# vorkommen, schadet aber nicht).
 if [[ "${#SYNCED_TIMERS[@]}" -gt 0 ]]; then
     mapfile -t SYNCED_TIMERS < <(printf '%s\n' "${SYNCED_TIMERS[@]}" | sort -u)
 fi

--- a/scripts/sync-watchdog-units.sh
+++ b/scripts/sync-watchdog-units.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+#
+# sync-watchdog-units.sh — IaC-Sync für user-systemd Watchdog-Units (#294)
+#
+# Spiegelt die Watchdog-Unit-Dateien aus `deploy/*-watchdog.{service,timer}`
+# als Symlinks in das user-systemd-Verzeichnis (Default ~/.config/systemd/user).
+# Damit ist die Aktivierung der Watchdogs deklarativ statt manueller
+# `ln -s` + `systemctl --user enable`-Sequenzen → kein Drift mehr.
+#
+# Eigenschaften:
+#   - Idempotent: korrekter Symlink → skip, falscher/fehlender → neu setzen.
+#   - Orphan-Erkennung: Units im Ziel ohne Pendant in deploy/ werden gemeldet
+#     (Hinweis ob reguläre Datei oder Symlink). Standard: nur Report.
+#   - --dry-run zeigt alle geplanten Aktionen, ändert NICHTS.
+#   - --prune entfernt verwaiste SYMLINKS (niemals reguläre Dateien).
+#   - --prune --force entfernt zusätzlich verwaiste REGULÄRE Dateien (laut!).
+#   - --strict: Exit 1 wenn Orphans gefunden (für CI/Drift-Gate).
+#
+# Nach Symlink-Änderungen (außer --dry-run): `systemctl --user daemon-reload`
+# + pro Timer `enable --now`.
+#
+# Anlass: audit-watchdog.{service,timer} läuft live als reguläre Datei im
+# user-Verzeichnis OHNE deploy/-Pendant → Orphan außerhalb der IaC.
+#
+set -euo pipefail
+
+# ---------- Pfade ----------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOY_DIR="${REPO_ROOT}/deploy"
+UNIT_DIR="${WATCHDOG_UNIT_DIR:-${HOME}/.config/systemd/user}"
+
+# ---------- Flags ----------
+DRY_RUN=0
+PRUNE=0
+FORCE=0
+STRICT=0
+
+usage() {
+    cat <<'EOF'
+sync-watchdog-units.sh — IaC-Sync für Watchdog-Units (#294)
+
+Usage: sync-watchdog-units.sh [OPTIONS]
+
+Options:
+  --dry-run   Zeigt geplante Aktionen, ändert nichts (kein Symlink, kein systemctl).
+  --prune     Entfernt verwaiste Watchdog-SYMLINKS im Ziel-Verzeichnis.
+  --force     Nur mit --prune: entfernt auch verwaiste REGULÄRE Dateien (laut!).
+  --strict    Exit-Code 1 wenn Orphans gefunden (für CI/Drift-Gate).
+  -h, --help  Diese Hilfe.
+
+Env:
+  WATCHDOG_UNIT_DIR   Ziel-Verzeichnis (Default: ~/.config/systemd/user).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        --prune)   PRUNE=1 ;;
+        --force)   FORCE=1 ;;
+        --strict)  STRICT=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unbekannte Option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# ---------- Logging-Helper ----------
+log()    { echo "[sync-watchdog] $*"; }
+action() {
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        echo "[sync-watchdog] (dry-run) $*"
+    else
+        echo "[sync-watchdog] $*"
+    fi
+}
+
+# ---------- systemctl-Gate (im Dry-Run übersprungen, in Tests neutralisierbar) ----------
+# Alle systemd-Mutationen laufen NUR über diese Funktion. Im Dry-Run wird sie
+# zum reinen Echo. Tests setzen WATCHDOG_UNIT_DIR auf tmp + nutzen --dry-run,
+# damit niemals echtes systemd berührt wird.
+run_systemctl() {
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        action "würde ausführen: systemctl --user $*"
+        return 0
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        log "WARN: systemctl nicht gefunden — überspringe '$*'"
+        return 0
+    fi
+    systemctl --user "$@"
+}
+
+# ---------- Vorbedingungen ----------
+if [[ ! -d "${DEPLOY_DIR}" ]]; then
+    echo "FEHLER: deploy/-Verzeichnis nicht gefunden: ${DEPLOY_DIR}" >&2
+    exit 1
+fi
+
+log "Repo-Root:   ${REPO_ROOT}"
+log "Deploy-Dir:  ${DEPLOY_DIR}"
+log "Ziel-Dir:    ${UNIT_DIR}"
+[[ "${DRY_RUN}" -eq 1 ]] && log "Modus:       DRY-RUN (keine Änderungen)"
+if [[ "${PRUNE}" -eq 1 ]]; then
+    if [[ "${FORCE}" -eq 1 ]]; then
+        log "Prune:       aktiv (Symlinks + reguläre Dateien via --force)"
+    else
+        log "Prune:       aktiv (nur Symlinks)"
+    fi
+fi
+[[ "${STRICT}"  -eq 1 ]] && log "Strict:      aktiv (Exit 1 bei Orphans)"
+
+# Ziel-Verzeichnis sicherstellen (außer dry-run).
+if [[ ! -d "${UNIT_DIR}" ]]; then
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        action "würde Verzeichnis anlegen: ${UNIT_DIR}"
+    else
+        mkdir -p "${UNIT_DIR}"
+    fi
+fi
+
+# ---------- Quell-Units einsammeln ----------
+declare -a SOURCE_UNITS=()
+shopt -s nullglob
+for f in "${DEPLOY_DIR}"/*-watchdog.service "${DEPLOY_DIR}"/*-watchdog.timer; do
+    SOURCE_UNITS+=("$(basename "$f")")
+done
+shopt -u nullglob
+
+if [[ "${#SOURCE_UNITS[@]}" -eq 0 ]]; then
+    log "WARN: keine Watchdog-Units in ${DEPLOY_DIR} gefunden."
+fi
+
+# ---------- Sync: Symlinks setzen ----------
+SYNCED=0
+SKIPPED=0
+CHANGED=0   # ob daemon-reload nötig
+declare -a SYNCED_TIMERS=()
+
+for unit in "${SOURCE_UNITS[@]}"; do
+    src="${DEPLOY_DIR}/${unit}"
+    dst="${UNIT_DIR}/${unit}"
+
+    if [[ -L "${dst}" ]]; then
+        current="$(readlink "${dst}")"
+        if [[ "${current}" == "${src}" ]]; then
+            SKIPPED=$((SKIPPED + 1))
+            [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
+            continue
+        fi
+        action "Symlink korrigieren: ${unit} (war → ${current})"
+        if [[ "${DRY_RUN}" -eq 0 ]]; then
+            ln -sfn "${src}" "${dst}"
+        fi
+        SYNCED=$((SYNCED + 1)); CHANGED=1
+    elif [[ -e "${dst}" ]]; then
+        # Reguläre Datei am Ziel-Pfad — NICHT blind überschreiben.
+        log "WARN: ${unit} existiert als REGULÄRE Datei im Ziel — wird NICHT durch Symlink ersetzt."
+        log "      → Manuell prüfen/entfernen, dann erneut syncen. (Datei: ${dst})"
+        SKIPPED=$((SKIPPED + 1))
+        [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
+    else
+        action "Symlink anlegen:    ${unit} → ${src}"
+        if [[ "${DRY_RUN}" -eq 0 ]]; then
+            ln -sfn "${src}" "${dst}"
+        fi
+        SYNCED=$((SYNCED + 1)); CHANGED=1
+    fi
+
+    [[ "${unit}" == *.timer ]] && SYNCED_TIMERS+=("${unit}")
+done
+
+# Doppelte Timer-Einträge (skip+append) deduplizieren.
+if [[ "${#SYNCED_TIMERS[@]}" -gt 0 ]]; then
+    mapfile -t SYNCED_TIMERS < <(printf '%s\n' "${SYNCED_TIMERS[@]}" | sort -u)
+fi
+
+# ---------- Orphan-Erkennung ----------
+# Units im Ziel, die auf *-watchdog.{service,timer} matchen, aber kein
+# Pendant in deploy/ haben.
+declare -a ORPHANS=()
+shopt -s nullglob
+for dst in "${UNIT_DIR}"/*-watchdog.service "${UNIT_DIR}"/*-watchdog.timer; do
+    unit="$(basename "${dst}")"
+    if [[ ! -e "${DEPLOY_DIR}/${unit}" ]]; then
+        ORPHANS+=("${unit}")
+    fi
+done
+shopt -u nullglob
+
+ORPHAN_COUNT="${#ORPHANS[@]}"
+PRUNED=0
+
+if [[ "${ORPHAN_COUNT}" -gt 0 ]]; then
+    log "----- ORPHANS (kein Pendant in deploy/) -----"
+    for unit in "${ORPHANS[@]}"; do
+        dst="${UNIT_DIR}/${unit}"
+        if [[ -L "${dst}" ]]; then
+            kind="Symlink → $(readlink "${dst}")"
+        else
+            kind="REGULÄRE Datei"
+        fi
+        log "ORPHAN: ${unit}  [${kind}]"
+
+        if [[ "${PRUNE}" -eq 1 ]]; then
+            if [[ -L "${dst}" ]]; then
+                action "prune Symlink:    ${unit}"
+                if [[ "${DRY_RUN}" -eq 0 ]]; then
+                    rm -f "${dst}"
+                fi
+                PRUNED=$((PRUNED + 1)); CHANGED=1
+            elif [[ "${FORCE}" -eq 1 ]]; then
+                log "WARN: !!! Entferne verwaiste REGULÄRE Datei (--prune --force): ${unit} !!!"
+                action "prune Datei:      ${unit}"
+                if [[ "${DRY_RUN}" -eq 0 ]]; then
+                    rm -f "${dst}"
+                fi
+                PRUNED=$((PRUNED + 1)); CHANGED=1
+            else
+                log "      → reguläre Datei NICHT entfernt (benötigt --prune --force)."
+            fi
+        fi
+    done
+fi
+
+# ---------- systemd aktivieren ----------
+if [[ "${CHANGED}" -eq 1 ]]; then
+    run_systemctl daemon-reload
+    for timer in "${SYNCED_TIMERS[@]}"; do
+        run_systemctl enable --now "${timer}"
+    done
+else
+    log "Keine Symlink-Änderungen → kein daemon-reload nötig."
+fi
+
+# ---------- Zusammenfassung ----------
+log "================ Zusammenfassung ================"
+log "Quell-Units:   ${#SOURCE_UNITS[@]}"
+log "Synced:        ${SYNCED}"
+log "Skipped:       ${SKIPPED}"
+log "Orphans:       ${ORPHAN_COUNT}"
+[[ "${PRUNE}" -eq 1 ]] && log "Pruned:        ${PRUNED}"
+log "================================================="
+
+# ---------- Exit-Code ----------
+if [[ "${STRICT}" -eq 1 && "${ORPHAN_COUNT}" -gt 0 ]]; then
+    log "STRICT-Modus: Orphans gefunden → Exit 1"
+    exit 1
+fi
+exit 0

--- a/tests/unit/test_sync_watchdog_units.py
+++ b/tests/unit/test_sync_watchdog_units.py
@@ -277,3 +277,68 @@ def test_regular_file_at_managed_path_not_overwritten(script_exists, tmp_path):
     assert "existiert als REGULÄRE Datei im Ziel" in result.stdout
     # Datei bleibt unverändert.
     assert (unit_dir / name).read_text().endswith("# handgepflegt\n")
+
+
+def test_regular_file_unit_not_enabled_while_others_are(script_exists, tmp_path):
+    """B1-Regression: eine als reguläre Datei vorliegende GEMANAGTE Timer-Unit
+    darf NICHT ge-enabled werden, während frisch verlinkte Timer es werden.
+
+    Setup: alle deploy-Timer werden frisch verlinkt (CHANGED=1). Genau EIN
+    deploy-Timer liegt aber als reguläre Datei im Ziel → dieser geht in den
+    'reguläre Datei'-Zweig und darf nie in SYNCED_TIMERS landen.
+    """
+    timers = sorted(p.name for p in DEPLOY_DIR.glob("*-watchdog.timer"))
+    assert len(timers) >= 2, "Test braucht mind. 2 deploy-Timer"
+    shadowed = timers[0]   # liegt als reguläre Datei vor → darf NICHT enabled werden
+    other = timers[1]      # wird frisch verlinkt → MUSS enabled werden
+
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / shadowed).write_text("[Timer]\n# handgepflegt, außerhalb der IaC\n")
+
+    result = _run(unit_dir, "--dry-run")
+    assert result.returncode == 0, result.stdout + result.stderr
+    # Positiv: ein regulär verlinkter Timer wird aktiviert.
+    assert f"systemctl --user enable --now {other}" in result.stdout
+    # Negativ (Kern der Regression): der reguläre-Datei-Timer wird NIE aktiviert.
+    assert f"enable --now {shadowed}" not in result.stdout
+
+
+def test_prune_force_real_run_deletes_regular_file(script_exists, tmp_path):
+    """B2-Regression: echter --prune --force-Lauf löscht die verwaiste reguläre
+    Datei — und NUR diese, keine unbeteiligten Dateien.
+
+    systemctl via PATH-Shim neutralisiert (echtes systemd wird nie berührt).
+    """
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    (shim / "systemctl").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (shim / "systemctl").chmod(0o755)
+
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    # Verwaiste reguläre Datei (matcht *-watchdog.timer, kein deploy-Pendant).
+    orphan_file = unit_dir / "foo-watchdog.timer"
+    orphan_file.write_text("[Timer]\n")
+    # Unbeteiligte Datei (matcht das Orphan-Glob NICHT) → muss überleben.
+    bystander = unit_dir / "keepme.txt"
+    bystander.write_text("nicht anfassen\n")
+
+    env = {
+        **os.environ,
+        "WATCHDOG_UNIT_DIR": str(unit_dir),
+        "PATH": f"{shim}:{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--prune", "--force"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not orphan_file.exists(), (
+        "verwaiste reguläre Datei hätte mit --prune --force gelöscht werden müssen"
+    )
+    assert bystander.exists(), "unbeteiligte Datei darf NICHT gelöscht werden"
+    assert bystander.read_text() == "nicht anfassen\n"

--- a/tests/unit/test_sync_watchdog_units.py
+++ b/tests/unit/test_sync_watchdog_units.py
@@ -1,0 +1,279 @@
+"""
+Tests für scripts/sync-watchdog-units.sh — IaC-Sync für Watchdog-Units (#294).
+
+Das Skript spiegelt `deploy/*-watchdog.{service,timer}` als Symlinks ins
+user-systemd-Verzeichnis. Diese Tests laufen das Skript als subprocess gegen
+TEMP-Verzeichnisse (WATCHDOG_UNIT_DIR auf tmp_path) und nutzen ausschließlich
+--dry-run für systemd-berührende Pfade, damit NIEMALS echtes systemd oder das
+reale ~/.config/systemd/user angefasst wird.
+
+Stil-Vorbild: tests/unit/test_service_watchdog_jq_filter.py (subprocess gegen
+Shell-Skript, Assertions auf Exit-Code + stdout).
+"""
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sync-watchdog-units.sh"
+DEPLOY_DIR = REPO_ROOT / "deploy"
+
+
+def _run(unit_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run sync-watchdog-units.sh mit isoliertem Ziel-Verzeichnis."""
+    env = {**os.environ, "WATCHDOG_UNIT_DIR": str(unit_dir)}
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _real_unit_name() -> str:
+    """Liefert den Namen einer echten Watchdog-Timer-Unit aus deploy/."""
+    timers = sorted(DEPLOY_DIR.glob("*-watchdog.timer"))
+    assert timers, "keine *-watchdog.timer in deploy/ gefunden"
+    return timers[0].name
+
+
+# ---------- Fixtures ----------
+
+@pytest.fixture(scope="module")
+def script_exists():
+    assert SCRIPT.exists(), f"sync-watchdog-units.sh nicht gefunden: {SCRIPT}"
+    assert shutil.which("bash"), "bash nicht installiert"
+    # Syntax-Check schützt vor kaputtem Skript in den restlichen Tests.
+    proc = subprocess.run(
+        ["bash", "-n", str(SCRIPT)], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+# ---------- Tests ----------
+
+def test_help_exits_zero(script_exists, tmp_path):
+    """--help gibt Usage aus und exit 0."""
+    result = _run(tmp_path, "--help")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Usage:" in result.stdout
+
+
+def test_dry_run_plans_symlinks_without_touching_fs(script_exists, tmp_path):
+    """Dry-Run gegen leeres Ziel: plant Symlinks, legt aber NICHTS an."""
+    result = _run(tmp_path, "--dry-run")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "DRY-RUN" in result.stdout
+    assert "Symlink anlegen" in result.stdout
+    # systemctl darf nur als geplante (dry-run) Aktion erscheinen, nie real.
+    assert "würde ausführen: systemctl --user daemon-reload" in result.stdout
+    # FS bleibt leer.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_dry_run_does_not_emit_real_systemctl_marker(script_exists, tmp_path):
+    """Im Dry-Run trägt JEDE Aktion das (dry-run)-Präfix (Gate greift)."""
+    result = _run(tmp_path, "--dry-run")
+    # Es darf keine systemctl-Zeile OHNE (dry-run)-Marker geben.
+    for line in result.stdout.splitlines():
+        if "systemctl --user" in line:
+            assert "(dry-run)" in line, f"echtes systemctl im Dry-Run: {line}"
+
+
+def test_real_run_creates_symlinks(script_exists, tmp_path):
+    """Echt-Run legt Symlinks an, die auf die deploy/-Dateien zeigen.
+
+    systemctl wird über einen PATH-Shim neutralisiert (exit 0), damit kein
+    echtes user-systemd berührt wird — das Skript ruft NUR `systemctl`.
+    """
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    (shim / "systemctl").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (shim / "systemctl").chmod(0o755)
+
+    unit_dir = tmp_path / "units"
+    env = {
+        **os.environ,
+        "WATCHDOG_UNIT_DIR": str(unit_dir),
+        "PATH": f"{shim}:{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    name = _real_unit_name()
+    link = unit_dir / name
+    assert link.is_symlink(), f"{name} sollte ein Symlink sein"
+    assert link.resolve() == (DEPLOY_DIR / name).resolve()
+    # Alle deploy-Units gespiegelt.
+    deploy_units = {p.name for p in DEPLOY_DIR.glob("*-watchdog.service")}
+    deploy_units |= {p.name for p in DEPLOY_DIR.glob("*-watchdog.timer")}
+    target_units = {p.name for p in unit_dir.iterdir()}
+    assert deploy_units == target_units
+
+
+def test_idempotent_second_run_skips(script_exists, tmp_path):
+    """Zweiter Lauf gegen bereits korrekt verlinktes Ziel → alles skipped."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    # Korrekte Symlinks vorab anlegen (simuliert vorherigen erfolgreichen Sync).
+    for src in list(DEPLOY_DIR.glob("*-watchdog.service")) + list(
+        DEPLOY_DIR.glob("*-watchdog.timer")
+    ):
+        (unit_dir / src.name).symlink_to(src)
+
+    result = _run(unit_dir, "--dry-run")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Synced:        0" in result.stdout
+    assert "Keine Symlink-Änderungen" in result.stdout
+    assert "Symlink anlegen" not in result.stdout
+
+
+def test_wrong_symlink_gets_corrected(script_exists, tmp_path):
+    """Falsch zeigender Symlink → wird als Korrektur geplant."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    name = _real_unit_name()
+    (unit_dir / name).symlink_to("/nonexistent/wrong-target")
+
+    result = _run(unit_dir, "--dry-run")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Symlink korrigieren" in result.stdout
+
+
+def test_orphan_regular_file_detected(script_exists, tmp_path):
+    """Reguläre Datei im Ziel ohne deploy-Pendant → als ORPHAN gemeldet."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / "audit-watchdog.service").write_text("[Unit]\n")
+    (unit_dir / "audit-watchdog.timer").write_text("[Timer]\n")
+
+    result = _run(unit_dir, "--dry-run")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ORPHAN: audit-watchdog.service" in result.stdout
+    assert "ORPHAN: audit-watchdog.timer" in result.stdout
+    assert "REGULÄRE Datei" in result.stdout
+    assert "Orphans:       2" in result.stdout
+
+
+def test_orphan_symlink_detected_with_kind(script_exists, tmp_path):
+    """Verwaister Symlink → als ORPHAN mit Symlink-Hinweis gemeldet."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / "foo-watchdog.timer").symlink_to("/nonexistent/foo-watchdog.timer")
+
+    result = _run(unit_dir, "--dry-run")
+    assert "ORPHAN: foo-watchdog.timer" in result.stdout
+    assert "Symlink" in result.stdout
+
+
+def test_strict_exits_nonzero_on_orphan(script_exists, tmp_path):
+    """--strict → Exit 1 wenn Orphans gefunden (für CI/Drift-Gate)."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / "audit-watchdog.timer").write_text("[Timer]\n")
+
+    result = _run(unit_dir, "--dry-run", "--strict")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "STRICT-Modus: Orphans gefunden" in result.stdout
+
+
+def test_strict_without_orphan_exits_zero(script_exists, tmp_path):
+    """--strict ohne Orphans → Exit 0."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    for src in list(DEPLOY_DIR.glob("*-watchdog.service")) + list(
+        DEPLOY_DIR.glob("*-watchdog.timer")
+    ):
+        (unit_dir / src.name).symlink_to(src)
+
+    result = _run(unit_dir, "--dry-run", "--strict")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_prune_removes_orphan_symlink_only(script_exists, tmp_path):
+    """--prune entfernt verwaisten Symlink, lässt reguläre Datei stehen."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / "foo-watchdog.timer").symlink_to("/nonexistent/foo-watchdog.timer")
+    (unit_dir / "audit-watchdog.timer").write_text("[Timer]\n")
+
+    result = _run(unit_dir, "--dry-run", "--prune")
+    assert result.returncode == 0, result.stdout + result.stderr
+    # Symlink wird zum Prune geplant …
+    assert "prune Symlink:    foo-watchdog.timer" in result.stdout
+    # … reguläre Datei NICHT (braucht --force).
+    assert "reguläre Datei NICHT entfernt" in result.stdout
+    assert "Prune:       aktiv (nur Symlinks)" in result.stdout
+
+
+def test_prune_real_run_deletes_symlink_keeps_regular(script_exists, tmp_path):
+    """Echter --prune-Lauf: Symlink weg, reguläre Datei bleibt.
+
+    systemctl via PATH-Shim neutralisiert.
+    """
+    shim = tmp_path / "shim"
+    shim.mkdir()
+    (shim / "systemctl").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (shim / "systemctl").chmod(0o755)
+
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    orphan_link = unit_dir / "foo-watchdog.timer"
+    orphan_link.symlink_to("/nonexistent/foo-watchdog.timer")
+    orphan_file = unit_dir / "audit-watchdog.timer"
+    orphan_file.write_text("[Timer]\n")
+
+    env = {
+        **os.environ,
+        "WATCHDOG_UNIT_DIR": str(unit_dir),
+        "PATH": f"{shim}:{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT), "--prune"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not orphan_link.exists() and not orphan_link.is_symlink(), (
+        "verwaister Symlink hätte entfernt werden müssen"
+    )
+    assert orphan_file.exists(), "reguläre Datei darf ohne --force NICHT gelöscht werden"
+
+
+def test_prune_force_plans_regular_file_removal(script_exists, tmp_path):
+    """--prune --force plant auch Entfernung verwaister regulärer Dateien (laut)."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / "audit-watchdog.timer").write_text("[Timer]\n")
+
+    result = _run(unit_dir, "--dry-run", "--prune", "--force")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Entferne verwaiste REGULÄRE Datei" in result.stdout
+    assert "prune Datei:      audit-watchdog.timer" in result.stdout
+
+
+def test_regular_file_at_managed_path_not_overwritten(script_exists, tmp_path):
+    """Reguläre Datei am Pfad einer GEMANAGTEN Unit → nicht durch Symlink ersetzt."""
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    name = _real_unit_name()  # Name existiert in deploy/ → ist KEIN Orphan
+    (unit_dir / name).write_text("[Timer]\n# handgepflegt\n")
+
+    result = _run(unit_dir, "--dry-run")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "existiert als REGULÄRE Datei im Ziel" in result.stdout
+    # Datei bleibt unverändert.
+    assert (unit_dir / name).read_text().endswith("# handgepflegt\n")


### PR DESCRIPTION
## Was

`scripts/sync-watchdog-units.sh` — idempotentes IaC-Sync-Skript, das alle
`deploy/*-watchdog.{service,timer}` als Symlinks ins user-systemd-Verzeichnis
spiegelt (Default `~/.config/systemd/user`, überschreibbar via `WATCHDOG_UNIT_DIR`).
Ersetzt die manuelle `ln -s` + `systemctl --user enable`-Liste aus
`MONITORING_SETUP.md` durch einen deklarativen, drift-erkennenden Lauf.

## Warum

Die 14 Watchdog-Unit-Paare werden aktuell manuell verlinkt+aktiviert → Drift-anfällig.
Konkreter Drift existiert bereits: **`audit-watchdog.{service,timer}` läuft live als
reguläre Datei in `~/.config/systemd/user/` OHNE Pendant in `deploy/`** — also außerhalb
der IaC. Genau solche Orphans meldet das Skript jetzt.

## Verhalten

- **Idempotent:** korrekter Symlink → skip; falscher/fehlender → neu setzen.
  `daemon-reload` + `enable --now` nur bei tatsächlichen Änderungen.
- **Orphan-Erkennung:** Units im Ziel ohne deploy/-Pendant werden gemeldet
  (mit Hinweis ob reguläre Datei oder Symlink). Standard: **nur Report**.
- **`--dry-run`:** zeigt alle geplanten Aktionen, ändert NICHTS — alle
  `systemctl`-Calls tragen das `(dry-run)`-Präfix (gated, kein echtes systemd).
- **`--prune`:** entfernt verwaiste **Symlinks** (niemals reguläre Dateien).
- **`--prune --force`:** entfernt zusätzlich verwaiste reguläre Dateien (lauter Warnhinweis).
- **`--strict`:** Exit 1 bei Orphans → nutzbar als Drift-Gate in CI/Cron.
- Robust gegen Aufruf aus beliebigem CWD (`BASH_SOURCE`-basierter Repo-Root).

## Tests

`tests/unit/test_sync_watchdog_units.py` — 14 Tests, alle als subprocess gegen
**tmp-Verzeichnisse** (`WATCHDOG_UNIT_DIR=tmp_path`) + `--dry-run`/PATH-Shim,
sodass NIEMALS echtes systemd oder das reale user-Verzeichnis berührt wird.

```
14 passed
```

## Doku

`deploy/MONITORING_SETUP.md`: neue Sektion „Deklarative Aktivierung" als
kanonischer Weg; die manuelle `systemctl`-Liste bleibt als Referenz/Fallback markiert.

## Nicht angefasst / offen

`service-watchdog.sh`, `bot-watchdog.sh`, `config.yaml`/`.env` unberührt.
Der **Live-Sync gegen das echte `~/.config/systemd/user`** ist bewusst NICHT
ausgeführt — das ist ein Cross-User-/systemd-Schritt für den Lead.

Closes #294