### PR TITLE
feat(watchdog): mayday Health-Checks über Traefik statt :3200 (SB5 #529)

### DIFF
--- a/deploy/mayday-sim-build-drift-watchdog.service
+++ b/deploy/mayday-sim-build-drift-watchdog.service
@@ -7,6 +7,8 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 EnvironmentFile=-%h/.config/shadowops-watchdog.env
+# SB5 (#529): über Traefik statt :3200 (web N-fach repliziert, kein Host-Port mehr)
+Environment=MAYDAY_HEALTH_URL=https://maydaysim.de/api/build-id
 ExecStart=%h/shadowops-bot/scripts/build-drift-watchdog.sh
 StandardOutput=journal
 StandardError=journal

--- a/deploy/mayday-sim-watchdog.service
+++ b/deploy/mayday-sim-watchdog.service
@@ -7,7 +7,9 @@ After=network-online.target docker.service
 Type=oneshot
 EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
 Environment=WATCHDOG_SERVICE_NAME=mayday-sim
-Environment=WATCHDOG_HEALTH_URL=http://127.0.0.1:3200/api/health
+# SB5 (#529): über Traefik statt :3200 — web ist N-fach repliziert, kein einzelnes
+# Host-Port-Binding mehr. Testet die ganze Kette (DNS+Traefik+TLS+LB+App).
+Environment=WATCHDOG_HEALTH_URL=https://maydaysim.de/api/health
 Environment=WATCHDOG_REQUIRE_BOT_READY=0
 ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
 SuccessExitStatus=0 1


### PR DESCRIPTION
Begleit-PR zu mayday-sim SB5 (#529, mayday-sim PR #530): web wird N-fach repliziert hinter dem Traefik-LB → kein einzelnes `:3200`-Host-Port-Binding mehr.

## Änderung
- `mayday-sim-watchdog`: `WATCHDOG_HEALTH_URL` → `https://maydaysim.de/api/health`
- `mayday-sim-build-drift-watchdog`: `MAYDAY_HEALTH_URL` → `https://maydaysim.de/api/build-id`

Beide gehen jetzt über Traefik (testet die ganze Kette DNS+Traefik+TLS+LB+App, wie der `zerodox-watchdog`). Bereits live (daemon-reload + getriggert, beide `OK`/`drift=0`, kein False-Alert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)