### PR TITLE
fix(security-engine): Fix-Phase crasht bei summary als dict (Session #539) (#290)

### DIFF
--- a/src/integrations/security_engine/scan_agent.py
+++ b/src/integrations/security_engine/scan_agent.py
@@ -1398,9 +1398,15 @@ class SecurityScanAgent:
             if deletion_warnings:
                 summary_extra = " | DELETION-WARNUNG: " + "; ".join(deletion_warnings)
 
+            summary_val = fix_result.get('summary', '')
+            if not isinstance(summary_val, str):
+                # LLM liefert summary gelegentlich als strukturiertes Objekt (dict) —
+                # Session #539 (2026-07-09): dict + str crashte die komplette Fix-Phase.
+                summary_val = json.dumps(summary_val, ensure_ascii=False, default=str)
+
             logger.info("Fix-Phase: %d gefixt, %d PRs (von %d)", fixed_count, pr_count, len(fixable))
             await self._notify_fix_phase_complete(fixed_count, pr_count, len(fixable),
-                                                   fix_result.get('summary', '') + summary_extra)
+                                                   summary_val + summary_extra)
         except Exception as e:
             logger.error("Fix-Phase Fehler: %s", e, exc_info=True)
         finally:

--- a/tests/unit/test_scan_agent.py
+++ b/tests/unit/test_scan_agent.py
@@ -175,3 +175,25 @@ async def test_can_start_session_returns_false_when_disabled(agent):
     agent._consecutive_failures = MAX_CONSECUTIVE_FAILURES
 
     assert await agent.can_start_session() is False
+
+
+@pytest.mark.asyncio
+async def test_run_fix_phase_summary_als_dict_crasht_nicht(agent, mock_ai_engine):
+    """Session #539 (2026-07-09): LLM liefert summary manchmal als dict statt str —
+    fix_result['summary'] + summary_extra crashte mit TypeError, 0 Findings gefixt."""
+    agent._get_fixable_findings = AsyncMock(return_value=[{
+        'id': 1, 'severity': 'high', 'category': 'test', 'title': 'X',
+        'description': 'Y', 'affected_project': 'zerodox', 'affected_files': [],
+        'github_issue_url': None,
+    }])
+    agent._post_fix_integrity_check = AsyncMock(return_value=None)
+    agent._check_deletion_guard = AsyncMock(return_value=[])
+    agent._notify_fix_phase_complete = AsyncMock()
+    mock_ai_engine.run_fix_session = AsyncMock(return_value={
+        'results': [],
+        'summary': {'status': 'done', 'detail': 'x'},
+    })
+
+    await agent._run_fix_phase(scan_session_id=1)
+
+    agent._notify_fix_phase_complete.assert_awaited_once()


### PR DESCRIPTION
## Root-Cause

Live-Crash in Session #539 (heute, 2026-07-09 04:59): `TypeError: unsupported operand type(s) for +: 'dict' and 'str'` in `scan_agent.py:1403`.

`_run_fix_phase` hängt `fix_result.get('summary', '')` mit `+ summary_extra` zusammen. Das LLM liefert `summary` aber nicht immer als String — gelegentlich als strukturiertes Objekt (dict). `dict + str` crasht, die Exception wird vom umschließenden `except Exception` in `_run_fix_phase` nur geloggt (nicht neu geworfen) — dadurch wurde `_notify_fix_phase_complete` nie erreicht und **0 von 11 Findings gefixt**, ohne dass der Prozess sichtbar abgebrochen ist.

## Fix

`summary_val` wird vor der Verkettung defensiv auf `str` normalisiert: ist es bereits ein String, bleibt es unverändert; ist es etwas anderes (z. B. dict), wird es via `json.dumps(..., default=str)` in eine lesbare String-Repräsentation umgewandelt, bevor `summary_extra` angehängt wird.

## Test-Nachweis (TDD)

Neuer Test `test_run_fix_phase_summary_als_dict_crasht_nicht` in `tests/unit/test_scan_agent.py`:
- Vor dem Fix: **rot** — `_notify_fix_phase_complete` wurde wegen der intern gefangenen `TypeError` nie aufgerufen (`Awaited 0 times`).
- Nach dem Fix: **grün** — `_notify_fix_phase_complete` wird wie erwartet einmal awaited.

Vollständiger Lauf `tests/unit/test_scan_agent.py`: **7 passed, 0 failed** (venv-Python, `.venv/bin/python -m pytest`, alle DB/AI-Engine-Calls gemockt, keine echten Netzwerk-/DB-Zugriffe).

## Scope

Nur `scan_agent.py` (Fix) + `test_scan_agent.py` (Test). Kein Migrationsbedarf, keine Config-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)