### PR TITLE
feat(watchdog): mayday-scheduler-watchdog (container-Mode) für SB3-Scheduler

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -57,6 +57,7 @@ paths:
 | `zerodox-watchdog.timer` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 3 min |
 | `guildscout-watchdog.timer` | http | http://localhost:8765/health | 4 min |
 | `mayday-sim-watchdog.timer` | http | http://127.0.0.1:3200/api/health | 5 min |
+| `mayday-scheduler-watchdog.timer` | container | leitstelle-scheduler (Docker-Health, Tick-Owner SB3) | 7 min |
 | `ai-agent-framework-watchdog.timer` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 6 min |
 | `memory-watchdog.timer` | meminfo | RAM ≥90% oder Swap ≥80% — Frühwarnung OOM (Throttle 60 min, seit Vorfall 2026-05-25) | 4 min |
 | `disk-hygiene-watchdog.timer` | disk + auto-prune | Auto-Prune (docker builder/image + journald) bei Disk >85%, Alarm >90% (stündlich, Selbstpflege seit 2026-05-30) | hourly |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Zusätzlich zum internen `project_monitor.py` laufen 14 unabhängige user-system
 | `mayday-sim-watchdog` | http | http://127.0.0.1:3200/api/health |
 | `mayday-ci-runner-watchdog` | http + jq-filter | http://10.8.0.10:9100/health, filter=`.components.ci_runner.ok` (#mayday-sim#425) |
 | `mayday-sim-build-drift-watchdog` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD — Alert bei >30 min Drift, Zyklus 15 min (#mayday-sim#416) |
+| `mayday-scheduler-watchdog` | container | leitstelle-scheduler (Docker-Health) — Game-Tick-Owner seit SB3 (#mayday-sim#498), unüberwachter SPOF ohne diesen Watchdog |
 | `ai-agent-framework-watchdog` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent |
 | `cmdshadow-design-watchdog` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h, 1h-Cycle) |
 | `memory-watchdog` | meminfo | RAM ≥90% oder Swap ≥80% auf VPS, Frühwarnung vor OOM-Cascade (seit 2026-05-25, Vorfall logind-Kill durch earlyoom) |

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -193,6 +193,7 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 | `mayday-sim` | http | http://127.0.0.1:3200/api/health | 5 min | 5 min |
 | `mayday-ci-runner` | http + jq-filter | http://10.8.0.10:9100/health, filter `.components.ci_runner.ok` (#mayday-sim#425) | 5 min | 7 min |
 | `mayday-sim-build-drift` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD (max. 30 min Drift, #mayday-sim#416) | 15 min | 2 min |
+| `mayday-scheduler` | container | leitstelle-scheduler (Docker-Health, Game-Tick-Owner SB3 #mayday-sim#498) | 5 min | 7 min |
 | `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 5 min | 6 min |
 | `cmdshadow-design` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h) | 1 h | 8 min |
 | `disk-hygiene` | disk + auto-prune | Auto-Prune (docker builder/image + journald) bei Disk >85%, Alarm >90% (Selbstpflege seit 2026-05-30) | 1 h | — |

--- a/deploy/mayday-scheduler-watchdog.service
+++ b/deploy/mayday-scheduler-watchdog.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=mayday-scheduler Watchdog — leitstelle-scheduler Container-Health + Discord-Alert
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=mayday-scheduler
+Environment=WATCHDOG_MODE=container
+Environment=WATCHDOG_CONTAINER=leitstelle-scheduler
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/mayday-scheduler-watchdog.timer
+++ b/deploy/mayday-scheduler-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=mayday-scheduler Watchdog Timer — alle 5 Minuten (mit Jitter)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 7 Minuten nach Boot (versetzt zu mayday-sim:5, ai-agent:6)
+OnBootSec=7min
+OnUnitActiveSec=5min
+RandomizedDelaySec=45s
+AccuracySec=15s
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/scripts/service-watchdog.sh
+++ b/scripts/service-watchdog.sh
@@ -310,12 +310,69 @@ check_health_systemd_result() {
     return 0
 }
 
+# ─── Health-Check (container-Mode) ─────────────────────────────────────
+# Prueft den Docker-Healthcheck-Status eines Containers via `docker inspect`.
+# Fuer kritische Container OHNE Host-Port-Binding (z.B. leitstelle-scheduler
+# :3203 nur intern erreichbar). DOWN wenn der Container fehlt, nicht laeuft,
+# oder ein definierter Healthcheck != healthy meldet. Container ohne eigenen
+# Healthcheck gelten als UP solange sie laufen ("running").
+# Nutzt `docker` ohne sudo (Watchdog-User ist in der docker-Gruppe; vgl.
+# disk-hygiene-watchdog.sh).
+check_health_container() {
+    if [[ -z "${WATCHDOG_CONTAINER:-}" ]]; then
+        echo "DOWN:no_container_configured"
+        return 1
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "DOWN:docker_not_found"
+        return 1
+    fi
+
+    # docker-Zugriff: bevorzugt direkt (Watchdog-User in docker-Gruppe), sonst
+    # via passwordless sudo. Noetig, weil der `systemd --user`-Manager die
+    # docker-Gruppe nicht aktiv haben kann, wenn er vor dem usermod gestartet
+    # wurde (Gruppen-Caching) → `docker` ohne sudo schlaegt dann fehl.
+    local DK="docker"
+    if ! docker info >/dev/null 2>&1; then
+        if sudo -n docker info >/dev/null 2>&1; then
+            DK="sudo -n docker"
+        else
+            echo "DOWN:docker_unreachable"
+            return 1
+        fi
+    fi
+
+    local state
+    state=$($DK inspect "$WATCHDOG_CONTAINER" --format '{{.State.Status}}' 2>/dev/null || echo "missing")
+    if [[ "$state" == "missing" ]]; then
+        echo "DOWN:container_missing"
+        return 1
+    fi
+    if [[ "$state" != "running" ]]; then
+        echo "DOWN:state_${state}"
+        return 1
+    fi
+
+    # Health-Status nur pruefen, wenn der Container einen Healthcheck definiert.
+    local health
+    health=$($DK inspect "$WATCHDOG_CONTAINER" \
+        --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' 2>/dev/null || echo "unknown")
+    if [[ "$health" != "none" && "$health" != "healthy" ]]; then
+        echo "DOWN:health_${health}"
+        return 1
+    fi
+
+    echo "UP"
+    return 0
+}
+
 # ─── Health-Check Dispatcher ───────────────────────────────────────────
 check_health() {
     case "${WATCHDOG_MODE:-http}" in
         http)           check_health_http ;;
         systemd)        check_health_systemd ;;
         systemd-result) check_health_systemd_result ;;
+        container)      check_health_container ;;
         *)              echo "DOWN:invalid_mode_${WATCHDOG_MODE}"
                         return 1
                         ;;


### PR DESCRIPTION
## Was

`leitstelle-scheduler` ist seit dem SB3-Cutover (mayday-sim#498, heute live) der **alleinige Game-Tick-Owner** — und damit ein **unüberwachter Single-Point-of-Failure**: Stirbt der Container, friert das ganze Spiel ein (keine Einsätze, keine Timer, kein Event-Relay) und niemand merkt es. Dieser Watchdog schließt die Lücke.

## Änderungen
- **`scripts/service-watchdog.sh`: neuer `container`-Mode** (additiv) — prüft den Docker-Healthcheck-Status via `docker inspect`. Für kritische Container **ohne** Host-Port-Binding (scheduler `/health` :3203 ist nur intern). Mit `docker`→`sudo -n docker`-Fallback, weil der `systemd --user`-Manager die docker-Gruppe nicht aktiv hat, wenn er vor dem `usermod` gestartet wurde (Gruppen-Caching).
- **`deploy/mayday-scheduler-watchdog.{service,timer}`** — container-Mode, 5-min-Cycle, 7-min Boot-Offset (gestaffelt zu mayday-sim:5/ai-agent:6).
- **Doku:** Watchdog-Tabellen in `CLAUDE.md`, `.claude/rules/infrastructure.md`, `deploy/MONITORING_SETUP.md`.

## Verifikation
- `test_sync_watchdog_units.py`: 16 passed · `test_service_watchdog_jq_filter.py`: 8 passed · `bash -n` OK
- container-Mode manuell: scheduler → UP (healthy), nicht-existenter Container → DOWN
- **Live installiert** (systemd --user, Timer aktiv) + **Recovery-Alert verifiziert** (Discord HTTP 204)

## Hinweis
Der Watchdog läuft bereits live (Roll-out = Ops-Schritt, bleibt bei cmdshadow). Dieser PR ist die Repo-Persistenz. Generischer `container`-Mode ist auch für `leitstelle-projections` wiederverwendbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)