### PR TITLE
fix(security-engine): AI-Kern wiederbeleben — CLI-Pfad, Codex-Modell, Reflection-KeyError (#290 Phase 0)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -138,14 +138,16 @@ ai:
     cli_path: "codex"
     # Modelle nach Geschwindigkeit
     models:
-      fast: "gpt-5.3-codex"       # Schnelle Analysen
-      standard: "gpt-5.3-codex"   # Standard-Analysen + Structured Output
+      fast: "gpt-5.5"       # Schnelle Analysen (ChatGPT-Abo: gpt-5.5, NICHT gpt-5.x-codex)
+      standard: "gpt-5.5"   # Standard-Analysen + Structured Output
       thinking: "o3"              # Komplexe Planungsaufgaben
 
   # === CLAUDE CLI (FALLBACK — Anthropic Claude via CLI) ===
   claude:
-    # Pfad zur Claude CLI
-    cli_path: "/home/cmdshadow/.local/bin/claude"
+    # Pfad zur Claude CLI. Wird zur Laufzeit robust aufgelöst (env CLAUDE_CLI_PATH →
+    # shutil.which('claude') → Fallback-Liste), daher optional. Nur setzen, wenn ein
+    # nicht im PATH liegender Pfad erzwungen werden soll.
+    cli_path: "/home/cmdshadow/.npm-global/bin/claude"
     # Modelle nach Geschwindigkeit
     models:
       fast: "claude-sonnet-4-6"    # Schnelle Analysen
@@ -165,7 +167,7 @@ security_analyst:
   enabled: true
   database_dsn: "postgresql://security_analyst:SICHERES_PASSWORT@127.0.0.1:5433/security_analyst"
   max_sessions_per_day: 1           # Basis-Limit (dynamisch erhoehbar bei Backlog)
-  model: "gpt-5.3-codex"            # Primaeres Modell fuer taegliche Scans (Codex mit Full-Access)
+  model: "gpt-5.5"                  # Primaeres Modell fuer taegliche Scans (Codex/ChatGPT-Abo: gpt-5.5)
   fallback_model: "claude-opus-4-6"  # Fallback + Weekly-Deep-Scan Modell (Claude)
   maintenance_scan_days: 1          # Tage zwischen Scans bei 0 Backlog (1 = taeglich)
   # Adaptive Steuerung: >=20 Findings → bis 3 Sessions, 5-19 → bis 2, 1-4 → 1, 0 → daily full_scan

--- a/src/cogs/claude_cli.py
+++ b/src/cogs/claude_cli.py
@@ -122,7 +122,7 @@ class ClaudeCLICog(commands.Cog):
         except FileNotFoundError:
             await interaction.followup.send(
                 "❌ `claude` CLI nicht gefunden. PATH prüfen "
-                "(`/home/cmdshadow/.local/bin/claude` erwartet).",
+                "(`which claude`) oder `CLAUDE_CLI_PATH` setzen.",
                 ephemeral=True,
             )
             return

--- a/src/integrations/ai_engine.py
+++ b/src/integrations/ai_engine.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import signal
 import re
 import tempfile
@@ -29,6 +30,48 @@ from pathlib import Path
 import jsonschema
 
 logger = logging.getLogger('shadowops')
+
+
+# Bekannte Fallback-Pfade zur Claude-CLI (npm-global zuerst — reale Location seit 2026-07,
+# nachdem die npm-Installation von ~/.local/bin nach ~/.npm-global/bin gewandert ist).
+_CLAUDE_CLI_FALLBACKS = [
+    '/home/cmdshadow/.npm-global/bin/claude',
+    '/home/cmdshadow/.local/bin/claude',
+]
+
+
+def resolve_claude_cli_path(configured_path: Optional[str] = None) -> str:
+    """Löst den Pfad zur Claude-CLI robust zur Laufzeit auf.
+
+    Ein hartcodierter Pfad brach den Claude-Fallback (FileNotFoundError), sobald die
+    npm-Installation umzog. Reihenfolge (erster Treffer gewinnt):
+      1. Env-Override ``CLAUDE_CLI_PATH`` (falls gesetzt und Datei existiert)
+      2. Explizit konfigurierter Pfad (falls Datei existiert)
+      3. ``shutil.which('claude')`` — nutzt den PATH des Bot-Prozesses
+      4. Bekannte Fallback-Pfade (erster existierender)
+      5. Letzter Ausweg: erster Fallback-Pfad, damit Fehlermeldungen einen Pfad zeigen
+    """
+    env_override = os.environ.get('CLAUDE_CLI_PATH')
+    if env_override:
+        if os.path.isfile(env_override):
+            return env_override
+        logger.warning(
+            "CLAUDE_CLI_PATH=%s gesetzt, aber Datei existiert nicht — nutze Auto-Auflösung",
+            env_override,
+        )
+
+    if configured_path and os.path.isfile(configured_path):
+        return configured_path
+
+    which_path = shutil.which('claude')
+    if which_path:
+        return which_path
+
+    for candidate in _CLAUDE_CLI_FALLBACKS:
+        if os.path.isfile(candidate):
+            return candidate
+
+    return _CLAUDE_CLI_FALLBACKS[0]
 
 # Basis-Pfad zu den JSON-Schemas
 SCHEMAS_DIR = Path(__file__).parent.parent / 'schemas'
@@ -386,7 +429,7 @@ class ClaudeProvider:
     """
 
     def __init__(self, config: dict):
-        self.cli_path = config.get('cli_path', '/home/cmdshadow/.local/bin/claude')
+        self.cli_path = resolve_claude_cli_path(config.get('cli_path'))
         self.models = config.get('models', {
             'fast': 'claude-sonnet-4-6',
             'standard': 'claude-sonnet-4-6',
@@ -873,7 +916,8 @@ class AIEngine:
             'timeout_thinking': 300,
         })
         fallback_cfg = ai_cfg.get('fallback', {
-            'cli_path': '/home/cmdshadow/.local/bin/claude',
+            # cli_path bewusst weggelassen — ClaudeProvider löst den Pfad via
+            # resolve_claude_cli_path() robust zur Laufzeit auf (env → which → Fallback-Liste).
             'models': {'fast': 'claude-sonnet-4-6', 'standard': 'claude-sonnet-4-6', 'thinking': 'claude-opus-4-6'},
             'timeout': 120,
         })
@@ -2196,7 +2240,7 @@ class AIEngine:
         details_str = json.dumps(details, indent=2, default=str) if details else "Keine Details verfuegbar"
 
         prompt_parts = [
-            f"Du bist ein Security-Analyst fuer Linux-Server (Debian 12).",
+            f"Du bist ein Security-Analyst fuer Linux-Server (Debian 13 trixie).",
             f"Analysiere das folgende Security-Event und erstelle eine Fix-Strategie.",
             f"",
             f"## Event-Details",

--- a/src/integrations/analyst/prompts.py
+++ b/src/integrations/analyst/prompts.py
@@ -18,7 +18,7 @@ Du bist ein Security Engineer. Scanne diesen Produktiv-Server und melde Findings
 
 - Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH Port 47822
 - WireGuard VPN (10.8.0.0/24), UFW aktiv, Traefik v3 (80/443)
-- Tools: CrowdSec, Fail2ban, AIDE, Trivy, earlyoom
+- Tools: CrowdSec, AIDE, Trivy, earlyoom (KEIN fail2ban — durch CrowdSec ersetzt, Issue #295)
 
 ## Projekte
 

--- a/src/integrations/analyst/prompts.py
+++ b/src/integrations/analyst/prompts.py
@@ -16,7 +16,7 @@ Du bist ein Security Engineer. Scanne diesen Produktiv-Server und melde Findings
 
 ## Server
 
-- Debian 12, 6 Kerne, 8 GB RAM, SSH Port 47822
+- Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH Port 47822
 - WireGuard VPN (10.8.0.0/24), UFW aktiv, Traefik v3 (80/443)
 - Tools: CrowdSec, Fail2ban, AIDE, Trivy, earlyoom
 
@@ -124,7 +124,7 @@ Du hast genug Zeit und Turns. Lass nichts aus.
 
 ## Server
 
-Debian 12, SSH 47822, UFW, Traefik v3.
+Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH 47822, UFW, Traefik v3.
 Projekte: ~/GuildScout/, ~/ZERODOX/, ~/shadowops-bot/, ~/agents/, ~/openclaw/
 
 ## Findings

--- a/src/integrations/security_engine/prompts.py
+++ b/src/integrations/security_engine/prompts.py
@@ -25,7 +25,7 @@ dieses Produktiv-Servers durch. Sei systematisch und gruendlich.
 
 - Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH Port 47822
 - WireGuard VPN (10.8.0.0/24), UFW aktiv, Traefik v3 (80/443)
-- Tools: CrowdSec, Fail2ban, AIDE, Trivy, earlyoom
+- Tools: CrowdSec, AIDE, Trivy, earlyoom (KEIN fail2ban — durch CrowdSec ersetzt, Issue #295)
 
 ## Projekte
 
@@ -140,7 +140,7 @@ gruendlicher als der taegliche Scan. Nimm dir Zeit, geh in die Tiefe.
 
 - Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH Port 47822
 - WireGuard VPN (10.8.0.0/24), UFW aktiv, Traefik v3 (80/443)
-- Tools: CrowdSec, Fail2ban, AIDE, Trivy, earlyoom
+- Tools: CrowdSec, AIDE, Trivy, earlyoom (KEIN fail2ban — durch CrowdSec ersetzt, Issue #295)
 
 ## Projekte
 

--- a/src/integrations/security_engine/prompts.py
+++ b/src/integrations/security_engine/prompts.py
@@ -23,7 +23,7 @@ dieses Produktiv-Servers durch. Sei systematisch und gruendlich.
 
 ## Server
 
-- Debian 12, 6 Kerne, 8 GB RAM, SSH Port 47822
+- Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH Port 47822
 - WireGuard VPN (10.8.0.0/24), UFW aktiv, Traefik v3 (80/443)
 - Tools: CrowdSec, Fail2ban, AIDE, Trivy, earlyoom
 
@@ -138,7 +138,7 @@ gruendlicher als der taegliche Scan. Nimm dir Zeit, geh in die Tiefe.
 
 ## Server
 
-- Debian 12, 6 Kerne, 8 GB RAM, SSH Port 47822
+- Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH Port 47822
 - WireGuard VPN (10.8.0.0/24), UFW aktiv, Traefik v3 (80/443)
 - Tools: CrowdSec, Fail2ban, AIDE, Trivy, earlyoom
 
@@ -278,6 +278,22 @@ Antworte als JSON:
 """
 
 
+def render_reflection_prompt(session_summary: str, weekly_context: str) -> str:
+    """Rendert den REFLECTION_PROMPT mit den Session-Werten.
+
+    Nutzt bewusst ``str.replace()`` statt ``str.format()``: Das Template enthält ein
+    JSON-Beispiel (``{"quality_score": ...}``), dessen geschweifte Klammern ``str.format()``
+    als Replacement-Field fehlinterpretiert — das warf reproduzierbar ``KeyError: '"quality_score"'``
+    und legte die Post-Scan-Reflection lahm. ``.replace()`` ist robust gegen die JSON-Klammern
+    und bleibt es auch, wenn das JSON-Beispiel später erweitert wird.
+    """
+    return (
+        REFLECTION_PROMPT
+        .replace('{session_summary}', session_summary)
+        .replace('{weekly_context}', weekly_context)
+    )
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Fix-Session Prompt — Arbeitet Findings aus der DB ab
 # ─────────────────────────────────────────────────────────────────────
@@ -290,7 +306,7 @@ Du hast genug Zeit und Turns. Lass nichts aus.
 
 ## Server
 
-Debian 12, SSH 47822, UFW, Traefik v3.
+Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1, SSH 47822, UFW, Traefik v3.
 Projekte: ~/GuildScout/, ~/ZERODOX/, ~/shadowops-bot/, ~/agents/
 
 ## Findings

--- a/src/integrations/security_engine/scan_agent.py
+++ b/src/integrations/security_engine/scan_agent.py
@@ -32,7 +32,7 @@ import discord
 from .activity_monitor import ActivityMonitor
 from .fingerprint import compute_finding_fingerprint
 from .prompts import (ANALYST_SYSTEM_PROMPT, ANALYST_CONTEXT_TEMPLATE, FIX_SESSION_PROMPT,
-                       WEEKLY_DEEP_PROMPT, REFLECTION_PROMPT)
+                       WEEKLY_DEEP_PROMPT, render_reflection_prompt)
 
 logger = logging.getLogger('shadowops.scan_agent')
 
@@ -2467,7 +2467,7 @@ von der ShadowOps Review-Pipeline reviewt — halte den Scope eng."""
             except Exception:
                 weekly_context = "(Wochen-Kontext nicht verfuegbar)"
 
-            prompt = REFLECTION_PROMPT.format(
+            prompt = render_reflection_prompt(
                 session_summary=session_summary,
                 weekly_context=weekly_context,
             )

--- a/src/integrations/server_assistant.py
+++ b/src/integrations/server_assistant.py
@@ -427,8 +427,8 @@ class ServerAssistant:
         # EIN AI-Call
         prompt = (
             "Du bist Security-Analyst fuer einen Produktiv-VPS "
-            "(Debian 12, 6 Kerne, 8 GB RAM) mit GuildScout, ZERODOX, "
-            "und diversen Agents.\n\n"
+            "(Debian 13 trixie, Intel i7-6700 4C/8T, 64 GB RAM, NVMe RAID1) "
+            "mit GuildScout, ZERODOX, und diversen Agents.\n\n"
             "Analysiere diesen Wochenbericht und liefere:\n"
             "1. **Sicherheitsbewertung** (1-10, 10 = perfekt)\n"
             "2. **Top 3 Risiken** (konkret, mit Handlungsempfehlung)\n"
@@ -736,9 +736,13 @@ class ServerAssistant:
         """
         result: Dict[str, List] = {'info': []}
 
+        # Claude-CLI-Pfad robust auflösen (nicht hartcodieren — Location zog 2026-07 um).
+        from .ai_engine import resolve_claude_cli_path
+        claude_cli = resolve_claude_cli_path()
+
         checks = {
             'codex': 'codex --version 2>/dev/null',
-            'claude': '/home/cmdshadow/.local/bin/claude --version 2>/dev/null',
+            'claude': f'{claude_cli} --version 2>/dev/null',
         }
 
         for name, cmd in checks.items():

--- a/tests/unit/test_ai_engine.py
+++ b/tests/unit/test_ai_engine.py
@@ -3,6 +3,7 @@ Unit Tests für AI Engine — Dual-Engine (Codex CLI + Claude CLI)
 Ersetzt das alte Ollama-basierte AIService.
 """
 
+import os
 import time
 import pytest
 import json
@@ -493,12 +494,21 @@ class TestClaudeProvider:
 
     @pytest.mark.asyncio
     async def test_claude_cli_path_used(self, ai_config):
-        """Claude CLI Pfad aus Config wird korrekt verwendet"""
+        """Konfigurierter Claude-CLI-Pfad wird verwendet, wenn die Datei existiert.
+
+        Neuer Contract seit der robusten Pfad-Aufloesung: ein konfigurierter Pfad wird
+        nur honoriert, wenn er tatsaechlich existiert (sonst greift which/Fallback).
+        """
         from src.integrations.ai_engine import ClaudeProvider
 
-        provider = ClaudeProvider(ai_config.ai['fallback'])
-        captured_args = []
+        configured = ai_config.ai['fallback'].get('cli_path', '/home/cmdshadow/.local/bin/claude')
 
+        # Pfad-Existenz simulieren, damit der konfigurierte Pfad honoriert wird.
+        # Konstruktion muss innerhalb des Patches passieren (Aufloesung geschieht in __init__).
+        with patch('src.integrations.ai_engine.os.path.isfile', lambda p: p == configured):
+            provider = ClaudeProvider(ai_config.ai['fallback'])
+
+        captured_args = []
         mock_proc = make_mock_process(stdout='{"result": "{}"}')
 
         async def capture_exec(*args, **kwargs):
@@ -508,7 +518,7 @@ class TestClaudeProvider:
         with patch('asyncio.create_subprocess_exec', side_effect=capture_exec):
             await provider.query("Test", model='standard')
 
-        assert captured_args[0] == '/home/cmdshadow/.local/bin/claude'
+        assert captured_args[0] == configured
 
     @pytest.mark.asyncio
     async def test_schema_in_prompt_for_claude(self, ai_config, schemas_dir):
@@ -972,3 +982,67 @@ class TestAIEngine:
 
         # Vorherige Versuche muessen erwaehnt werden
         assert 'Erster Versuch' in prompt or 'failed' in prompt.lower() or 'versuch' in prompt.lower()
+
+
+# ============================================================================
+# RESOLVE CLAUDE CLI PATH — Regressionstests (Bug: hartcodierter CLI-Pfad)
+# ============================================================================
+class TestResolveClaudeCliPath:
+    """Robuste Aufloesung des Claude-CLI-Pfads.
+
+    Regression: Der Pfad war hartcodiert auf /home/cmdshadow/.local/bin/claude; nach
+    dem npm-Umzug nach ~/.npm-global/bin lag die CLI woanders -> FileNotFoundError bei
+    jedem Claude-Fallback. resolve_claude_cli_path() loest zur Laufzeit robust auf.
+    """
+
+    def test_env_override_wins_when_file_exists(self):
+        from src.integrations.ai_engine import resolve_claude_cli_path
+        with patch.dict(os.environ, {'CLAUDE_CLI_PATH': '/custom/claude'}, clear=True):
+            with patch('src.integrations.ai_engine.os.path.isfile',
+                       lambda p: p == '/custom/claude'):
+                assert resolve_claude_cli_path('/ignored/config/path') == '/custom/claude'
+
+    def test_env_override_ignored_when_missing(self):
+        """Zeigt CLAUDE_CLI_PATH ins Leere, wird auf Auto-Aufloesung zurueckgefallen."""
+        from src.integrations.ai_engine import resolve_claude_cli_path
+        with patch.dict(os.environ, {'CLAUDE_CLI_PATH': '/nope/claude'}, clear=True):
+            with patch('src.integrations.ai_engine.os.path.isfile', return_value=False):
+                with patch('src.integrations.ai_engine.shutil.which',
+                           return_value='/usr/bin/claude'):
+                    assert resolve_claude_cli_path(None) == '/usr/bin/claude'
+
+    def test_configured_path_used_when_exists(self):
+        from src.integrations.ai_engine import resolve_claude_cli_path
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('src.integrations.ai_engine.os.path.isfile',
+                       lambda p: p == '/opt/claude'):
+                assert resolve_claude_cli_path('/opt/claude') == '/opt/claude'
+
+    def test_which_used_when_config_missing(self):
+        from src.integrations.ai_engine import resolve_claude_cli_path
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('src.integrations.ai_engine.os.path.isfile', return_value=False):
+                with patch('src.integrations.ai_engine.shutil.which',
+                           return_value='/usr/local/bin/claude'):
+                    assert resolve_claude_cli_path(None) == '/usr/local/bin/claude'
+
+    def test_fallback_list_used_when_which_none(self):
+        from src.integrations.ai_engine import (resolve_claude_cli_path,
+                                                _CLAUDE_CLI_FALLBACKS)
+        # Nur der zweite Fallback-Kandidat existiert
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('src.integrations.ai_engine.os.path.isfile',
+                       lambda p: p == _CLAUDE_CLI_FALLBACKS[1]):
+                with patch('src.integrations.ai_engine.shutil.which', return_value=None):
+                    assert resolve_claude_cli_path(None) == _CLAUDE_CLI_FALLBACKS[1]
+
+    def test_last_resort_returns_npm_global_first(self):
+        """Findet nichts existierendes, wird der npm-global-Pfad (reale Location) geliefert."""
+        from src.integrations.ai_engine import (resolve_claude_cli_path,
+                                                _CLAUDE_CLI_FALLBACKS)
+        with patch.dict(os.environ, {}, clear=True):
+            with patch('src.integrations.ai_engine.os.path.isfile', return_value=False):
+                with patch('src.integrations.ai_engine.shutil.which', return_value=None):
+                    assert resolve_claude_cli_path(None) == _CLAUDE_CLI_FALLBACKS[0]
+        # npm-global MUSS vor .local/bin stehen (Regression: reale Location seit 2026-07)
+        assert _CLAUDE_CLI_FALLBACKS[0] == '/home/cmdshadow/.npm-global/bin/claude'

--- a/tests/unit/test_reflection_prompt.py
+++ b/tests/unit/test_reflection_prompt.py
@@ -1,0 +1,49 @@
+"""
+Regressionstests fuer den Reflection-Prompt der Security-Engine.
+
+Bug (Journal 13.06. + 28.06.): Die Post-Scan-Reflection crashte reproduzierbar mit
+``KeyError: '"quality_score"'``. Root-Cause: ``REFLECTION_PROMPT.format(...)`` lief ueber
+ein Template, das ein JSON-Beispiel (``{"quality_score": ...}``) enthaelt — ``str.format()``
+interpretiert die geschweiften Klammern als Replacement-Field.
+
+Fix: ``render_reflection_prompt()`` nutzt ``.replace()`` statt ``.format()``.
+"""
+
+import pytest
+
+from src.integrations.security_engine.prompts import (
+    REFLECTION_PROMPT,
+    render_reflection_prompt,
+)
+
+
+def test_old_format_call_would_crash():
+    """Beweist den alten Crash: .format() auf dem ECHTEN Template wirft KeyError.
+
+    Rot vor Fix (das war der Live-Aufruf), dokumentiert die Falle dauerhaft.
+    """
+    with pytest.raises(KeyError, match='quality_score'):
+        REFLECTION_PROMPT.format(session_summary="X", weekly_context="Y")
+
+
+def test_render_substitutes_both_placeholders():
+    out = render_reflection_prompt("SESSION_MARKER", "WEEK_MARKER")
+    assert "SESSION_MARKER" in out
+    assert "WEEK_MARKER" in out
+    # Keine unaufgeloesten Platzhalter mehr
+    assert "{session_summary}" not in out
+    assert "{weekly_context}" not in out
+
+
+def test_render_preserves_json_example():
+    """Das JSON-Beispiel (mit quality_score) muss unveraendert im Prompt bleiben."""
+    out = render_reflection_prompt("s", "w")
+    assert '{"quality_score": 75' in out
+    assert '"blind_spots"' in out
+
+
+def test_render_does_not_raise_with_braces_in_values():
+    """Werte mit geschweiften Klammern (z.B. JSON im Session-Summary) brechen nichts."""
+    summary = 'Session-Ergebnis: {"findings": 3, "fixes": 1}'
+    out = render_reflection_prompt(summary, "Woche ok")
+    assert summary in out


### PR DESCRIPTION
## Kontext

Der AI-Kern der Security-Engine war seit dem Server-Umzug (2026-06-07) bzw. dem npm-Umzug tot: Sessions #535–#538 (07.07.+09.07.) schlugen fehl, die Post-Scan-Reflection crashte (Journal 13.06.+28.06.). Diese PR behebt die drei Blocker plus die stale Server-Fakten. **Refs #290 (Phase 0).**

Alle Root-Causes wurden am Code verifiziert (nicht nur übernommen).

---

## Root-Cause-Analyse je Bug

### 1. CLI-Pfad hartcodiert → FileNotFoundError bei jedem Claude-Fallback
`ClaudeProvider.__init__`, der AIEngine-Fallback-Default und der CLI-Versions-Check in `ServerAssistant` zeigten fest auf `/home/cmdshadow/.local/bin/claude`. Real liegt die CLI seit dem npm-Umzug unter `/home/cmdshadow/.npm-global/bin/claude` (verifiziert: `.local/bin/claude` existiert nicht mehr, `which claude` → npm-global). Jeder Claude-Fallback (und die Fix-Phase) lief in `FileNotFoundError`.

**Fix:** Neue Helper-Funktion `resolve_claude_cli_path()` in `ai_engine.py` löst den Pfad zur Laufzeit robust auf — Reihenfolge: Env-Override `CLAUDE_CLI_PATH` → konfigurierter Pfad (falls existiert) → `shutil.which('claude')` → Fallback-Liste (`npm-global` zuerst, dann `.local/bin`) → letzter Ausweg npm-global. Alle drei Stellen nutzen jetzt denselben Helper (`ai_engine.py:432`, `ai_engine.py:916`, `server_assistant.py:740-741`). Der Hinweistext im `/claude`-Cog (`claude_cli.py:125`) wurde von der falschen Pfadangabe auf `which claude` / `CLAUDE_CLI_PATH` entschärft.
Repoweiter grep bestätigt: kein weiterer hartcodierter Pfad übrig (außer dem beabsichtigten Fallback-Kandidaten in der Liste).

### 2. Reflection-KeyError `'"quality_score"'` — was es wirklich war
Bestätigt am Code: `scan_agent.py:2470` rief `REFLECTION_PROMPT.format(session_summary=…, weekly_context=…)`. Das Template (`prompts.py:238`) enthält am Ende ein **JSON-Beispiel** `{"quality_score": 75, …}`. `str.format()` interpretiert die geschweiften Klammern als Replacement-Field, liest `"quality_score"` (inkl. Anführungszeichen) als Feldnamen → `KeyError: '"quality_score"'`. Exakt der gemeldete Fehler. Der Crash passierte NACH GSC/SERP/AI, aber vor der Persistenz → kein Datenverlust, aber Reflection/Insights fielen aus.

**Fix:** Neue reine Funktion `render_reflection_prompt()` in `prompts.py` nutzt `.replace()` statt `.format()` — robust gegen die JSON-Klammern und auch dann, wenn das JSON-Beispiel später erweitert wird. `scan_agent.py` ruft jetzt den Renderer; ungenutzter `REFLECTION_PROMPT`-Import entfernt.
`.replace()` statt `{{ }}`-Escaping bewusst gewählt: Das Template ist voller JSON-Klammern, Escaping wäre fragil bei künftigen Edits. Kein Escaping-Präzedenzfall im Repo (die `{{ }}` in `ANALYST_SYSTEM_PROMPT` sind Go-Docker-`--format`-Syntax und laufen nie durch `.format()`).

### 3. Stale Server-Fakten
Prompts behaupteten „Debian 12, 6 Kerne, 8 GB RAM". Real seit Umzug: **Debian 13 (trixie), Intel i7-6700 (4C/8T), 64 GB RAM, NVMe RAID1**. Falsche Ressourcen-Fakten verzerren die Security-Bewertung (z.B. Fehleinschätzung von Resource-Exhaustion-Findings). Aktualisiert in `security_engine/prompts.py` (3×: ANALYST_SYSTEM/WEEKLY_DEEP/FIX_SESSION), `analyst/prompts.py` (2×), `ai_engine.py` (Incident-Prompt) und `server_assistant.py` (Weekly-Report-Prompt).

### 4. Codex-Modell (config.example.yaml)
`gpt-5.3-codex` liefert HTTP 400 „not supported when using Codex with a ChatGPT account". Sparsam getestet (je 1 Mini-Call): `gpt-5.5-codex` → **400** (nicht unterstützt), `gpt-5.5` → **OK**. `config/config.example.yaml` auf `gpt-5.5` umgestellt (`ai.codex.models.fast/standard` + `security_analyst.model`), Claude-`cli_path` im Beispiel auf npm-global korrigiert + als optional dokumentiert. `o3` (thinking) und die Claude-Modelle blieben unangetastet (nicht Teil des 400-Fehlers, ungetestet). **LIVE `config/config.yaml` NICHT verändert.**

---

## Test-Nachweis (alle Suiten mit venv-Python, einzeln, Worktree-Code via PYTHONPATH)

| Suite | Ergebnis |
|---|---|
| `tests/unit/test_reflection_prompt.py` (**neu**) | **4 passed** — reproduziert den alten `.format()`-Crash (rot vor Fix) |
| `tests/unit/test_ai_engine.py` | **52 passed** — inkl. 6 neuer `TestResolveClaudeCliPath` + angepasstem `test_claude_cli_path_used` |
| `tests/unit/test_scan_agent.py` | **6 passed** |
| `tests/unit/test_security_analyst.py` | **21 skipped** (Legacy, unverändert) |
| `test_deep_scan_mode` + 5× `test_scan_agent_*` | **81 passed** |

Summe betroffener Suiten: **143 passed, 21 skipped, 0 failed**. Keine echten `gh`/`npm`/`claude`/`codex`-Calls in Tests — alles gemockt (Lehre aus Vorfall #1069). Zusätzlicher Integrations-Smoke: `resolve_claude_cli_path()` liefert auf dem Server real `/home/cmdshadow/.npm-global/bin/claude` (existiert) → Original-Bug nachweislich behoben.

`test_claude_cli_path_used` musste angepasst werden: der alte Test asserte den hartcodierten Pfad verbatim; neuer Contract honoriert einen konfigurierten Pfad nur, wenn er existiert (sonst which/Fallback). Test bildet den neuen Contract ab und ist grün.

---

## ⚙️ Ops-Schritt für die LIVE-`config/config.yaml` (nicht in Git, manuell)

Der Code-Fix allein revived den Claude-Fallback + die Reflection. Damit der **primäre** Codex-Scan wieder läuft, muss das Modell in der Live-Config gesetzt werden:

1. In `~/shadowops-bot/config/config.yaml` das Modell `gpt-5.3-codex` → `gpt-5.5` ändern an:
   - `security_analyst.model` (die Kern-Zeile für den Tages-Scan)
   - `ai.codex.models.fast` und `ai.codex.models.standard`
   - (`ai.codex.models.thinking: o3` und die Claude-Modelle unverändert lassen)
2. Bot neu starten: `bash ~/shadowops-bot/scripts/restart.sh`
3. Verifizieren: nächster Scan ohne HTTP 400; Reflection ohne KeyError im Journal.

Optional: `CLAUDE_CLI_PATH` muss NICHT gesetzt werden — der Resolver findet die CLI via `which`/Fallback automatisch.

---

## Verbliebene Risiken / Auffälligkeiten

- **Dormante Code-Defaults** `gpt-5.3-codex` als Fallback-Wert an mehreren Stellen (u.a. `scan_agent.py:389`, `analyst/security_analyst.py:147`, `ai_engine.py:914` primary_cfg-Default). Diese greifen NUR, wenn die Config das Modell nicht liefert — die LIVE-Config liefert es, also produktiv unkritisch. Bewusst außerhalb dieses Scopes gelassen (Bug D war auf die Beispiel-Config beschränkt); Kandidat für einen Hygiene-Folge-PR.
- **Test-Fixtures** mit `gpt-5.3-codex` / „Debian 12" (`conftest.py`, `test_config.py`, Mock-Returns) bewusst NICHT geändert — deren Werte werden geprüft bzw. sind reine Eingabedaten.
- **`o3`** (thinking-Modell) ungetestet gelassen — nicht Teil des gemeldeten 400-Fehlers.
- CI-Lint `ruff check . || true` ist nicht-blockierend (Default-Regeln ohne Blank-Line-Checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)