### PR TITLE
docs: mayday-sim Watchdog-Health über Traefik statt :3200 (SB5 #529)

### DIFF
--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -56,7 +56,7 @@ paths:
 | `shadowops-watchdog.timer` | http | http://127.0.0.1:8766/health (bot_ready=true Pflicht) | 2 min |
 | `zerodox-watchdog.timer` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 3 min |
 | `guildscout-watchdog.timer` | http | http://localhost:8765/health | 4 min |
-| `mayday-sim-watchdog.timer` | http | http://127.0.0.1:3200/api/health | 5 min |
+| `mayday-sim-watchdog.timer` | http | https://maydaysim.de/api/health | 5 min |
 | `mayday-scheduler-watchdog.timer` | container | leitstelle-scheduler (Docker-Health, Tick-Owner SB3) | 7 min |
 | `ai-agent-framework-watchdog.timer` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 6 min |
 | `memory-watchdog.timer` | meminfo | RAM ≥90% oder Swap ≥80% — Frühwarnung OOM (Throttle 60 min, seit Vorfall 2026-05-25) | 4 min |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,9 @@ Zusätzlich zum internen `project_monitor.py` laufen 14 unabhängige user-system
 | `zerodox-watchdog` | http | https://zerodox.de/api/health |
 | `zerodox-akquise-ai-watchdog` | http | http://172.19.0.1:9300/health (Bridge-Gateway, kein bot_ready) |
 | `guildscout-watchdog` | http | http://localhost:8765/health |
-| `mayday-sim-watchdog` | http | http://127.0.0.1:3200/api/health |
+| `mayday-sim-watchdog` | http | https://maydaysim.de/api/health |
 | `mayday-ci-runner-watchdog` | http + jq-filter | http://10.8.0.10:9100/health, filter=`.components.ci_runner.ok` (#mayday-sim#425) |
-| `mayday-sim-build-drift-watchdog` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD — Alert bei >30 min Drift, Zyklus 15 min (#mayday-sim#416) |
+| `mayday-sim-build-drift-watchdog` | build-drift | https://maydaysim.de/api/build-id vs. origin/main HEAD — Alert bei >30 min Drift, Zyklus 15 min (#mayday-sim#416) |
 | `mayday-scheduler-watchdog` | container | leitstelle-scheduler (Docker-Health) — Game-Tick-Owner seit SB3 (#mayday-sim#498), unüberwachter SPOF ohne diesen Watchdog |
 | `ai-agent-framework-watchdog` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent |
 | `cmdshadow-design-watchdog` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h, 1h-Cycle) |

--- a/deploy/MONITORING_SETUP.md
+++ b/deploy/MONITORING_SETUP.md
@@ -21,7 +21,7 @@
                                                         alle 5min
        │         │           │                  │            │
        ▼         ▼           ▼                  ▼            ▼
-  :8766/    https://    localhost:8765   127.0.0.1:3200  systemctl --user
+  :8766/    https://    localhost:8765   maydaysim.de    systemctl --user
   health    zerodox.de  /health          /api/health     is-active
             /api/health                                  (3 Core-Agents)
 ```
@@ -190,9 +190,9 @@ echo '{"last_status":"up","last_alert_at":"","consecutive_failures":0}' \
 | `zerodox` | http | https://zerodox.de/api/health (testet via Internet DNS+Traefik+TLS+App) | 5 min | 3 min |
 | `zerodox-akquise-ai` | http | http://172.19.0.1:9300/health (Bridge-Gateway, kein bot_ready, Vorfall 2026-05-24 OOM-Kill) | 5 min | 7 min |
 | `guildscout` | http | http://localhost:8765/health | 5 min | 4 min |
-| `mayday-sim` | http | http://127.0.0.1:3200/api/health | 5 min | 5 min |
+| `mayday-sim` | http | https://maydaysim.de/api/health | 5 min | 5 min |
 | `mayday-ci-runner` | http + jq-filter | http://10.8.0.10:9100/health, filter `.components.ci_runner.ok` (#mayday-sim#425) | 5 min | 7 min |
-| `mayday-sim-build-drift` | build-drift | http://127.0.0.1:3200/api/build-id vs. origin/main HEAD (max. 30 min Drift, #mayday-sim#416) | 15 min | 2 min |
+| `mayday-sim-build-drift` | build-drift | https://maydaysim.de/api/build-id vs. origin/main HEAD (max. 30 min Drift, #mayday-sim#416) | 15 min | 2 min |
 | `mayday-scheduler` | container | leitstelle-scheduler (Docker-Health, Game-Tick-Owner SB3 #mayday-sim#498) | 5 min | 7 min |
 | `ai-agent-framework` | systemd | guildscout-feedback-agent, zerodox-support-agent, seo-agent | 5 min | 6 min |
 | `cmdshadow-design` | systemd-result | cmdshadow-design-healthcheck.service (max_age=36h) | 1 h | 8 min |


### PR DESCRIPTION
Doku-Nachzug nach mayday-sim SB5 (#529): web hat keinen Host-Port `:3200` mehr (N Replicas hinter Traefik). Aktualisiert die Watchdog-Tabellen/Health-Pfade in `CLAUDE.md`, `.claude/rules/infrastructure.md`, `deploy/MONITORING_SETUP.md` auf `https://maydaysim.de/api/health` + `/api/build-id`. Die `.service`-Files selbst wurden bereits in PR #320 umgestellt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)