### PR TITLE
chore(monitoring): phase_5e Health-Aggregator → 🤖-bot-status

### DIFF
--- a/src/cogs/phase_5e_health_aggregator.py
+++ b/src/cogs/phase_5e_health_aggregator.py
@@ -70,7 +70,7 @@ TREND_REPORT_HOUR = 9  # 09:00 lokal
 DB_PATH = Path(__file__).resolve().parents[2] / "data" / "health_history.db"
 RETENTION_DAYS = 90
 
-DASHBOARD_CHANNEL_ID = 1479615549356114124  # 📊-dashboard
+DASHBOARD_CHANNEL_ID = 1441655486981214309  # 🤖-bot-status (verschoben aus 📊-dashboard 2026-06-12 — dort nur noch Budget + project_monitor-Dashboard)
 CRITICAL_CHANNEL_ID = 1441655480840617994   # 🚨-critical
 
 # STATUS_COLOR / STATUS_EMOJI sind ab jetzt Single-Source in


### PR DESCRIPTION
## Was
`phase_5e_health_aggregator` postet sein 5-Min-Health-Embed + den täglichen Trend-Report (Runner-VM, ZERODOX prod/dev) ab jetzt in **🤖-bot-status** statt **📊-dashboard**.

## Warum
📊-dashboard soll nur noch das **project_monitor**-Projekt-Dashboard + ein neues **Claude-Budget**-Embed zeigen. Die Health-/Trend-Reports passen thematisch nach 🤖-bot-status ("Health-Checks und System-Status").

## Scope
- Nur `DASHBOARD_CHANNEL_ID` (1479615549356114124 → 1441655486981214309).
- 🚨-critical Drift-/Recovery-Alerts **unverändert**.
- phase_5e persistiert keine Message-ID auf Platte → erstellt im neuen Channel nach Restart automatisch neu.

## Nach Merge/Deploy
Alt-Embeds in 📊-dashboard werden manuell aufgeräumt (Keeper: project-dashboard `1513195749414797384` + Budget-Embed).