### PR TITLE
fix(deploy): externer Deploy-Post erreicht Kunden-Channel (dash/underscore)

### DIFF
--- a/src/integrations/deployment_manager.py
+++ b/src/integrations/deployment_manager.py
@@ -904,7 +904,21 @@ class DeploymentManager:
     async def _forward_deploy_to_external(self, project_name: str, embed: discord.Embed):
         """Deployment-Embed an externe Guilds weiterleiten (Kunden-Discord)."""
         try:
-            project_config = self.bot.config.projects.get(project_name, {})
+            # GitHub-Repo-Namen nutzen Bindestriche ("mayday-sim"), Config-Keys oft
+            # Underscores ("mayday_sim"). Gleicher dash/underscore-Fallback wie in
+            # deploy_project/_trigger_deployment — sonst bleibt external_notifications
+            # leer und der Kunden-Deploy-Post wird nie gesendet (Issue #504, gleicher
+            # Bug-Typ wie Vorfall 2026-05-25 PR #449/#450).
+            projects = self.bot.config.projects
+            project_config = None
+            normalized_name = project_name.lower().replace("-", "_")
+            for key in projects.keys():
+                key_lower = key.lower()
+                if key_lower == project_name.lower() or key_lower.replace("-", "_") == normalized_name:
+                    project_config = projects[key]
+                    break
+            if not project_config:
+                return
             notifications = project_config.get('external_notifications', [])
 
             for notif in notifications:

--- a/tests/unit/test_deployment_external_forward.py
+++ b/tests/unit/test_deployment_external_forward.py
@@ -1,0 +1,86 @@
+"""Tests für _forward_deploy_to_external (Issue #504).
+
+Der Deploy-Post an den externen Kunden-Channel (`🚀-deploy-log`) blieb aus,
+weil `_forward_deploy_to_external` den rohen GitHub-Repo-Namen ("mayday-sim",
+Bindestrich) direkt für `config.projects.get(...)` nutzte — der Config-Key ist
+aber "mayday_sim" (Underscore). Ergebnis: leere `external_notifications`, kein
+Post. `deploy_project`/`_trigger_deployment` normalisieren bereits; diese
+Funktion wurde übersehen (gleicher Bug-Typ wie Vorfall 2026-05-25, PR #449/#450).
+"""
+from __future__ import annotations
+
+import discord
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.integrations.deployment_manager import DeploymentManager
+
+
+def _mgr_with_external(projects: dict):
+    """DeploymentManager-Stub mit gemocktem externen Channel + roher config.projects."""
+    mgr = DeploymentManager.__new__(DeploymentManager)
+    mgr.logger = MagicMock()
+    ext_channel = MagicMock()
+    ext_channel.send = AsyncMock()
+    mgr.bot = MagicMock()
+    mgr.bot.get_channel = MagicMock(return_value=ext_channel)
+    mgr.bot.config = MagicMock()
+    mgr.bot.config.projects = projects
+    return mgr, ext_channel
+
+
+def _deploy_embed():
+    embed = discord.Embed(
+        title="✅ Deployment erfolgreich: mayday-sim", description="alle Schritte ok"
+    )
+    embed.add_field(name="Projekt", value="`mayday-sim`", inline=True)
+    embed.add_field(name="Branch", value="`main`", inline=True)
+    embed.add_field(name="Dauer", value="42.0s", inline=True)
+    return embed
+
+
+def _mayday_projects():
+    return {
+        "mayday_sim": {
+            "external_notifications": [
+                {
+                    "enabled": True,
+                    "notify_on": {"deployments": True},
+                    "deploy_channel_id": 1486899717362421840,
+                }
+            ]
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_forward_resolves_dashed_repo_name_to_underscore_config_key():
+    """Repo 'mayday-sim' (Bindestrich) muss Config-Key 'mayday_sim' (Underscore) treffen."""
+    mgr, ext_channel = _mgr_with_external(_mayday_projects())
+
+    await mgr._forward_deploy_to_external("mayday-sim", _deploy_embed())
+
+    # Vor dem Fix: config.projects.get("mayday-sim") → {} → kein Versand.
+    ext_channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forward_exact_config_key_still_posts():
+    """Regressionsschutz: exakter Key-Match (Underscore == Underscore) postet weiterhin."""
+    mgr, ext_channel = _mgr_with_external(_mayday_projects())
+
+    await mgr._forward_deploy_to_external("mayday_sim", _deploy_embed())
+
+    ext_channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forward_skips_when_deployments_flag_off():
+    """notify_on.deployments=False → kein Post, auch bei korrekt aufgelöstem Projekt."""
+    projects = _mayday_projects()
+    projects["mayday_sim"]["external_notifications"][0]["notify_on"]["deployments"] = False
+    mgr, ext_channel = _mgr_with_external(projects)
+
+    await mgr._forward_deploy_to_external("mayday-sim", _deploy_embed())
+
+    ext_channel.send.assert_not_called()


### PR DESCRIPTION
## Problem

Der Deploy-Post im `#🚀-deploy-log` des **mayday-sim Kunden-Discords** (Channel-ID `1486899717362421840`) kam **nie** an — der Channel war komplett leer. Aufgenommen als [mayday-sim#504](https://github.com/Commandershadow9/mayday-sim/issues/504) nach Deploy-Verifikation von PR #503.

## Root Cause

`DeploymentManager._forward_deploy_to_external()` schlug die Projekt-Config mit dem **rohen GitHub-Repo-Namen** nach:

```python
project_config = self.bot.config.projects.get(project_name, {})  # project_name = "mayday-sim"
```

Der Trigger-Pfad (`handle_pr_event` → `_trigger_deployment` → `deploy_project`) reicht den GitHub-Repo-Namen `"mayday-sim"` (**Bindestrich**) durch. Der Config-Key ist aber `mayday_sim` (**Underscore**). Ergebnis:

- `config.projects.get("mayday-sim")` → `{}` → `external_notifications = []` → Schleife läuft nie → **kein Post**.
- Der **interne** `#🚀-deployment-log` bekam Posts, weil `_send_deployment_success` den **globalen** `deployment_channel_id` nutzt (kein Projekt-Lookup). Nur der externe Kunden-Post hing am Projekt-Lookup und fiel still durch.

Exakt derselbe Bug-Typ wie der Vorfall **2026-05-25 (PR #449/#450, CLAUDE.md Patch-Notiz)** — damals wurde der dash/underscore-Fallback in `deploy_project` und `_trigger_deployment` ergänzt, `_forward_deploy_to_external` aber übersehen.

## Verifikation (vor dem Fix)

| Check | Ergebnis |
|---|---|
| Deploy PR #503 (`mayday-sim@d4e2ff9`) lief über ShadowOps | ✅ `ci_mixin.py:568/582`, Log 14.06. 11:35–11:39 |
| Interner `#🚀-deployment-log` (`1441655502441414675`) | ✅ bekommt Posts |
| Externer `#🚀-deploy-log` (`1486899717362421840`) | ❌ leer |
| `deploy_channel_id` in `config.projects.mayday_sim.external_notifications` | ✅ korrekt gesetzt |

→ Channel-ID war **nicht** falsch (entgegen erstem Verdacht im Issue). Der reine Lookup-Mismatch war die Ursache.

## Fix

`_forward_deploy_to_external` nutzt jetzt denselben dash/underscore-toleranten Lookup wie `_trigger_deployment` (Z. 503–509) und `deploy_project` (Z. 157–163). Keine API-Änderung (private Methode).

## Tests

Neue Datei `tests/unit/test_deployment_external_forward.py`:
- `test_forward_resolves_dashed_repo_name_to_underscore_config_key` — der Bug (vor Fix RED)
- `test_forward_exact_config_key_still_posts` — Regressionsschutz exakter Key
- `test_forward_skips_when_deployments_flag_off` — `notify_on.deployments=false` respektiert

**41 Deploy-/GitHub-Integration-Tests grün**, keine Regression.

## Hinweis (separat, nicht in diesem PR)

`notifications_mixin.py` hat denselben latenten Mismatch an zwei Stellen mit rohem `repo_name`:
- `_get_last_version_from_git` (Z. 486) und `_get_version_from_commit_tags` (Z. 517) → `config.projects.get(repo_name, {})` ohne dash/underscore-Toleranz.

Diese degradieren nur still (Versions-Fallback bei mayday-sim), betreffen **nicht** Deploy-Posts. Sollten separat geprüft/gefixt werden.

## Doku-Drift

Die mayday-sim-Doku referenziert `#🚀-deployment-log`, der vom Team sichtbare Channel heißt aber `#🚀-deploy-log`. Wird in einem separaten mayday-sim-PR mitgezogen (Issue-Punkt 3).

Bezug: Commandershadow9/mayday-sim#504

🤖 Generated with [Claude Code](https://claude.com/claude-code)