### PR TITLE
feat(secteam): W1 — Orchestrator-Loop, Trigger/Reaper/Soak-Scripts, Freshness-Watchdog (#290)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -245,7 +245,7 @@ github:
   local_polling_enabled: true       # Pollt Repos lokal auf neue Commits (Fallback zu Webhooks)
   local_polling_interval: 60        # Polling-Intervall in Sekunden
 
-# Security-Agent-Team (P1) — default OFF. Env-Override: SECURITY_TEAM_ENABLED
+# Security-Agent-Team (W1) — default OFF. Env-Override: SECURITY_TEAM_ENABLED
 security_team:
   enabled: false
   active_workers: ["npm_audit"]
@@ -253,7 +253,7 @@ security_team:
     guildscout:
       npm_audit_path: "/home/cmdshadow/GuildScout/web"
     zerodox:
-      npm_audit_path: "/home/cmdshadow/ZERODOX"
+      npm_audit_path: "/home/cmdshadow/ZERODOX/web"
 
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║ PROJECTS (Überwachte Projekte)                                           ║

--- a/deploy/security-freshness-watchdog.service
+++ b/deploy/security-freshness-watchdog.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Security-Team Freshness Watchdog — letzter erfolgreicher sec_jobs-Lauf < 26h (DB completed_at)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=security-freshness
+Environment=WATCHDOG_MODE=pg-freshness
+Environment=WATCHDOG_PG_CONTAINER=guildscout-postgres
+Environment=WATCHDOG_PG_USER=security_analyst
+Environment=WATCHDOG_PG_DB=security_analyst
+Environment=WATCHDOG_MAX_AGE_HOURS=26
+Environment="WATCHDOG_PG_QUERY=SELECT COALESCE(EXTRACT(EPOCH FROM (NOW()-MAX(completed_at)))/3600, 999999) FROM sec_jobs WHERE status IN ('ok','partial')"
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/deploy/security-freshness-watchdog.timer
+++ b/deploy/security-freshness-watchdog.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Security-Team Freshness Watchdog Timer — stündlich (mit Jitter)
+Documentation=https://github.com/Commandershadow9/shadowops-bot
+
+[Timer]
+# Erster Lauf 11 Minuten nach Boot (versetzt zu den anderen Watchdogs).
+OnBootSec=11min
+OnUnitActiveSec=1h
+RandomizedDelaySec=5min
+AccuracySec=1min
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/deploy/shadowops-security-team.env.example
+++ b/deploy/shadowops-security-team.env.example
@@ -1,6 +1,8 @@
-# Security-Agent-Team (#290 P1) — wird von den systemd-Units via EnvironmentFile geladen.
+# Security-Agent-Team (#290 W1) — wird von den systemd-Units via EnvironmentFile geladen.
 # Kopieren nach ~/.config/shadowops-security-team.env und chmod 600.
 # Enthaelt KEINE echten Secrets im Repo — nur Platzhalter.
-SECURITY_ANALYST_DB_URL=postgresql://USER:PASSWORD@127.0.0.1:PORT/security_analyst
-REDIS_URL=redis://127.0.0.1:6379/0
+# DSN: identisch zu security_analyst.database_dsn in config/config.yaml.
+SECURITY_ANALYST_DB_URL=postgresql://security_analyst:PASSWORD@127.0.0.1:5433/security_analyst
+# ACHTUNG: guildscout-redis laeuft MIT requirepass — Passwort-Form ist Pflicht:
+REDIS_URL=redis://:REDIS_PASSWORD@127.0.0.1:6379/0
 SECURITY_TEAM_ENABLED=false

--- a/docs/plans/2026-07-09-security-agent-team-w1.md
+++ b/docs/plans/2026-07-09-security-agent-team-w1.md
@@ -534,8 +534,10 @@ cp ~/shadowops-bot/deploy/security-npm-audit-worker.service ~/.config/systemd/us
 cp ~/shadowops-bot/deploy/security-freshness-watchdog.service ~/.config/systemd/user/
 cp ~/shadowops-bot/deploy/security-freshness-watchdog.timer ~/.config/systemd/user/
 systemctl --user daemon-reload
-systemctl --user enable --now security-orchestrator security-npm-audit-worker security-freshness-watchdog.timer
+systemctl --user enable --now security-orchestrator security-npm-audit-worker
 ```
+
+> **Hinweis:** Der `security-freshness-watchdog.timer` wird hier bewusst NICHT mit-enabled — `sec_jobs` ist zu diesem Zeitpunkt noch leer, der Watchdog würde sofort einen Kaltstart-Alarm werfen (Alter „seit nie" → 999999h). Erst nach dem ersten erfolgreichen manuellen Trigger-Lauf aktivieren (siehe Step 7).
 
 - [ ] **Step 5: Smoke:** `systemctl --user status security-orchestrator security-npm-audit-worker` → beide `active (running)`, Journal zeigt `Orchestrator bereit — subscribed=sec:trigger` bzw. `npm_audit bereit`.
 - [ ] **Step 6: Manueller Trigger-Lauf:** `~/shadowops-bot/scripts/security-trigger.sh manual` → Ausgabe `an 1 Subscriber publiziert`; danach in der DB prüfen:
@@ -547,8 +549,9 @@ docker exec guildscout-postgres psql -U security_analyst -d security_analyst \
 
 Expected: 2 Rows (guildscout+zerodox), status `ok`/`partial`, completed_at gesetzt.
 
-- [ ] **Step 7: Watchdog-Staleness-Test:** einmalig mit `WATCHDOG_MAX_AGE_HOURS=0` laufen lassen (systemd-run oder env-Override) → Discord-Alarm in `#🩺-uptime-alerts` kommt; danach normaler Lauf → kein Alarm.
-- [ ] **Step 8: Crons eintragen** (Off-Minuten, bewusst NICHT :00/:30):
+- [ ] **Step 7: Watchdog-Timer erst jetzt aktivieren:** `systemctl --user enable --now security-freshness-watchdog.timer` (erst jetzt — Kaltstart-Alarm vermeiden, siehe Hinweis bei Step 4; `sec_jobs` hat durch Step 6 bereits frische Rows).
+- [ ] **Step 8: Watchdog-Staleness-Test:** einmalig mit `WATCHDOG_MAX_AGE_HOURS=0` laufen lassen (systemd-run oder env-Override) → Discord-Alarm in `#🩺-uptime-alerts` kommt; danach normaler Lauf → kein Alarm.
+- [ ] **Step 9: Crons eintragen** (Off-Minuten, bewusst NICHT :00/:30):
 
 ```
 23 5 * * * /home/cmdshadow/shadowops-bot/scripts/security-trigger.sh daily # Security-Team Daily-Trigger (W1, #290)
@@ -556,8 +559,8 @@ Expected: 2 Rows (guildscout+zerodox), status `ok`/`partial`, completed_at geset
 31 7 * * * /home/cmdshadow/shadowops-bot/scripts/security-soak-compare.sh # 7d-Soak Worker vs. Monolith (W1, #290)
 ```
 
-- [ ] **Step 9: Issue-#290-Kommentar** — W1 aktiv, Soak-Start-Datum + geplantes Soak-Ende (Start + 7 Tage), Verweis auf `logs/security-soak-w1.log`.
-- [ ] **Step 10: CLAUDE.md (shadowops-bot)** — Security-Team-Eintrag aktualisieren: W1 aktiv, Soak läuft, Flag-Standort, neue Crons + Watchdog dokumentieren.
+- [ ] **Step 10: Issue-#290-Kommentar** — W1 aktiv, Soak-Start-Datum + geplantes Soak-Ende (Start + 7 Tage), Verweis auf `logs/security-soak-w1.log`.
+- [ ] **Step 11: CLAUDE.md (shadowops-bot)** — Security-Team-Eintrag aktualisieren: W1 aktiv, Soak läuft, Flag-Standort, neue Crons + Watchdog dokumentieren.
 
 ---
 

--- a/scripts/security-job-reaper.sh
+++ b/scripts/security-job-reaper.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# security-job-reaper.sh — Bricht Zombie-Jobs (status='in_progress') in sec_jobs ab.
+# Worker, die hart sterben (OOM/SIGKILL), hinterlassen sonst ewige in_progress-Rows.
+# Muster: ~/agents/projects/seo/scripts/job-reaper.sh. Cron: taeglich (siehe W1-Ops).
+set -euo pipefail
+
+if ! docker ps >/dev/null 2>&1; then
+    exec sg docker -c "$0 ${*:-}"
+fi
+
+DB_CONTAINER="${DB_CONTAINER:-guildscout-postgres}"
+DB_USER="${DB_USER:-security_analyst}"
+DB_NAME="${DB_NAME:-security_analyst}"
+STALE_HOURS="${STALE_HOURS:-6}"
+LOG_FILE="/home/cmdshadow/shadowops-bot/logs/security-job-reaper.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+log() { echo "[$(date -Iseconds)] $*" | tee -a "$LOG_FILE" >&2; }
+
+reaped=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+  "UPDATE sec_jobs
+   SET status='cancelled', completed_at=NOW(),
+       error_message='job-reaper: in_progress > ${STALE_HOURS}h (Zombie)'
+   WHERE status='in_progress'
+     AND started_at < NOW() - make_interval(hours => ${STALE_HOURS})
+   RETURNING 1" | wc -l)
+
+log "Reaped: ${reaped} Zombie-Jobs (threshold=${STALE_HOURS}h)"

--- a/scripts/security-job-reaper.sh
+++ b/scripts/security-job-reaper.sh
@@ -5,6 +5,11 @@
 set -euo pipefail
 
 if ! docker ps >/dev/null 2>&1; then
+    if [ -n "${_SEC_SG_REEXEC:-}" ]; then
+        echo "FEHLER: docker weiterhin unerreichbar nach sg-Re-Exec — Abbruch." >&2
+        exit 3
+    fi
+    export _SEC_SG_REEXEC=1
     exec sg docker -c "$0 ${*:-}"
 fi
 
@@ -18,11 +23,14 @@ mkdir -p "$(dirname "$LOG_FILE")"
 log() { echo "[$(date -Iseconds)] $*" | tee -a "$LOG_FILE" >&2; }
 
 reaped=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
-  "UPDATE sec_jobs
-   SET status='cancelled', completed_at=NOW(),
-       error_message='job-reaper: in_progress > ${STALE_HOURS}h (Zombie)'
-   WHERE status='in_progress'
-     AND started_at < NOW() - make_interval(hours => ${STALE_HOURS})
-   RETURNING 1" | wc -l)
+  "WITH d AS (
+     UPDATE sec_jobs
+     SET status='cancelled', completed_at=NOW(),
+         error_message='job-reaper: in_progress > ${STALE_HOURS}h (Zombie)'
+     WHERE status='in_progress'
+       AND started_at < NOW() - make_interval(hours => ${STALE_HOURS})
+     RETURNING 1
+   )
+   SELECT count(*) FROM d")
 
 log "Reaped: ${reaped} Zombie-Jobs (threshold=${STALE_HOURS}h)"

--- a/scripts/security-soak-compare.sh
+++ b/scripts/security-soak-compare.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# security-soak-compare.sh — 7d-Soak W1: vergleicht npm-audit-Findings des
+# Team-Workers (session_id IS NULL) mit denen des Monolithen (session_id IS NOT NULL)
+# der letzten 24h anhand finding_fingerprint. Output → Log (Cron, taeglich).
+set -euo pipefail
+
+if ! docker ps >/dev/null 2>&1; then
+    exec sg docker -c "$0 ${*:-}"
+fi
+
+DB_CONTAINER="${DB_CONTAINER:-guildscout-postgres}"
+DB_USER="${DB_USER:-security_analyst}"
+DB_NAME="${DB_NAME:-security_analyst}"
+LOG_FILE="/home/cmdshadow/shadowops-bot/logs/security-soak-w1.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+psql_q() {
+    docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tAc "$1"
+}
+
+worker=$(psql_q "SELECT COUNT(DISTINCT finding_fingerprint) FROM findings
+    WHERE category LIKE '%npm%' AND session_id IS NULL
+      AND created_at > NOW() - INTERVAL '24 hours'")
+monolith=$(psql_q "SELECT COUNT(DISTINCT finding_fingerprint) FROM findings
+    WHERE category LIKE '%npm%' AND session_id IS NOT NULL
+      AND created_at > NOW() - INTERVAL '24 hours'")
+nur_worker=$(psql_q "SELECT COUNT(*) FROM (
+    SELECT DISTINCT finding_fingerprint FROM findings
+    WHERE category LIKE '%npm%' AND session_id IS NULL
+      AND created_at > NOW() - INTERVAL '24 hours'
+    EXCEPT
+    SELECT DISTINCT finding_fingerprint FROM findings
+    WHERE category LIKE '%npm%' AND session_id IS NOT NULL
+      AND created_at > NOW() - INTERVAL '24 hours') d")
+nur_monolith=$(psql_q "SELECT COUNT(*) FROM (
+    SELECT DISTINCT finding_fingerprint FROM findings
+    WHERE category LIKE '%npm%' AND session_id IS NOT NULL
+      AND created_at > NOW() - INTERVAL '24 hours'
+    EXCEPT
+    SELECT DISTINCT finding_fingerprint FROM findings
+    WHERE category LIKE '%npm%' AND session_id IS NULL
+      AND created_at > NOW() - INTERVAL '24 hours') d")
+
+echo "[$(date -Iseconds)] worker=${worker} monolith=${monolith} nur_worker=${nur_worker} nur_monolith=${nur_monolith}" \
+    | tee -a "$LOG_FILE"

--- a/scripts/security-soak-compare.sh
+++ b/scripts/security-soak-compare.sh
@@ -5,6 +5,11 @@
 set -euo pipefail
 
 if ! docker ps >/dev/null 2>&1; then
+    if [ -n "${_SEC_SG_REEXEC:-}" ]; then
+        echo "FEHLER: docker weiterhin unerreichbar nach sg-Re-Exec — Abbruch." >&2
+        exit 3
+    fi
+    export _SEC_SG_REEXEC=1
     exec sg docker -c "$0 ${*:-}"
 fi
 
@@ -20,26 +25,26 @@ psql_q() {
 
 worker=$(psql_q "SELECT COUNT(DISTINCT finding_fingerprint) FROM findings
     WHERE category LIKE '%npm%' AND session_id IS NULL
-      AND created_at > NOW() - INTERVAL '24 hours'")
+      AND found_at > NOW() - INTERVAL '24 hours'")
 monolith=$(psql_q "SELECT COUNT(DISTINCT finding_fingerprint) FROM findings
     WHERE category LIKE '%npm%' AND session_id IS NOT NULL
-      AND created_at > NOW() - INTERVAL '24 hours'")
+      AND found_at > NOW() - INTERVAL '24 hours'")
 nur_worker=$(psql_q "SELECT COUNT(*) FROM (
     SELECT DISTINCT finding_fingerprint FROM findings
     WHERE category LIKE '%npm%' AND session_id IS NULL
-      AND created_at > NOW() - INTERVAL '24 hours'
+      AND found_at > NOW() - INTERVAL '24 hours'
     EXCEPT
     SELECT DISTINCT finding_fingerprint FROM findings
     WHERE category LIKE '%npm%' AND session_id IS NOT NULL
-      AND created_at > NOW() - INTERVAL '24 hours') d")
+      AND found_at > NOW() - INTERVAL '24 hours') d")
 nur_monolith=$(psql_q "SELECT COUNT(*) FROM (
     SELECT DISTINCT finding_fingerprint FROM findings
     WHERE category LIKE '%npm%' AND session_id IS NOT NULL
-      AND created_at > NOW() - INTERVAL '24 hours'
+      AND found_at > NOW() - INTERVAL '24 hours'
     EXCEPT
     SELECT DISTINCT finding_fingerprint FROM findings
     WHERE category LIKE '%npm%' AND session_id IS NULL
-      AND created_at > NOW() - INTERVAL '24 hours') d")
+      AND found_at > NOW() - INTERVAL '24 hours') d")
 
 echo "[$(date -Iseconds)] worker=${worker} monolith=${monolith} nur_worker=${nur_worker} nur_monolith=${nur_monolith}" \
     | tee -a "$LOG_FILE"

--- a/scripts/security-trigger.sh
+++ b/scripts/security-trigger.sh
@@ -8,6 +8,11 @@ set -euo pipefail
 
 # Gruppen-Session-Drift: falls docker-Gruppe nicht aktiv, re-exec via sg
 if ! docker ps >/dev/null 2>&1; then
+    if [ -n "${_SEC_SG_REEXEC:-}" ]; then
+        echo "FEHLER: docker weiterhin unerreichbar nach sg-Re-Exec — Abbruch." >&2
+        exit 3
+    fi
+    export _SEC_SG_REEXEC=1
     exec sg docker -c "$0 ${*:-}"
 fi
 
@@ -20,8 +25,20 @@ TRIGGER="${1:-daily}"
 # Passwort aus REDIS_URL extrahieren (Form redis://:PASS@host:port/db)
 PASS=$(printf '%s' "${REDIS_URL:-}" | sed -n 's|redis://:\([^@]*\)@.*|\1|p')
 
-SUBS=$(docker exec guildscout-redis redis-cli ${PASS:+-a "$PASS"} --no-auth-warning \
-    publish sec:trigger "{\"trigger\":\"${TRIGGER}\"}")
+# Passwort NICHT via argv (-a) uebergeben (sichtbar in ps/argv) — stattdessen
+# REDISCLI_AUTH nur setzen, wenn ein Passwort vorhanden ist.
+if [ -n "$PASS" ]; then
+    SUBS=$(docker exec -e REDISCLI_AUTH="$PASS" guildscout-redis redis-cli --no-auth-warning \
+        publish sec:trigger "{\"trigger\":\"${TRIGGER}\"}")
+else
+    SUBS=$(docker exec guildscout-redis redis-cli --no-auth-warning \
+        publish sec:trigger "{\"trigger\":\"${TRIGGER}\"}")
+fi
+
+if ! [[ "${SUBS:-}" =~ ^[0-9]+$ ]]; then
+    echo "FEHLER: unerwartete redis-cli-Antwort: ${SUBS:-<leer>}" >&2
+    exit 5
+fi
 
 if [ "${SUBS:-0}" -eq 0 ]; then
     echo "FEHLER: 0 Subscriber auf sec:trigger — Security-Orchestrator laeuft nicht?" >&2

--- a/scripts/security-trigger.sh
+++ b/scripts/security-trigger.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# security-trigger.sh — publisht sec:trigger auf dem Job-Bus (guildscout-redis).
+# Externer Cron-Trigger statt Self-Retrigger im Prozess (crash-safe — Muster
+# aus ~/agents/projects/seo/scripts/trigger-audit.sh).
+# Exit 4 = 0 Subscriber → Orchestrator laeuft nicht (Alarm-Signal fuer Cron/Watchdog).
+# Aufruf: security-trigger.sh [daily|manual|<beliebig>]
+set -euo pipefail
+
+# Gruppen-Session-Drift: falls docker-Gruppe nicht aktiv, re-exec via sg
+if ! docker ps >/dev/null 2>&1; then
+    exec sg docker -c "$0 ${*:-}"
+fi
+
+ENV_FILE="$HOME/.config/shadowops-security-team.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a; . "$ENV_FILE"; set +a
+fi
+
+TRIGGER="${1:-daily}"
+# Passwort aus REDIS_URL extrahieren (Form redis://:PASS@host:port/db)
+PASS=$(printf '%s' "${REDIS_URL:-}" | sed -n 's|redis://:\([^@]*\)@.*|\1|p')
+
+SUBS=$(docker exec guildscout-redis redis-cli ${PASS:+-a "$PASS"} --no-auth-warning \
+    publish sec:trigger "{\"trigger\":\"${TRIGGER}\"}")
+
+if [ "${SUBS:-0}" -eq 0 ]; then
+    echo "FEHLER: 0 Subscriber auf sec:trigger — Security-Orchestrator laeuft nicht?" >&2
+    exit 4
+fi
+echo "sec:trigger (${TRIGGER}) an ${SUBS} Subscriber publiziert"

--- a/scripts/security-trigger.sh
+++ b/scripts/security-trigger.sh
@@ -25,11 +25,16 @@ TRIGGER="${1:-daily}"
 # Passwort aus REDIS_URL extrahieren (Form redis://:PASS@host:port/db)
 PASS=$(printf '%s' "${REDIS_URL:-}" | sed -n 's|redis://:\([^@]*\)@.*|\1|p')
 
-# Passwort NICHT via argv (-a) uebergeben (sichtbar in ps/argv) — stattdessen
-# REDISCLI_AUTH nur setzen, wenn ein Passwort vorhanden ist.
+# Passwort NICHT via argv uebergeben (sichtbar in ps/argv) — auch nicht als
+# "-e REDISCLI_AUTH=$PASS" (der Wert landet dabei ebenfalls in der host-argv
+# des docker-exec-Aufrufs, empirisch belegt). Stattdessen Name-only-Form:
+# "-e REDISCLI_AUTH" reicht den Wert aus der Shell-Umgebung durch, ohne dass
+# er als Argument erscheint.
 if [ -n "$PASS" ]; then
-    SUBS=$(docker exec -e REDISCLI_AUTH="$PASS" guildscout-redis redis-cli --no-auth-warning \
+    export REDISCLI_AUTH="$PASS"
+    SUBS=$(docker exec -e REDISCLI_AUTH guildscout-redis redis-cli --no-auth-warning \
         publish sec:trigger "{\"trigger\":\"${TRIGGER}\"}")
+    unset REDISCLI_AUTH
 else
     SUBS=$(docker exec guildscout-redis redis-cli --no-auth-warning \
         publish sec:trigger "{\"trigger\":\"${TRIGGER}\"}")

--- a/src/integrations/ai_engine.py
+++ b/src/integrations/ai_engine.py
@@ -911,7 +911,7 @@ class AIEngine:
 
         # Provider erstellen
         primary_cfg = ai_cfg.get('primary', {
-            'models': {'fast': 'gpt-4o', 'standard': 'gpt-5.3-codex', 'thinking': 'o3'},
+            'models': {'fast': 'gpt-4o', 'standard': 'gpt-5.5', 'thinking': 'o3'},
             'timeout': 60,
             'timeout_thinking': 300,
         })

--- a/src/integrations/ai_engine.py
+++ b/src/integrations/ai_engine.py
@@ -168,14 +168,14 @@ class CodexProvider:
 
     Modelle:
         fast     -> gpt-4o (schnell, guenstig)
-        standard -> gpt-5.3-codex (ausgewogen)
+        standard -> gpt-5.5 (ausgewogen)
         thinking -> o3 (tiefe Analyse, laengerer Timeout)
     """
 
     def __init__(self, config: dict):
         self.models = config.get('models', {
             'fast': 'gpt-4o',
-            'standard': 'gpt-5.3-codex',
+            'standard': 'gpt-5.5',
             'thinking': 'o3',
         })
         self.timeout = config.get('timeout', 60)
@@ -1394,7 +1394,7 @@ class AIEngine:
         prompt: str,
         timeout: int = 1800,
         max_turns: int = 25,
-        codex_model: str = 'gpt-5.3-codex',
+        codex_model: str = 'gpt-5.5',
         claude_model: str = 'claude-opus-4-6',
     ) -> Optional[Dict]:
         """
@@ -1407,7 +1407,7 @@ class AIEngine:
             prompt: Analyse-Prompt mit Aufgabenbeschreibung
             timeout: Maximale Laufzeit fuer Claude-Fallback (Default: 30 Min)
             max_turns: Maximale Tool-Aufrufe fuer Claude-Fallback (Default: 25)
-            codex_model: Codex-Modell (Default: gpt-5.3-codex)
+            codex_model: Codex-Modell (Default: gpt-5.5)
             claude_model: Claude-Fallback-Modell (Default: claude-opus-4-6)
 
         Returns:
@@ -1662,7 +1662,7 @@ class AIEngine:
         self,
         prompt: str,
         schema_path: str,
-        model: str = 'gpt-5.3-codex',
+        model: str = 'gpt-5.5',
         timeout: int = 900,
     ) -> Optional[Dict]:
         """Analyst-Session via Codex CLI (primaer).

--- a/src/integrations/analyst/security_analyst.py
+++ b/src/integrations/analyst/security_analyst.py
@@ -144,7 +144,7 @@ class SecurityAnalyst:
         )
 
         # Modelle aus Config (Codex primaer, Claude Fallback)
-        self.codex_model = analyst_cfg.get('model', 'gpt-5.3-codex')
+        self.codex_model = analyst_cfg.get('model', 'gpt-5.5')
         self.claude_model = analyst_cfg.get('fallback_model', 'claude-opus-4-6')
 
         # Datenbank-DSN: Priorität Config → Umgebungsvariable → Fehler

--- a/src/integrations/llm_fine_tuning.py
+++ b/src/integrations/llm_fine_tuning.py
@@ -289,7 +289,7 @@ Generated: {datetime.now(timezone.utc).isoformat()}
      primary:
        engine: codex
        models:
-         standard: gpt-5.3-codex
+         standard: gpt-5.5
    ```
 
 3. **Restart ShadowOps**:

--- a/src/integrations/security_engine/scan_agent.py
+++ b/src/integrations/security_engine/scan_agent.py
@@ -386,7 +386,7 @@ class SecurityScanAgent:
         self.max_sessions_per_day = analyst_cfg.get(
             'max_sessions_per_day', DEFAULT_MAX_SESSIONS_PER_DAY
         )
-        self.codex_model = analyst_cfg.get('model', 'gpt-5.3-codex')
+        self.codex_model = analyst_cfg.get('model', 'gpt-5.5')
         self.claude_model = analyst_cfg.get('fallback_model', 'claude-opus-4-6')
         self.maintenance_scan_days = analyst_cfg.get(
             'maintenance_scan_days', MAINTENANCE_SCAN_INTERVAL_DAYS

--- a/src/integrations/security_engine/team/orchestrator.py
+++ b/src/integrations/security_engine/team/orchestrator.py
@@ -53,6 +53,7 @@ class SecurityOrchestrator:
 
     async def handle_trigger(
         self, projects: dict[str, dict], active_workers: list[str],
+        trigger: str = "manual",
     ) -> list[SecurityJob]:
         """Fan-out: je aktivem Worker-Typ × Projekt (mit passendem <type>_path) ein Job."""
         jobs: list[SecurityJob] = []
@@ -63,6 +64,6 @@ class SecurityOrchestrator:
                     continue
                 jobs.append(await self.dispatch_job(
                     worker_type=worker_type, project=project,
-                    payload={"path": cfg[path_key]},
+                    payload={"path": cfg[path_key]}, trigger=trigger,
                 ))
         return jobs

--- a/src/integrations/security_engine/team/orchestrator_main.py
+++ b/src/integrations/security_engine/team/orchestrator_main.py
@@ -14,10 +14,10 @@ import signal
 
 import redis.asyncio as aioredis
 
-try:
-    from utils.config import Config
-except ImportError:  # Tests importieren via src.-Praefix
-    from src.utils.config import Config
+try:  # pragma: no cover - Import-Pfad haengt von pythonpath ab
+    from utils.config import get_config
+except ImportError:  # pragma: no cover
+    from src.utils.config import get_config  # type: ignore[no-redef]
 
 from ..db import SecurityDB
 from .orchestrator import SecurityOrchestrator
@@ -33,7 +33,7 @@ async def handle_trigger_message(orchestrator, config, raw) -> list:
     try:
         payload = json.loads(raw) if raw else {}
         if isinstance(payload, dict):
-            trigger = str(payload.get("trigger", "manual"))
+            trigger = str(payload.get("trigger") or "manual")
     except (json.JSONDecodeError, TypeError):
         logger.warning("Ungueltige sec:trigger-Payload: %r", raw)
     jobs = await orchestrator.handle_trigger(
@@ -50,7 +50,7 @@ async def _amain() -> None:
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
-    config = Config()
+    config = get_config()
     if not config.security_team_enabled:
         logger.info("security_team disabled — orchestrator exit")
         return

--- a/src/integrations/security_engine/team/orchestrator_main.py
+++ b/src/integrations/security_engine/team/orchestrator_main.py
@@ -1,13 +1,99 @@
-"""systemd-Entrypoint-Stub fuer den Security-Orchestrator (P1).
+"""systemd-Entrypoint: Security-Orchestrator mit sec:trigger-Subscribe-Loop (W1).
 
-P1 triggert manuell/per Test. Der dauerhafte sec:trigger-Subscribe-Loop wird
-in einer Folge-Iteration ergaenzt (analog runner._amain). Bis dahin beendet
-sich der Prozess sofort, wenn das Feature-Flag aus ist.
+Lauscht auf sec:trigger (Redis Pub/Sub) und faechert pro Trigger Jobs an die
+aktiven Worker auf (SecurityOrchestrator.handle_trigger). Result-Aggregation
++ Token-Cap-Enforcement folgen in W2. Muster: team/runner.py::_amain.
 """
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
 import os
+import signal
+
+import redis.asyncio as aioredis
+
+try:
+    from utils.config import Config
+except ImportError:  # Tests importieren via src.-Praefix
+    from src.utils.config import Config
+
+from ..db import SecurityDB
+from .orchestrator import SecurityOrchestrator
+
+logger = logging.getLogger("security.orchestrator.main")
+
+TRIGGER_CHANNEL = "sec:trigger"
+
+
+async def handle_trigger_message(orchestrator, config, raw) -> list:
+    """Verarbeitet EINE sec:trigger-Message. Ungueltige Payload → trigger='manual'."""
+    trigger = "manual"
+    try:
+        payload = json.loads(raw) if raw else {}
+        if isinstance(payload, dict):
+            trigger = str(payload.get("trigger", "manual"))
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Ungueltige sec:trigger-Payload: %r", raw)
+    jobs = await orchestrator.handle_trigger(
+        projects=config.security_team_projects,
+        active_workers=config.security_team_active_workers,
+        trigger=trigger,
+    )
+    logger.info("sec:trigger (%s) → %d Jobs dispatched", trigger, len(jobs))
+    return jobs
+
+
+async def _amain() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    config = Config()
+    if not config.security_team_enabled:
+        logger.info("security_team disabled — orchestrator exit")
+        return
+
+    dsn = os.environ.get("SECURITY_ANALYST_DB_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("SECURITY_ANALYST_DB_URL oder DATABASE_URL muss gesetzt sein")
+    redis_url = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
+
+    db = SecurityDB(dsn)
+    await db.initialize()
+    rconn = aioredis.from_url(redis_url, decode_responses=True)
+    orchestrator = SecurityOrchestrator(redis=rconn, db=db)
+
+    pubsub = rconn.pubsub()
+    await pubsub.subscribe(TRIGGER_CHANNEL)
+    logger.info("Orchestrator bereit — subscribed=%s", TRIGGER_CHANNEL)
+
+    stop = asyncio.Event()
+
+    def _graceful(*_):
+        logger.info("SIGTERM — fahre Orchestrator herunter")
+        stop.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _graceful)
+
+    try:
+        while not stop.is_set():
+            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+            if message is None or message.get("type") != "message":
+                continue
+            try:
+                await handle_trigger_message(orchestrator, config, message.get("data"))
+            except Exception:
+                # Ein kaputter Trigger darf den Loop nie beenden.
+                logger.exception("Trigger-Verarbeitung fehlgeschlagen")
+    finally:
+        await pubsub.unsubscribe(TRIGGER_CHANNEL)
+        await rconn.aclose()
+        await db.close()
+
 
 if __name__ == "__main__":
-    if os.environ.get("SECURITY_TEAM_ENABLED", "false").lower() not in ("1", "true", "yes", "on"):
-        print("security_team disabled — orchestrator exit")
-        raise SystemExit(0)
-    print("orchestrator P1-Stub: sec:trigger-Loop folgt in Folge-Iteration")
+    asyncio.run(_amain())

--- a/tests/unit/test_security_orchestrator.py
+++ b/tests/unit/test_security_orchestrator.py
@@ -42,3 +42,18 @@ async def test_handle_trigger_fans_out_per_project_with_path():
     assert len(jobs) == 2
     assert {j.project for j in jobs} == {"guildscout", "zerodox"}
     assert redis.publish.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_handle_trigger_reicht_trigger_typ_durch():
+    """handle_trigger(trigger='daily') muss den Trigger-Typ in die Jobs schreiben."""
+    orch = SecurityOrchestrator(redis=_redis(), db=_db())
+
+    jobs = await orch.handle_trigger(
+        projects={"zerodox": {"npm_audit_path": "/tmp/x"}},
+        active_workers=["npm_audit"],
+        trigger="daily",
+    )
+
+    assert len(jobs) == 1
+    assert jobs[0].trigger == "daily"

--- a/tests/unit/test_security_orchestrator_main.py
+++ b/tests/unit/test_security_orchestrator_main.py
@@ -1,0 +1,44 @@
+"""Tests für den Orchestrator-Entrypoint (sec:trigger-Loop, W1)."""
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.integrations.security_engine.team import orchestrator_main
+
+
+@pytest.mark.asyncio
+async def test_handle_trigger_message_daily():
+    """Gültige Payload → handle_trigger mit trigger='daily'."""
+    orch = MagicMock()
+    orch.handle_trigger = AsyncMock(return_value=[MagicMock(), MagicMock()])
+    config = MagicMock()
+    config.security_team_projects = {"zerodox": {"npm_audit_path": "/tmp/x"}}
+    config.security_team_active_workers = ["npm_audit"]
+
+    jobs = await orchestrator_main.handle_trigger_message(
+        orch, config, json.dumps({"trigger": "daily"})
+    )
+
+    assert len(jobs) == 2
+    orch.handle_trigger.assert_awaited_once_with(
+        projects=config.security_team_projects,
+        active_workers=["npm_audit"],
+        trigger="daily",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_trigger_message_kaputte_payload_faellt_auf_manual():
+    """Ungültiges JSON darf nicht crashen — Fallback trigger='manual'."""
+    orch = MagicMock()
+    orch.handle_trigger = AsyncMock(return_value=[])
+    config = MagicMock()
+    config.security_team_projects = {}
+    config.security_team_active_workers = []
+
+    await orchestrator_main.handle_trigger_message(orch, config, "{kaputt")
+
+    orch.handle_trigger.assert_awaited_once_with(
+        projects={}, active_workers=[], trigger="manual",
+    )

--- a/tests/unit/test_security_orchestrator_main.py
+++ b/tests/unit/test_security_orchestrator_main.py
@@ -42,3 +42,38 @@ async def test_handle_trigger_message_kaputte_payload_faellt_auf_manual():
     orch.handle_trigger.assert_awaited_once_with(
         projects={}, active_workers=[], trigger="manual",
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw", [None, ""])
+async def test_handle_trigger_message_leere_payload_faellt_auf_manual(raw):
+    """raw=None/"" (kein Redis-Payload-Body) darf nicht crashen — Fallback trigger='manual'."""
+    orch = MagicMock()
+    orch.handle_trigger = AsyncMock(return_value=[])
+    config = MagicMock()
+    config.security_team_projects = {}
+    config.security_team_active_workers = []
+
+    await orchestrator_main.handle_trigger_message(orch, config, raw)
+
+    orch.handle_trigger.assert_awaited_once_with(
+        projects={}, active_workers=[], trigger="manual",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_trigger_message_trigger_null_faellt_auf_manual():
+    """{"trigger": null} darf NICHT zu trigger='None' fuehren — Fallback trigger='manual'."""
+    orch = MagicMock()
+    orch.handle_trigger = AsyncMock(return_value=[])
+    config = MagicMock()
+    config.security_team_projects = {}
+    config.security_team_active_workers = []
+
+    await orchestrator_main.handle_trigger_message(
+        orch, config, json.dumps({"trigger": None})
+    )
+
+    orch.handle_trigger.assert_awaited_once_with(
+        projects={}, active_workers=[], trigger="manual",
+    )


### PR DESCRIPTION
## Zweck

Welle 1 des Security-Agent-Teams ([#290](https://github.com/Commandershadow9/shadowops-bot/issues/290)): Das P1-Fundament wird lauffähig gemacht und bekommt Selbstüberwachung. Spec: `docs/design/2026-07-09-security-agent-team-v2-spec.md`, Plan: `docs/plans/2026-07-09-security-agent-team-w1.md`.

## Änderungen

**Orchestrator (TDD):**
- `handle_trigger` reicht den Trigger-Typ in die Jobs durch (vorher ging er verloren)
- `orchestrator_main.py`: vom Exit-Stub zum echten `sec:trigger`-Subscribe-Loop (Feature-Flag-Gate, Graceful Shutdown, ein fehlerhafter Trigger beendet den Loop nie)

**Konfiguration:**
- `config.example.yaml`: zerodox-Scan-Pfad korrigiert (Lockfile liegt im `web/`-Unterverzeichnis)
- `deploy/shadowops-security-team.env.example`: Redis-URL-Platzhalter jetzt mit Auth-Form (der produktive Redis verlangt ein Passwort)

**Betriebs-Scripts (`scripts/`):**
- `security-trigger.sh` — crash-sicherer externer Trigger für den Job-Bus (Exit 4 bei 0 Subscribern = totes Team)
- `security-job-reaper.sh` — räumt Zombie-Jobs (`in_progress` nach hartem Worker-Tod) auf
- `security-soak-compare.sh` — täglicher Soak-Vergleich Worker vs. Monolith über Finding-Fingerprints

**Selbstüberwachung:**
- `deploy/security-freshness-watchdog.{service,timer}` — prüft den letzten **erfolgreichen Lauf in der DB** statt nur Prozess-State (Lehre aus zwei stillen Ausfällen)

**Hygiene:**
- Veraltete Modell-Default-Strings repo-weit auf das aktuell unterstützte Modell gezogen (nur dormante Code-Defaults, keine Test-Fixtures)

## Qualitätssicherung

- Zweistufig reviewt (Spec-Compliance + Code-Qualität, je zwei Runden). Die Reviews fanden u.a. einen CRITICAL (falscher Spaltenname im Soak-Vergleich — empirisch verifiziert) und einen IMPORTANT (Off-by-one in der Reaper-Zählung durch psql-Command-Tag) — beide gefixt.
- Härtungen aus dem Review: Redis-Passwort via Name-only-Env statt argv, Re-Exec-Loop-Guard, Numerik-Guard.
- Tests: alle 7 Team-Suiten einzeln grün (29 passed, 0 failed), neue Regressionstests per TDD (rot-vor-Fix verifiziert).

## Betrieb

Die Aktivierung (env-Datei, Live-Config, Unit-Installation, Trigger, 7-Tage-Soak) erfolgt nach dem Merge durch den Betreiber — Schritte in `docs/plans/2026-07-09-security-agent-team-w1.md`, Task 9. Wichtig: Der Watchdog-Timer wird erst nach dem ersten erfolgreichen Lauf aktiviert (Kaltstart-Alarm).

Refs #290 (W1 von 5 — Issue bleibt offen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
