### PR TITLE
fix: ZERODOX-Deploy Re-Poll + buildSha-Drift-Backstop (ZERODOX#1720)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -360,6 +360,40 @@ projects:
       - "zerodox-support-agent"
       - "seo-agent"
 
+  # === ZERODOX ===
+  # Hinweis: dieses Beispiel zeigt nur den fuer den buildSha-Drift-Backstop
+  # (Issue #1720) relevanten Ausschnitt. Im echten (gitignored) config.yaml
+  # existiert der zerodox-Projektblock bereits (Webhook-Auto-Deploy laeuft
+  # ja schon) — hier nur den `checks:`-Eintrag unter dem bestehenden
+  # `monitor:`-Knoten ergaenzen, nicht den ganzen Block ersetzen.
+  zerodox:
+    enabled: true
+    tag: "[ZERODOX]"
+    path: "/home/cmdshadow/ZERODOX"
+    repo_url: "https://github.com/Commandershadow9/ZERODOX"
+    services:
+      - "zerodox-web"
+    critical: true
+    monitor:
+      enabled: true
+      checks:
+        # buildSha-Drift-Backstop (Issue #1720): Fallback-Netz FALLS der
+        # Re-Poll nach Deploy (ci_mixin.py, _repoll_after_deploy) das aktive
+        # Nachholen verpasst (z.B. Repoll-Rundenlimit erschoepft, Working-
+        # Tree-Guard bricht wiederholt ab). Meldet nur, deployt NICHT selbst
+        # (heal: alert-only) — Skript unterscheidet dabei benignen
+        # Docs-only-Drift (Allowlist identisch zu ZERODOX/scripts/deploy.sh
+        # Issue #1262: docs/**, .claude/**, Top-Level *.md) von echtem,
+        # deploy-relevantem Drift. flake_polls=7 * interval=300s ≈ 35 Min
+        # Persistenz vor Alert (liegt im Issue-Zielkorridor 30-45 Min).
+        - id: zerodox-build-drift
+          type: script
+          target: "/home/cmdshadow/shadowops-bot/scripts/zerodox-build-drift-check.py"
+          interval: 300
+          timeout: 30
+          flake_polls: 7
+          heal: { action: alert-only }
+
   # === MAYDAY SIM ===
   mayday_sim:
     enabled: true

--- a/scripts/zerodox-build-drift-check.py
+++ b/scripts/zerodox-build-drift-check.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+zerodox-build-drift-check.py — buildSha-Drift-Backstop fuer ZERODOX (stdlib-only).
+
+Hintergrund (ZERODOX-Issue #1720): bei schnell aufeinanderfolgenden main-Pushes
+kann der Bot-Webhook-Trigger einen Deploy verpassen (Race im Deploy-Lock) oder
+der Working-Tree-Guard bricht einen Deploy ab, ohne dass spaeter automatisch
+nachgeholt wird. Ergebnis: `origin/main` laeuft von der laufenden Produktion
+weg, ohne dass irgendjemand das merkt. Dieses Skript ist der Backstop dafuer —
+es vergleicht periodisch den live `buildSha` (aus `/api/health`) gegen den
+`origin/main`-HEAD des lokalen ZERODOX-Repos.
+
+Wird als `type: script`-Check im deklarativen Check-Engine (project_monitor.py)
+eingehaengt (siehe config/config.example.yaml, Sektion `projects.zerodox.monitor.checks`).
+Exit 0 = OK, Exit != 0 = FAIL (Message = stderr, von check_runner._run_script
+auf 200 Zeichen gekappt). Die Flake-Filter-Toleranz (`flake_polls`) UND die
+Alert-Infrastruktur (Discord, Anti-Spam-Cooldown) kommen komplett aus dem
+bestehenden Check-Engine — dieses Skript enthaelt bewusst KEIN eigenes
+State-File, keinen eigenen Discord-Call, keinen eigenen Timer.
+
+WICHTIGER DESIGN-PUNKT (PFLICHT-Hinweis aus Issue-Kommentar 2026-07-08):
+Nicht jeder buildSha-Unterschied ist ein Fehler. `ZERODOX/scripts/deploy.sh`
+hat seit Issue #1262 einen dokumentierten Docs-only-Graceful-Skip: ein Commit,
+der AUSSCHLIESSLICH nicht-deploy-relevante Pfade aendert (Top-Level *.md,
+docs/**, .claude/**), wird von deploy.sh bewusst NICHT deployt (Runtime bleibt
+unveraendert) — daher bleibt buildSha dort absichtlich hinter origin/main
+zurueck. Dieses Skript uebernimmt exakt dieselbe Allowlist-Regex wie
+deploy.sh (dort: `grep -vE '^(docs/|\\.claude/|[^/]+\\.md$)'`), damit beide
+Stellen konsistent bewerten, was "deploy-relevant" heisst. Bei Aenderung der
+Allowlist in deploy.sh MUSS diese Kopie synchron gehalten werden (siehe
+NON_DEPLOY_RELEVANT_RE unten).
+
+Fail-Open vs. Fail-Safe (bewusst unterschiedlich, je nach Fehlerquelle):
+  - `/api/health` nicht erreichbar / buildSha fehlt / "unknown"
+    -> Fail-OPEN (exit 0). Erreichbarkeit von zerodox.de wird bereits von
+       `zerodox-watchdog` ueberwacht (siehe infrastructure.md Watchdog-Tabelle)
+       — ein zweiter Alarm fuer denselben Ausfall waere reines Rauschen.
+  - `git fetch`/`git rev-parse`/`git diff` im lokalen Repo schlaegt fehl
+    -> Fail-SAFE (exit 1, FAIL). Das ist NICHT redundant abgedeckt und
+       entspricht genau der Fail-Safe-Philosophie, die deploy.sh selbst fuer
+       den analogen Fall dokumentiert ("im Zweifel NICHT als docs-only werten").
+
+ENV-Overrides:
+  ZERODOX_HEALTH_URL          Health-Endpoint (default https://zerodox.de/api/health)
+  ZERODOX_REPO_PATH           Lokaler Repo-Pfad (default /home/cmdshadow/ZERODOX)
+  ZERODOX_HEALTH_TIMEOUT_SEC  HTTP-Timeout Sekunden (default 10)
+  ZERODOX_GIT_TIMEOUT_SEC     Timeout pro Git-Kommando Sekunden (default 15)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from urllib import error, request
+
+# ─── Konfig ──────────────────────────────────────────────────────────────────
+HEALTH_URL = os.environ.get("ZERODOX_HEALTH_URL", "https://zerodox.de/api/health")
+REPO_PATH = os.environ.get("ZERODOX_REPO_PATH", "/home/cmdshadow/ZERODOX")
+HEALTH_TIMEOUT_SEC = float(os.environ.get("ZERODOX_HEALTH_TIMEOUT_SEC", "10"))
+GIT_TIMEOUT_SEC = float(os.environ.get("ZERODOX_GIT_TIMEOUT_SEC", "15"))
+
+# Identisch zu ZERODOX/scripts/deploy.sh (Issue #1262, "DEPLOY_RELEVANT="-Zeile):
+# nicht-deploy-relevant = Top-Level *.md, docs/**, .claude/**. Alles andere
+# (insbesondere web/**, auch web/**/*.md wie Blog-Posts) gilt als deploy-relevant.
+NON_DEPLOY_RELEVANT_RE = re.compile(r"^(docs/|\.claude/|[^/]+\.md$)")
+
+
+def fetch_live_build_sha(url: str, timeout: float) -> "str | None":
+    """Holt buildSha aus /api/health. None bei jedem Fehler (fail-open-Fall)."""
+    try:
+        with request.urlopen(url, timeout=timeout) as resp:
+            if resp.status != 200:
+                print(f"[drift-check] /api/health HTTP {resp.status}", file=sys.stderr)
+                return None
+            body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (error.URLError, error.HTTPError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        print(f"[drift-check] /api/health nicht erreichbar/ungueltig: {e}", file=sys.stderr)
+        return None
+
+    sha = body.get("buildSha")
+    if not sha or sha == "unknown":
+        print(f"[drift-check] buildSha fehlt oder 'unknown' (Alt-Image?): {sha!r}", file=sys.stderr)
+        return None
+    return sha
+
+
+def run_git(args: list, timeout: float) -> "tuple[bool, str]":
+    """Fuehrt `git -C REPO_PATH <args>` aus. Rueckgabe (ok, stdout-oder-stderr)."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", REPO_PATH, *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return False, str(e)
+    if proc.returncode != 0:
+        return False, proc.stderr.strip()
+    return True, proc.stdout.strip()
+
+
+def deploy_relevant_paths(changed_paths: list) -> list:
+    """Filtert die Docs-only-Allowlist raus (Analog zu deploy.sh grep -vE)."""
+    return [p for p in changed_paths if p and not NON_DEPLOY_RELEVANT_RE.match(p)]
+
+
+def main() -> int:
+    live_sha = fetch_live_build_sha(HEALTH_URL, HEALTH_TIMEOUT_SEC)
+    if not live_sha:
+        # Fail-open: Erreichbarkeit wird schon von zerodox-watchdog abgedeckt.
+        print("[drift-check] OK (fail-open): buildSha nicht bestimmbar, kein Alarm hier.")
+        return 0
+
+    fetch_ok, fetch_msg = run_git(["fetch", "origin", "main"], GIT_TIMEOUT_SEC)
+    if not fetch_ok:
+        print(f"[drift-check] Warnung: git fetch origin main fehlgeschlagen: {fetch_msg}", file=sys.stderr)
+        # Weiter versuchen mit dem, was lokal an origin/main bekannt ist —
+        # falls das auch fehlschlaegt, greift der Fail-Safe-Zweig unten.
+
+    rev_ok, origin_sha = run_git(["rev-parse", "origin/main"], GIT_TIMEOUT_SEC)
+    if not rev_ok:
+        # Fail-safe: lokales Repo nicht auswertbar -> nicht stillschweigend OK.
+        print(
+            f"[drift-check] FAIL: origin/main HEAD nicht bestimmbar "
+            f"(fetch_ok={fetch_ok}): {origin_sha}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if live_sha == origin_sha:
+        print(f"[drift-check] OK: buildSha aktuell ({live_sha[:12]})")
+        return 0
+
+    diff_ok, diff_out = run_git(["diff", "--name-only", live_sha, origin_sha], GIT_TIMEOUT_SEC)
+    if not diff_ok:
+        # Fail-safe, analog deploy.sh-Kommentar: nach force-push/rebase evtl.
+        # live_sha nicht mehr im lokalen Repo -> "im Zweifel NICHT als
+        # docs-only werten", sondern alarmieren.
+        print(
+            f"[drift-check] FAIL: git diff {live_sha[:12]}..{origin_sha[:12]} "
+            f"fehlgeschlagen (evtl. force-push/rebase): {diff_out}",
+            file=sys.stderr,
+        )
+        return 1
+
+    changed_paths = [p for p in diff_out.splitlines() if p]
+    relevant = deploy_relevant_paths(changed_paths)
+    if not relevant:
+        print(
+            f"[drift-check] OK: buildSha {live_sha[:12]} != origin/main {origin_sha[:12]}, "
+            f"aber nur nicht-deploy-relevante Pfade geaendert ({len(changed_paths)} Datei(en), "
+            f"docs-only wie deploy.sh #1262)."
+        )
+        return 0
+
+    preview = ", ".join(relevant[:5])
+    more = f" (+{len(relevant) - 5} weitere)" if len(relevant) > 5 else ""
+    print(
+        f"[drift-check] FAIL: buildSha-Drift live={live_sha[:12]} "
+        f"origin/main={origin_sha[:12]}, {len(relevant)} deploy-relevante Datei(en): "
+        f"{preview}{more}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/integrations/github_integration/ci_mixin.py
+++ b/src/integrations/github_integration/ci_mixin.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
 import aiohttp
@@ -20,6 +21,11 @@ _CI_FAILURE_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out", "actio
 # Stati, die als "running" gelten — alle anderen Werte fallen durch
 # `status != 'completed'` weiter in den Poll-Loop.
 _CI_RUNNING_STATI = frozenset({"queued", "in_progress", "requested", "waiting", "pending"})
+
+# ZERODOX#1720: Default-Obergrenze fuer Re-Poll-Runden nach einem erfolgreichen
+# Deploy (Schleifen-Schutz). Ueberschreibbar per Projekt via
+# deploy.repoll_max_rounds.
+_DEFAULT_REPOLL_MAX_ROUNDS = 2
 
 
 class CIMixin:
@@ -478,12 +484,21 @@ class CIMixin:
         commit_sha: str,
         repo_full_name: Optional[str] = None,
         full_sha: Optional[str] = None,
+        _repoll_round: int = 0,
     ):
         """
         Trigger deployment for a repository
 
         Welle 9.10 (2026-05-11): Wartet auf CI-Completion bevor deploy.sh
         getriggert wird. Verhindert Race Condition aus dem 58h-Vorfall.
+
+        ZERODOX#1720: Nach einem erfolgreichen (Nicht-Self-)Deploy prueft
+        `_repoll_after_deploy`, ob origin/<branch> inzwischen weiter ist als
+        der gerade deployte Commit — z.B. weil waehrend des Deploy-Fensters
+        ein zweiter Push/PR-Merge durch den "already in progress"-Guard in
+        deploy_project() stillschweigend verworfen wurde. Falls ja, wird
+        rekursiv ein weiterer Deploy angestossen (Schleifen-Schutz via
+        _repoll_round / deploy.repoll_max_rounds).
 
         Args:
             repo_name: Name of the repository (e.g. "ZERODOX")
@@ -492,6 +507,9 @@ class CIMixin:
             repo_full_name: e.g. "Commandershadow9/ZERODOX". Wenn None, wird Wait
                             uebersprungen (Backward-Compat fuer alte Caller).
             full_sha: 40-char SHA. Wenn None, wird Wait uebersprungen.
+            _repoll_round: Interner Zaehler fuer Re-Poll-Rekursion (ZERODOX#1720).
+                           Nicht von aussen setzen — wird nur von
+                           _repoll_after_deploy hochgezaehlt.
         """
         if not self.deployment_manager:
             self.logger.warning("⚠️ No deployment manager configured")
@@ -580,8 +598,104 @@ class CIMixin:
 
             if result['success']:
                 self.logger.info(f"✅ Deployment erfolgreich: {repo_name}")
+                # ZERODOX#1720: Re-Poll — self-deploy hat einen imminenten
+                # Prozess-Restart geplant (deployment_manager), daher hier bewusst
+                # ausgenommen (kein sinnvoller Folge-Check moeglich/noetig).
+                if not is_self_deploy:
+                    await self._repoll_after_deploy(
+                        repo_name=repo_name,
+                        branch=branch,
+                        project_config=project_config,
+                        repo_full_name=repo_full_name,
+                        repoll_round=_repoll_round,
+                    )
             else:
                 self.logger.warning(f"⚠️ Deployment fehlgeschlagen: {repo_name}")
 
         except Exception as e:
             self.logger.error(f"❌ Deployment Fehler: {e}", exc_info=True)
+
+    async def _repoll_after_deploy(
+        self,
+        repo_name: str,
+        branch: str,
+        project_config: Optional[Dict],
+        repo_full_name: Optional[str],
+        repoll_round: int,
+    ) -> None:
+        """
+        ZERODOX#1720: Re-Poll nach abgeschlossenem Deploy.
+
+        Prueft, ob origin/<branch> inzwischen weiter ist als der gerade
+        deployte Commit (deploy_project() hat das lokale Repo bereits per
+        `git pull` aktualisiert, HEAD ist also der deployte Stand). Ursache
+        eines solchen Drifts ist typischerweise der `active_deployments`-Guard
+        in deployment_manager.deploy_project(): ein zweiter Push/PR-Merge, der
+        waehrend eines laufenden Deploys eintrifft, wird dort mit
+        {'success': False, 'error': 'Deployment already in progress ...'}
+        stillschweigend verworfen (kein Retry, kein Discord-Alert). Der
+        Re-Poll heilt diesen Fall, indem er nach Abschluss des ersten Deploys
+        prueft, ob origin/<branch> vorausgelaufen ist, und in diesem Fall
+        einen weiteren, ganz normalen Deploy ueber _trigger_deployment
+        anstoesst (inkl. CI-Wait + Per-SHA-Dedup via _reserve_deploy).
+
+        Schleifen-Schutz: bricht nach `deploy.repoll_max_rounds` (Default
+        `_DEFAULT_REPOLL_MAX_ROUNDS`) Runden in Folge ab, statt endlos zu
+        re-pollen, falls origin/<branch> kontinuierlich weiterwaechst.
+        """
+        if not project_config:
+            return
+
+        deploy_config = project_config.get('deploy', {})
+        if not deploy_config.get('repoll_enabled', True):
+            return
+
+        repo_path_raw = project_config.get('path')
+        if not repo_path_raw:
+            return
+        repo_path = Path(repo_path_raw)
+        if not repo_path.exists():
+            return
+
+        max_rounds = int(deploy_config.get('repoll_max_rounds', _DEFAULT_REPOLL_MAX_ROUNDS))
+        if repoll_round >= max_rounds:
+            self.logger.warning(
+                f"⚠️ Re-Poll-Limit erreicht fuer {repo_name} ({max_rounds} Runde(n)) — "
+                f"breche ab. Falls origin/{branch} weiterhin voraus ist, greift "
+                f"spaetestens der buildSha-Drift-Watchdog als Backstop."
+            )
+            return
+
+        if not self._safe_git_fetch(repo_path):
+            return
+
+        deployed_sha = self._get_commit_sha(repo_path, 'HEAD')
+        remote_sha = self._get_commit_sha(repo_path, f'origin/{branch}')
+
+        if not deployed_sha or not remote_sha or deployed_sha == remote_sha:
+            return  # nichts verpasst, oder SHAs nicht ermittelbar
+
+        self.logger.info(
+            f"🔁 Re-Poll: origin/{branch} ({remote_sha[:7]}) ist weiter als der "
+            f"gerade deployte Stand ({deployed_sha[:7]}) fuer {repo_name} — "
+            f"starte Runde {repoll_round + 1}/{max_rounds}."
+        )
+
+        # Dieselbe Per-SHA-Dedup wie bei normalen Webhook-Triggern nutzen:
+        # falls der normale push/pull_request-Handler diesen SHA parallel
+        # bereits reserviert hat, hier NICHT doppelt deployen.
+        if not self._reserve_deploy(repo_name, remote_sha):
+            self.logger.info(
+                f"ℹ️ Re-Poll: {repo_name}@{remote_sha[:7]} bereits durch einen "
+                f"anderen Trigger reserviert — kein doppelter Re-Poll-Deploy."
+            )
+            return
+
+        await self._trigger_deployment(
+            repo_name=repo_name,
+            branch=branch,
+            commit_sha=remote_sha[:7],
+            repo_full_name=repo_full_name,
+            full_sha=remote_sha,
+            _repoll_round=repoll_round + 1,
+        )

--- a/tests/unit/test_zerodox_build_drift_check.py
+++ b/tests/unit/test_zerodox_build_drift_check.py
@@ -1,0 +1,136 @@
+"""Tests fuer scripts/zerodox-build-drift-check.py — buildSha-Drift-Backstop
+(ZERODOX#1720, Teil 2).
+
+Der Kernpunkt ist die Docs-only-Ausnahme aus dem Issue-Kommentar 2026-07-08:
+ein buildSha-Unterschied ist NUR dann ein Alarm wert, wenn zwischen dem
+deployten und dem origin/main-Commit auch deploy-relevante Pfade geaendert
+wurden (Allowlist identisch zu ZERODOX/scripts/deploy.sh, Issue #1262).
+
+Geladen wird das Script (Dateiname mit Bindestrich) per importlib — siehe
+test_ki_cost_watchdog.py fuer das Vorbild. `main()` ruft die Modul-Funktionen
+`fetch_live_build_sha`/`run_git` ueber die Modul-Globals auf, daher reicht
+`monkeypatch.setattr(mod, "...", stub)`, ohne echtes Netzwerk/subprocess.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "zerodox-build-drift-check.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("zerodox_build_drift_check", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _stub_run_git(fetch_ok=True, rev_ok=True, rev_out="origin1234567", diff_ok=True, diff_out=""):
+    """Baut einen run_git-Stub, der je nach aufgerufenem Git-Subkommando
+    (args[0]) eine unterschiedliche (ok, output)-Antwort liefert."""
+
+    def _run_git(args, timeout):
+        cmd = args[0]
+        if cmd == "fetch":
+            return fetch_ok, "" if fetch_ok else "fetch fehlgeschlagen"
+        if cmd == "rev-parse":
+            return rev_ok, rev_out if rev_ok else "unknown revision"
+        if cmd == "diff":
+            return diff_ok, diff_out if diff_ok else "bad object (force-push?)"
+        raise AssertionError(f"unerwartetes Git-Subkommando in Test-Stub: {cmd}")
+
+    return _run_git
+
+
+# ─── deploy_relevant_paths (reine Logik, kein Monkeypatch noetig) ───────────
+
+def test_deploy_relevant_paths_filters_docs_only():
+    mod = _load()
+    changed = [
+        "docs/PROJECT_TIMELINE.md",
+        ".claude/rules/safety.md",
+        "CHANGELOG.md",
+        "web/src/app/page.tsx",
+    ]
+    assert mod.deploy_relevant_paths(changed) == ["web/src/app/page.tsx"]
+
+
+def test_deploy_relevant_paths_web_markdown_is_relevant():
+    """Ein *.md UNTER web/ (z.B. ein Blog-Post-Content-File) ist NICHT die
+    Top-Level-Doku-Ausnahme -> gilt als deploy-relevant."""
+    mod = _load()
+    changed = ["web/content/blog/neuer-post.md"]
+    assert mod.deploy_relevant_paths(changed) == changed
+
+
+def test_deploy_relevant_paths_all_docs_only_returns_empty():
+    mod = _load()
+    changed = ["docs/a.md", "docs/b/c.md", ".claude/rules/x.md", "README.md"]
+    assert mod.deploy_relevant_paths(changed) == []
+
+
+# ─── main() Kontrollfluss (mit gestubbtem fetch/run_git) ────────────────────
+
+def test_main_ok_when_shas_equal(monkeypatch):
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: "abc1234567")
+    monkeypatch.setattr(mod, "run_git", _stub_run_git(rev_out="abc1234567"))
+    assert mod.main() == 0
+
+
+def test_main_ok_docs_only_diff(monkeypatch):
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: "abc1234567")
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        _stub_run_git(rev_out="def7654321", diff_out="docs/PROJECT_TIMELINE.md\nREADME.md\n"),
+    )
+    assert mod.main() == 0
+
+
+def test_main_fail_web_path_diff(monkeypatch):
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: "abc1234567")
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        _stub_run_git(rev_out="def7654321", diff_out="docs/x.md\nweb/src/app/page.tsx\n"),
+    )
+    assert mod.main() == 1
+
+
+def test_main_fail_open_health_unreachable(monkeypatch):
+    """Health-Endpoint kaputt/unbekannt -> fail-open (bereits durch
+    zerodox-watchdog abgedeckt, kein Doppel-Alarm)."""
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: None)
+    assert mod.main() == 0
+
+
+def test_main_fail_safe_rev_parse_fails(monkeypatch):
+    """Lokales Repo nicht auswertbar (origin/main HEAD unbekannt) -> fail-safe,
+    NICHT stillschweigend OK."""
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: "abc1234567")
+    monkeypatch.setattr(mod, "run_git", _stub_run_git(rev_ok=False))
+    assert mod.main() == 1
+
+
+def test_main_fail_safe_when_diff_fails(monkeypatch):
+    """git diff schlaegt fehl (z.B. live_sha nach force-push/rebase nicht mehr
+    lokal bekannt) -> fail-safe, nicht als docs-only werten."""
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: "abc1234567")
+    monkeypatch.setattr(mod, "run_git", _stub_run_git(rev_out="def7654321", diff_ok=False))
+    assert mod.main() == 1
+
+
+def test_main_tolerates_fetch_failure_if_rev_parse_still_works(monkeypatch):
+    """git fetch schlaegt fehl, aber origin/main ist lokal noch von einem
+    frueheren Fetch bekannt -> main() darf trotzdem auswerten (Warnung statt
+    Abbruch), Fail-Safe greift erst wenn rev-parse selbst scheitert."""
+    mod = _load()
+    monkeypatch.setattr(mod, "fetch_live_build_sha", lambda url, timeout: "abc1234567")
+    monkeypatch.setattr(mod, "run_git", _stub_run_git(fetch_ok=False, rev_out="abc1234567"))
+    assert mod.main() == 0

--- a/tests/unit/test_zerodox_deploy_repoll.py
+++ b/tests/unit/test_zerodox_deploy_repoll.py
@@ -1,0 +1,174 @@
+"""Tests fuer den Re-Poll-nach-Deploy-Backstop (ZERODOX#1720, Teil 1).
+
+Symptom: der `active_deployments`-Guard in DeploymentManager.deploy_project()
+verwirft einen zweiten Push/PR-Merge, der waehrend eines laufenden Deploys
+eintrifft, still ({'success': False, 'error': 'Deployment already in
+progress...'}) — kein Retry, kein Alert. `_repoll_after_deploy` (ci_mixin.py)
+prueft nach jedem erfolgreichen Deploy, ob origin/<branch> inzwischen weiter
+ist als der gerade deployte Commit, und stoesst in diesem Fall ueber
+_trigger_deployment einen weiteren normalen Deploy an (Schleifen-Schutz via
+repoll_max_rounds, Dedup via _reserve_deploy).
+"""
+import logging
+
+import pytest
+
+from src.integrations.github_integration.ci_mixin import CIMixin
+from src.integrations.github_integration.state_mixin import StateMixin
+
+
+class _RepollHarness(CIMixin, StateMixin):
+    """Minimaler Harness: _repoll_after_deploy braucht Logger, die beiden
+    Git-Methoden (hier gestubbt statt echtem subprocess) und _reserve_deploy
+    (echt aus StateMixin). _trigger_deployment wird gespyt statt rekursiv
+    echt auszufuehren."""
+
+    def __init__(self, shas: dict, fetch_ok: bool = True):
+        self.logger = logging.getLogger("test-repoll")
+        self._shas = shas  # {"HEAD": sha, "origin/main": sha}
+        self._fetch_ok = fetch_ok
+        self.trigger_calls: list = []
+
+    def _normalize_repo_name(self, name: str) -> str:
+        return name.lower().replace("-", "_")
+
+    def _safe_git_fetch(self, repo_path) -> bool:
+        return self._fetch_ok
+
+    def _get_commit_sha(self, repo_path, ref: str):
+        return self._shas.get(ref)
+
+    async def _trigger_deployment(self, **kwargs):
+        self.trigger_calls.append(kwargs)
+
+
+def _project_config(path, **deploy_overrides) -> dict:
+    return {"path": str(path), "deploy": deploy_overrides}
+
+
+@pytest.mark.asyncio
+async def test_repoll_noop_when_shas_equal(tmp_path):
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "aaa1111"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(tmp_path),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_triggers_when_remote_ahead(tmp_path):
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(tmp_path),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert len(h.trigger_calls) == 1
+    call = h.trigger_calls[0]
+    assert call["repo_name"] == "ZERODOX"
+    assert call["full_sha"] == "bbb2222"
+    assert call["commit_sha"] == "bbb2222"[:7]
+    assert call["_repoll_round"] == 1
+    assert call["repo_full_name"] == "Commandershadow9/ZERODOX"
+
+
+@pytest.mark.asyncio
+async def test_repoll_respects_max_rounds(tmp_path):
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(tmp_path, repoll_max_rounds=2),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=2,  # bereits am Limit
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_disabled_via_config(tmp_path):
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(tmp_path, repoll_enabled=False),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_noop_without_project_config():
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=None,
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_noop_without_path():
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config={"deploy": {}},  # kein 'path'-Key
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_noop_when_path_missing(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(missing),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_noop_when_git_fetch_fails(tmp_path):
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"}, fetch_ok=False)
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(tmp_path),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []
+
+
+@pytest.mark.asyncio
+async def test_repoll_dedup_via_reserve_deploy(tmp_path):
+    """Ein anderer Trigger (z.B. ein parallel eingetroffener normaler
+    Webhook fuer denselben Ziel-Commit) hat den SHA schon reserviert -> der
+    Re-Poll darf NICHT nochmal deployen (sonst Doppel-Deploy)."""
+    h = _RepollHarness(shas={"HEAD": "aaa1111", "origin/main": "bbb2222"})
+    assert h._reserve_deploy("ZERODOX", "bbb2222") is True  # simuliert Fremd-Reservierung
+    await h._repoll_after_deploy(
+        repo_name="ZERODOX",
+        branch="main",
+        project_config=_project_config(tmp_path),
+        repo_full_name="Commandershadow9/ZERODOX",
+        repoll_round=0,
+    )
+    assert h.trigger_calls == []


### PR DESCRIPTION
## Was wurde geaendert

Zwei Teile, wie im Issue beschrieben:

1. **Re-Poll nach Deploy** (`src/integrations/github_integration/ci_mixin.py`): `_trigger_deployment` ruft nach jedem erfolgreichen, nicht-selbst-deployenden Deploy die neue Methode `_repoll_after_deploy` auf. Die prueft per `git fetch` + `_get_commit_sha`, ob `origin/<branch>` inzwischen weiter ist als der gerade deployte Commit, und stoesst in dem Fall ueber denselben `_trigger_deployment`-Pfad (inkl. CI-Wait + Per-SHA-Dedup via `_reserve_deploy`) einen weiteren Deploy an. Schleifen-Schutz per `deploy.repoll_max_rounds` (Default 2 Runden, `_DEFAULT_REPOLL_MAX_ROUNDS`).

2. **buildSha-Drift-Backstop** (`scripts/zerodox-build-drift-check.py`, stdlib-only): periodischer Fallback fuer den Fall, dass auch der Re-Poll nichts nachholt (Rundenlimit erschoepft, Working-Tree-Guard bricht wiederholt ab). Vergleicht den live `buildSha` aus `/api/health` gegen `origin/main`. **Unterscheidet dabei Docs-only-Drift von echtem, deploy-relevantem Drift** — nutzt exakt dieselbe Allowlist-Regex wie `ZERODOX/scripts/deploy.sh` (Issue #1262: `docs/**`, `.claude/**`, Top-Level `*.md`), damit ein reiner Doku-Commit keinen Fehlalarm ausloest. Als deklarativer `type: script`-Check in `config/config.example.yaml` dokumentiert (`heal: alert-only`, kein Auto-Deploy).

## Architektur-Entscheidungen

- **Root Cause fuer den Re-Poll-Bedarf:** der `active_deployments`-Guard in `deployment_manager.deploy_project()` verwirft einen zweiten Push/PR-Merge, der waehrend eines laufenden Deploys eintrifft, still (`{'success': False, 'error': 'Deployment already in progress...'}`) — kein Retry, kein Alert. Re-Poll heilt genau diesen Fall organisch, ohne den Guard selbst anzufassen.
- **Dedup ueber bestehenden Mechanismus:** der Re-Poll nutzt `_reserve_deploy` (denselben Per-SHA-Dedup wie normale Webhook-Trigger) statt einer eigenen Sperre — verhindert Doppel-Deploy, falls ein paralleler Webhook-Trigger denselben Ziel-SHA bereits reserviert hat.
- **Check-Engine statt eigenem Timer:** Teil 2 haengt sich als `type: script`-Check in die bestehende deklarative Check-Engine (`check_definitions.py`/`project_monitor.py`) ein, statt einen neuen systemd-Timer zu bauen. Damit kommen Flake-Toleranz (`flake_polls: 7` * `interval: 300s` ≈ 35 Min Persistenz, im Issue-Zielkorridor 30-45 Min) und die Discord-Alert-Infrastruktur (Anti-Spam-Cooldown) kostenlos mit.
- **Docs-only-Allowlist reused, nicht neu erfunden:** die Regex `^(docs/|\.claude/|[^/]+\.md$)` ist 1:1 aus `ZERODOX/scripts/deploy.sh` uebernommen, damit beide Stellen (Deploy-Skript und Drift-Check) konsistent bewerten, was "deploy-relevant" heisst.
- **`config/config.yaml` ist gitignored** (enthaelt Secrets) — der neue Check ist deshalb nur in `config/config.example.yaml` als Template dokumentiert. Der echte `zerodox`-Projektblock existiert in der Live-Config bereits (Webhook-Auto-Deploy laeuft ja schon); der Operator muss nur den neuen `checks:`-Eintrag manuell nachziehen (siehe unten).
- **Fail-open vs. Fail-safe im Drift-Skript:** `/api/health` unerreichbar/`buildSha` fehlt → fail-open (exit 0), da Erreichbarkeit schon von `zerodox-watchdog` separat ueberwacht wird (kein Doppel-Alarm). Lokale Git-Operationen (`rev-parse`, `diff`) schlagen fehl → fail-safe (exit 1), analog zur "im Zweifel nicht als docs-only werten"-Philosophie von `deploy.sh`.

## Tests

19 neue Unit-Tests, alle gruen, keine Regressionen:

```
.venv/bin/python -m pytest tests/unit/test_zerodox_deploy_repoll.py tests/unit/test_zerodox_build_drift_check.py tests/unit/test_direct_push_deploy.py -v --no-cov
```
→ `24 passed` (9 neue Re-Poll-Tests, 10 neue Drift-Check-Tests, 5 bestehende StateMixin/CIMixin-Regressionstests unveraendert gruen).

Re-Poll-Tests decken ab: No-op bei gleichen SHAs, Trigger bei Remote-Vorsprung (inkl. `_repoll_round`-Inkrement), Rundenlimit, `repoll_enabled: false`, fehlende/kaputte `project_config`/`path`, fehlgeschlagener `git fetch`, Dedup ueber `_reserve_deploy`.

Drift-Check-Tests decken ab: identische SHAs → OK, Docs-only-Diff trotz SHA-Mismatch → OK, Web-Pfad-Diff → FAIL, `web/**/*.md` bewusst NICHT als docs-only gewertet, Health-Endpoint unerreichbar → fail-open, `rev-parse`/`diff` fehlgeschlagen → fail-safe, `git fetch`-Fehler alleine blockt nicht (solange `rev-parse` noch funktioniert).

## Was der Operator nach dem Merge tun muss

1. **Config-Eintrag manuell nachziehen:** den neuen `checks:`-Block aus `config/config.example.yaml` (Sektion `projects.zerodox.monitor.checks`, Check-ID `zerodox-build-drift`) in die echte, gitignored `config/config.yaml` unter dem bestehenden `projects.zerodox.monitor`-Knoten ergaenzen.
2. **Bot-Reload:** Fuer sowohl den Code-Teil (Re-Poll in `ci_mixin.py`) als auch die neue Check-Config braucht es einen normalen Bot-Restart (kein `systemctl restart` durch mich ausgefuehrt — hab ich als Guardrail nicht angefasst). Der naechste normale Deploy/Merge-Zyklus des Bots selbst (Self-Deploy) sollte das ohnehin erledigen; falls nicht, bitte manuell `systemctl --user restart <shadowops-bot-service>` (Servicename siehe `infrastructure.md`).
3. **Kein Migrations-/Schema-Schritt noetig**, kein neuer Secret/Env-Var.

## Type
- [x] `fix:`

## Risk-Score
- [x] **Medium** — beruehrt ein kritisches Modul (Deployment-Pfad in `ci_mixin.py`), aber additiv (neue Methode + neuer optionaler Recursion-Parameter mit Default), keine bestehende Logik veraendert; Teil 2 ist ein komplett neues, isoliertes Skript.

## Review-Fokus
- Schleifen-Schutz in `_repoll_after_deploy` (Rundenlimit + Dedup) — kann das unter realen Bedingungen trotzdem in eine Deploy-Kaskade laufen?
- Docs-only-Allowlist-Konsistenz zwischen `deploy.sh` und `zerodox-build-drift-check.py` — Drift zwischen beiden Kopien ist ein zukuenftiges Wartungsrisiko (im Skript-Docstring vermerkt).
- Ob `config.example.yaml` oder auch `config.recommended.yaml` das richtige/vollstaendige Template ist (nur ersteres wurde in diesem PR aktualisiert).

## Checkliste
- [x] CI gruen (pytest lokal; ruff/mypy nicht separat ausgefuehrt)
- [x] Diff ~628 Zeilen, aber klar in 2 unabhaengige, additive Einheiten gefasst (Re-Poll + Drift-Skript)
- [x] Keine neuen Secrets im Code
- [x] DO-NOT-TOUCH-Liste respektiert (`config/config.yaml` nicht angefasst/gelesen)
- [x] Tests vorhanden (19 neue, s.o.)
- [x] Doku angepasst (`config/config.example.yaml` + ausfuehrliche Docstrings in beiden neuen/geaenderten Dateien)
- [ ] Bei Routine-PR: State-File geupdated — n/a (kein Routine-Worker-PR)
- [x] Confidence-Score >= 85%

## Linked Issues
<!-- Cross-Repo: Issue lebt in ZERODOX, Fix hier in shadowops-bot -->
Refs Commandershadow9/ZERODOX#1720
