### PR TITLE
fix(deploy): Code-Commits ohne CI fail-closed blockieren (ZERODOX#1985)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ deployment:
   health_check_timeout: 30
 ```
 
-> **Welle 9.10 (2026-05-11) — Wait-for-CI vor Auto-Deploy:** Sobald ein PR auf einen `deploy_branches`-Branch gemergt wird, wartet der Bot vor dem Trigger von `deploy.sh` auf den Abschluss der in `projects.<name>.ci_workflows` konfigurierten Workflows (z.B. `["Web Quality"]`). Bei `failure`/`timeout` wird `deploy.sh` NICHT aufgerufen — stattdessen erscheint ein Alert im projekt-`ci_channel_id` oder `deployment_log`. Hard-Timeout 30 min (überschreibbar via `projects.<name>.ci_wait_max_min`). Exponential backoff 60s → 120s → 240s → cap 300s.
+> **Welle 9.10 / ZERODOX #1985 — Wait-for-CI vor Auto-Deploy:** Sobald ein PR auf einen `deploy_branches`-Branch gemergt wird, wartet der Bot vor dem Trigger von `deploy.sh` auf den Abschluss der in `projects.<name>.ci_workflows` konfigurierten Workflows (z.B. `["Web Quality"]`). Bei `failure`/`timeout` wird `deploy.sh` NICHT aufgerufen — stattdessen erscheint ein Alert im projekt-`ci_channel_id` oder `deployment_log`. Taucht innerhalb der Grace-Period kein Workflow auf, darf nur ein über die GitHub-Commit-Dateiliste verifizierter Docs-only-Commit (Top-Level `*.md`, `docs/**`, `.claude/**`) weiterlaufen. Code- und nicht eindeutig klassifizierbare Commits warten das volle Zeitfenster ab und werden danach mit einem „CI fehlt“-Alert fail-closed blockiert. Hard-Timeout 30 min (überschreibbar via `projects.<name>.ci_wait_max_min`). Exponential backoff 60s → 120s → 240s → cap 300s.
 
 **AI komplett deaktivieren (Monitoring + Patch Notes ohne KI):**
 - `ai.enabled: false`

--- a/src/integrations/github_integration/ci_mixin.py
+++ b/src/integrations/github_integration/ci_mixin.py
@@ -27,6 +27,24 @@ _CI_RUNNING_STATI = frozenset({"queued", "in_progress", "requested", "waiting", 
 # deploy.repoll_max_rounds.
 _DEFAULT_REPOLL_MAX_ROUNDS = 2
 
+# ZERODOX#1985: Muss mit der Docs-only-Allowlist in ZERODOX/scripts/deploy.sh
+# uebereinstimmen. Nur diese Pfade veraendern die Runtime garantiert nicht.
+_COMMIT_FILES_PER_PAGE = 100
+_COMMIT_FILES_MAX_PAGES = 30
+
+
+def _paths_are_docs_only(paths: list[str]) -> bool:
+    """Return True only for a non-empty, entirely non-runtime path list."""
+    normalized_paths = [str(path).strip() for path in paths if str(path).strip()]
+    if not normalized_paths:
+        return False
+
+    return all(
+        path.startswith(("docs/", ".claude/"))
+        or ("/" not in path and path.endswith(".md"))
+        for path in normalized_paths
+    )
+
 
 class CIMixin:
 
@@ -213,6 +231,75 @@ class CIMixin:
             )
             return None
 
+    async def _fetch_commit_files(
+        self,
+        repo_full_name: str,
+        head_sha: str,
+    ) -> Optional[list[str]]:
+        """Load every changed path for a commit, failing closed on API errors."""
+        if not repo_full_name or not head_sha:
+            return None
+
+        headers = {"Accept": "application/vnd.github+json"}
+        token = self._get_github_token()
+        if token:
+            headers["Authorization"] = f"token {token}"
+
+        changed_paths: list[str] = []
+        try:
+            async with aiohttp.ClientSession(headers=headers) as session:
+                for page in range(1, _COMMIT_FILES_MAX_PAGES + 1):
+                    url = (
+                        f"https://api.github.com/repos/{repo_full_name}/commits/{head_sha}"
+                        f"?per_page={_COMMIT_FILES_PER_PAGE}&page={page}"
+                    )
+                    async with session.get(url, timeout=20) as resp:
+                        if resp.status != 200:
+                            body = await resp.text()
+                            self.logger.warning(
+                                f"⚠️ Commit-Dateien fuer {repo_full_name}@{head_sha[:7]} "
+                                f"konnten nicht geladen werden ({resp.status}): {body[:200]}"
+                            )
+                            return None
+
+                        payload = await resp.json()
+                        files = payload.get("files")
+                        if not isinstance(files, list):
+                            self.logger.warning(
+                                f"⚠️ Commit-Dateien fuer {repo_full_name}@{head_sha[:7]} "
+                                "fehlen in der GitHub-Antwort."
+                            )
+                            return None
+
+                        page_paths = [
+                            str(item.get("filename") or "").strip()
+                            for item in files
+                            if isinstance(item, dict)
+                        ]
+                        if any(not path for path in page_paths) or len(page_paths) != len(files):
+                            self.logger.warning(
+                                f"⚠️ Commit-Dateien fuer {repo_full_name}@{head_sha[:7]} "
+                                "enthalten ungueltige Eintraege."
+                            )
+                            return None
+                        changed_paths.extend(page_paths)
+
+                        if len(files) < _COMMIT_FILES_PER_PAGE:
+                            return changed_paths
+
+            self.logger.warning(
+                f"⚠️ Commit-Dateiliste fuer {repo_full_name}@{head_sha[:7]} "
+                f"ueberschreitet {_COMMIT_FILES_MAX_PAGES * _COMMIT_FILES_PER_PAGE} Dateien."
+            )
+            return None
+        except Exception as e:
+            self.logger.error(
+                f"❌ Fehler beim Laden der Commit-Dateien fuer "
+                f"{repo_full_name}@{head_sha[:7]}: {e}",
+                exc_info=True,
+            )
+            return None
+
     async def _wait_for_ci_completion(
         self,
         repo_full_name: str,
@@ -220,7 +307,7 @@ class CIMixin:
         workflow_names: List[str],
         max_wait_min: int = 30,
         admin_merge_grace_min: int = 5,
-    ) -> Literal["success", "failure", "timeout", "no_workflows"]:
+    ) -> Literal["success", "failure", "timeout", "missing", "docs_only", "no_workflows"]:
         """
         Wait for required CI workflows on a given commit to complete.
 
@@ -228,12 +315,10 @@ class CIMixin:
         58h-Vorfall: Bot triggert deploy.sh sofort bei PR-merge → deploy.sh
         Pre-Flight-Gate sieht pending CI auf dem neuen SHA → exit 1.
 
-        Welle 9.16 (Issue #243): Admin-merged PRs triggern oft keinen CI-Run
-        (Required-Checks bleiben leer). Wenn nach `admin_merge_grace_min`
-        Minuten KEIN relevanter Workflow fuer den SHA gesichtet wurde,
-        gilt das als "kein CI vorhanden" → return "no_workflows" (Caller
-        deployt direkt). Sobald aber EIN Workflow gesehen wurde, gilt der
-        normale Timeout-Pfad (max_wait_min).
+        ZERODOX#1985: Wenn nach `admin_merge_grace_min` Minuten kein relevanter
+        Workflow sichtbar ist, darf nur ein nachweislich reiner Docs-Commit
+        ohne Deployment weiterlaufen. Code- oder unklare Commits warten bis
+        `max_wait_min` und werden danach fail-closed als "missing" gemeldet.
 
         Exponential backoff: 60s → 120s → 240s → cap 300s.
 
@@ -249,9 +334,10 @@ class CIMixin:
         Returns:
             "success"      — alle required Workflows haben conclusion=success
             "failure"      — mind. 1 Workflow ist failed/cancelled/timed_out
-            "timeout"      — nach max_wait_min noch nicht alle completed
-            "no_workflows" — kein workflow_names konfiguriert ODER admin-merge
-                             ohne CI-Trigger erkannt → caller entscheidet
+            "timeout"      — gesichtete Workflows nach max_wait_min nicht completed
+            "missing"      — nach max_wait_min kein relevanter Workflow sichtbar
+            "docs_only"    — nur nicht-deploy-relevante Pfade geaendert
+            "no_workflows" — kein workflow_names konfiguriert → caller entscheidet
         """
         if not workflow_names:
             self.logger.info(
@@ -274,6 +360,7 @@ class CIMixin:
         poll_interval_s = 60
         max_poll_interval_s = 300  # 5 min cap
         saw_any_relevant = False
+        commit_paths_checked = False
 
         self.logger.info(
             f"⏳ Welle 9.10: warte auf CI-Completion fuer {repo_full_name}@{merged_sha[:7]} "
@@ -308,17 +395,30 @@ class CIMixin:
                         break
 
             if not relevant:
-                # Welle 9.16 (Issue #243): admin-merged Detection. Wenn nach
-                # admin_merge_grace_min weiter KEIN Workflow fuer den SHA gesichtet
-                # wurde, ist es vermutlich ein admin-merge ohne CI-Trigger →
-                # weiter deployen (Caller behandelt "no_workflows" als OK).
-                if not saw_any_relevant and time.monotonic() >= admin_merge_deadline:
-                    self.logger.info(
-                        f"ℹ️ _wait_for_ci_completion: nach {admin_merge_grace_min}min "
-                        f"keine relevanten Workflows fuer {merged_sha[:7]} sichtbar — "
-                        f"admin-merge ohne CI-Trigger vermutet, fahre fort."
+                # ZERODOX#1985: Nach der Grace-Period genau einmal die Commit-
+                # Pfade pruefen. Nur die identische Allowlist aus deploy.sh darf
+                # ohne Workflow weiterlaufen; API-Fehler bleiben fail-closed.
+                if (
+                    not saw_any_relevant
+                    and not commit_paths_checked
+                    and time.monotonic() >= admin_merge_deadline
+                ):
+                    commit_paths_checked = True
+                    changed_paths = await self._fetch_commit_files(repo_full_name, merged_sha)
+                    if changed_paths is not None and _paths_are_docs_only(changed_paths):
+                        self.logger.info(
+                            f"ℹ️ _wait_for_ci_completion: Docs-only-Commit "
+                            f"{merged_sha[:7]} mit {len(changed_paths)} Datei(en) erkannt — "
+                            "kein Runtime-Deployment noetig."
+                        )
+                        return "docs_only"
+
+                    classification = "Code-Commit" if changed_paths is not None else "unklarer Commit"
+                    self.logger.warning(
+                        f"⚠️ _wait_for_ci_completion: {classification} {merged_sha[:7]} "
+                        f"nach {admin_merge_grace_min}min ohne relevanten Workflow — "
+                        f"warte fail-closed bis zum {max_wait_min}min-Limit."
                     )
-                    return "no_workflows"
                 self.logger.info(
                     f"⏳ _wait_for_ci_completion: noch keine relevanten Workflows "
                     f"fuer {merged_sha[:7]} sichtbar — weiter pollen ({poll_interval_s}s)..."
@@ -381,6 +481,13 @@ class CIMixin:
             await asyncio.sleep(poll_interval_s)
             poll_interval_s = min(poll_interval_s * 2, max_poll_interval_s)
 
+        if not saw_any_relevant:
+            self.logger.warning(
+                f"🛑 _wait_for_ci_completion: CI FEHLT nach {max_wait_min}min "
+                f"fuer {repo_full_name}@{merged_sha[:7]}"
+            )
+            return "missing"
+
         self.logger.warning(
             f"⏰ _wait_for_ci_completion: TIMEOUT nach {max_wait_min}min "
             f"fuer {repo_full_name}@{merged_sha[:7]}"
@@ -389,7 +496,7 @@ class CIMixin:
 
     async def _send_ci_wait_alert(
         self,
-        outcome: Literal["failure", "timeout"],
+        outcome: Literal["failure", "timeout", "missing"],
         repo_name: str,
         repo_full_name: str,
         branch: str,
@@ -431,7 +538,7 @@ class CIMixin:
                     f"`{merged_sha[:7]}` mit Failure/Cancelled/TimedOut abgeschlossen.\n\n"
                     f"**deploy.sh wurde NICHT getriggert.** Manueller Check noetig."
                 )
-            else:  # timeout
+            elif outcome == "timeout":
                 title = f"⏰ {repo_name}: Deploy zurueckgestellt — CI nicht durch"
                 color = 0xF1C40F
                 description = (
@@ -440,6 +547,16 @@ class CIMixin:
                     f"noch nicht alle completed.\n\n"
                     f"**deploy.sh wurde NICHT getriggert.** Sobald CI gruen ist, "
                     f"deploy.sh manuell triggern."
+                )
+            else:  # missing
+                title = f"🛑 {repo_name}: Deploy ABGEBROCHEN — CI fehlt"
+                color = 0xE67E22
+                description = (
+                    f"Fail-closed-Schutz: Fuer den Code-Commit `{merged_sha[:7]}` ist "
+                    f"nach {max_wait_min} Minuten keiner der erwarteten CI-Workflows "
+                    f"({', '.join(workflow_names) or '—'}) aufgetaucht.\n\n"
+                    f"**deploy.sh wurde NICHT getriggert.** Workflow-Trigger und "
+                    f"Required-Checks pruefen; danach Deployment manuell anstossen."
                 )
 
             embed = discord.Embed(
@@ -559,9 +676,9 @@ class CIMixin:
                         max_wait_min=max_wait_min,
                     )
                     return
-                if outcome == "timeout":
+                if outcome in {"timeout", "missing"}:
                     await self._send_ci_wait_alert(
-                        outcome="timeout",
+                        outcome=outcome,
                         repo_name=repo_name,
                         repo_full_name=repo_full_name,
                         branch=branch,
@@ -570,7 +687,8 @@ class CIMixin:
                         max_wait_min=max_wait_min,
                     )
                     return
-                # outcome == "success" oder "no_workflows" → weiter unten deployen
+                # success/docs_only/no_workflows → weiter unten deployen. Bei docs_only
+                # beendet deploy.sh selbst ohne Runtime-Aenderung (identische Allowlist).
             else:
                 self.logger.info(
                     f"ℹ️ _trigger_deployment: kein ci_workflows fuer {repo_name} "

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -5,11 +5,12 @@ Unit Tests for GitHub Integration
 import asyncio
 import hashlib
 import hmac
-from unittest.mock import Mock, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
 from src.integrations.github_integration import GitHubIntegration
+from src.integrations.github_integration.ci_mixin import _paths_are_docs_only
 from src.utils.config import Config
 
 
@@ -647,6 +648,56 @@ class TestWelle910WaitForCI:
         )
         assert result == 'no_workflows'
 
+    @pytest.mark.parametrize(
+        ('paths', 'expected'),
+        [
+            (['README.md', 'CLAUDE.md', 'docs/runbook.md', '.claude/settings.json'], True),
+            (['web/README.md'], False),
+            (['.github/workflows/web-quality.yml'], False),
+            (['docs/runbook.md', 'src/bot.py'], False),
+            ([], False),
+        ],
+    )
+    def test_docs_only_paths_match_zerodox_deploy_allowlist(self, paths, expected):
+        assert _paths_are_docs_only(paths) is expected
+
+    @pytest.mark.asyncio
+    async def test_fetch_commit_files_paginates_complete_file_list(
+        self, mock_bot, cfg_with_projects, monkeypatch,
+    ):
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        first_page = [{'filename': f'docs/page-{index}.md'} for index in range(100)]
+        second_page = [{'filename': 'README.md'}]
+
+        response_contexts = []
+        for files in (first_page, second_page):
+            response = MagicMock(status=200)
+            response.json = AsyncMock(return_value={'files': files})
+            response_context = MagicMock()
+            response_context.__aenter__ = AsyncMock(return_value=response)
+            response_context.__aexit__ = AsyncMock(return_value=None)
+            response_contexts.append(response_context)
+
+        session = MagicMock()
+        session.get = MagicMock(side_effect=response_contexts)
+        session_context = MagicMock()
+        session_context.__aenter__ = AsyncMock(return_value=session)
+        session_context.__aexit__ = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            'integrations.github_integration.ci_mixin.aiohttp.ClientSession',
+            lambda **_kwargs: session_context,
+        )
+
+        paths = await integration._fetch_commit_files(
+            'Commandershadow9/ZERODOX',
+            'a' * 40,
+        )
+
+        assert paths == [item['filename'] for item in first_page + second_page]
+        assert session.get.call_count == 2
+        assert 'page=1' in session.get.call_args_list[0].args[0]
+        assert 'page=2' in session.get.call_args_list[1].args[0]
+
     @pytest.mark.asyncio
     async def test_wait_returns_success_when_all_completed(self, mock_bot, cfg_with_projects):
         integration = GitHubIntegration(mock_bot, cfg_with_projects)
@@ -766,12 +817,10 @@ class TestWelle910WaitForCI:
         assert result == 'timeout'
 
     @pytest.mark.asyncio
-    async def test_wait_returns_no_workflows_after_admin_merge_grace(
+    async def test_wait_returns_docs_only_after_admin_merge_grace(
         self, mock_bot, cfg_with_projects, monkeypatch,
     ):
-        """Welle 9.16 (Issue #243): wenn nach admin_merge_grace_min weiter KEIN
-        Workflow für den SHA gesichtet wurde, gilt es als admin-merge ohne CI
-        → "no_workflows" (Caller deployt direkt) statt 30min Timeout."""
+        """Ein nachweislicher Docs-only-Commit darf ohne CI weiterlaufen."""
         integration = GitHubIntegration(mock_bot, cfg_with_projects)
         # API liefert konstant einen Workflow-Run, der NICHT zum Filter passt
         # (anderes Repo / anderer Name). Damit bleibt `relevant` immer leer.
@@ -786,6 +835,11 @@ class TestWelle910WaitForCI:
                 },
             ],
         })
+        integration._fetch_commit_files = AsyncMock(return_value=[
+            'README.md',
+            'docs/runbook.md',
+            '.claude/settings.json',
+        ])
 
         sleep_calls = []
 
@@ -795,7 +849,7 @@ class TestWelle910WaitForCI:
         monkeypatch.setattr('integrations.github_integration.ci_mixin.asyncio.sleep', fast_sleep)
 
         # time.monotonic: 0 (started_at), 0 (Loop-Eintritt) ⇒ in Grace,
-        # dann 400 (>5*60=300) ⇒ Grace abgelaufen ⇒ no_workflows
+        # dann 400 (>5*60=300) ⇒ Grace abgelaufen ⇒ Docs-Pruefung
         times = iter([0.0, 0.0, 400.0])
 
         def fake_monotonic():
@@ -813,7 +867,50 @@ class TestWelle910WaitForCI:
             max_wait_min=30,
             admin_merge_grace_min=5,
         )
-        assert result == 'no_workflows'
+        assert result == 'docs_only'
+        integration._fetch_commit_files.assert_awaited_once_with(
+            'Commandershadow9/ZERODOX',
+            'b' * 40,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('changed_paths', [['src/bot.py'], None])
+    async def test_wait_blocks_missing_ci_for_code_or_unknown_commit(
+        self, mock_bot, cfg_with_projects, monkeypatch, changed_paths,
+    ):
+        """Code und API-unklare Commits warten voll und enden fail-closed."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration._fetch_workflow_runs_for_sha = AsyncMock(return_value={
+            'workflow_runs': [],
+        })
+        integration._fetch_commit_files = AsyncMock(return_value=changed_paths)
+
+        async def fast_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.asyncio.sleep', fast_sleep)
+
+        # 0: started_at, 0: erste Loop, 400: Grace abgelaufen,
+        # 2000: volles 30min-Fenster abgelaufen.
+        times = iter([0.0, 0.0, 400.0, 2000.0])
+
+        def fake_monotonic():
+            try:
+                return next(times)
+            except StopIteration:
+                return 2000.0
+
+        monkeypatch.setattr('integrations.github_integration.ci_mixin.time.monotonic', fake_monotonic)
+
+        result = await integration._wait_for_ci_completion(
+            repo_full_name='Commandershadow9/ZERODOX',
+            merged_sha='d' * 40,
+            workflow_names=['Web Quality'],
+            max_wait_min=30,
+            admin_merge_grace_min=5,
+        )
+        assert result == 'missing'
+        integration._fetch_commit_files.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_wait_does_not_short_circuit_when_workflow_was_seen(
@@ -917,6 +1014,29 @@ class TestWelle910WaitForCI:
         assert kwargs['outcome'] == 'timeout'
 
     @pytest.mark.asyncio
+    async def test_trigger_deployment_blocks_and_alerts_when_ci_is_missing(
+        self, mock_bot, cfg_with_projects,
+    ):
+        """Code-Commit ohne gestartete CI darf deploy.sh nicht erreichen."""
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock(return_value={'success': True})
+        integration._wait_for_ci_completion = AsyncMock(return_value='missing')
+        integration._send_ci_wait_alert = AsyncMock()
+
+        await integration._trigger_deployment(
+            repo_name='zerodox',
+            branch='main',
+            commit_sha='abc1234',
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='a' * 40,
+        )
+
+        integration.deployment_manager.deploy_project.assert_not_called()
+        integration._send_ci_wait_alert.assert_awaited_once()
+        assert integration._send_ci_wait_alert.call_args.kwargs['outcome'] == 'missing'
+
+    @pytest.mark.asyncio
     async def test_trigger_deployment_proceeds_on_success(self, mock_bot, cfg_with_projects):
         """deploy.sh MUSS laufen wenn CI success."""
         integration = GitHubIntegration(mock_bot, cfg_with_projects)
@@ -935,6 +1055,27 @@ class TestWelle910WaitForCI:
 
         integration.deployment_manager.deploy_project.assert_called_once_with('zerodox', 'main')
         integration._send_ci_wait_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_trigger_deployment_proceeds_for_verified_docs_only_commit(
+        self, mock_bot, cfg_with_projects,
+    ):
+        integration = GitHubIntegration(mock_bot, cfg_with_projects)
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock(return_value={'success': True})
+        integration._wait_for_ci_completion = AsyncMock(return_value='docs_only')
+        integration._send_ci_wait_alert = AsyncMock()
+
+        await integration._trigger_deployment(
+            repo_name='zerodox',
+            branch='main',
+            commit_sha='abc1234',
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='a' * 40,
+        )
+
+        integration.deployment_manager.deploy_project.assert_awaited_once_with('zerodox', 'main')
+        integration._send_ci_wait_alert.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_trigger_deployment_skips_wait_when_no_full_args(self, mock_bot, cfg_with_projects):


### PR DESCRIPTION
## Ergebnis

- übernimmt exakt die Docs-only-Allowlist aus ZERODOX/scripts/deploy.sh (Top-Level *.md, docs/**, .claude/**)
- lädt die vollständige Commit-Dateiliste paginiert über die GitHub API; leere, ungültige oder nicht abrufbare Antworten bleiben fail-closed
- erlaubt nur verifizierten Docs-only-Commits den Grace-Pfad
- wartet bei Code- und unklaren Commits das volle konfigurierte CI-Fenster statt nach 5 Minuten zu deployen
- blockiert anschließend mit eigenem missing-Ergebnis und einem CI-fehlt-Discord-Alert
- dokumentiert die verschärfte Semantik im README

## Verifikation

- 21 gezielte Wait-for-CI-Tests bestanden
- vollständige Unit-Suite: 1364 bestanden, 87 übersprungen
- Python-Compile und git diff --check bestanden
- Ruff meldet nur bereits repositoryweit vorhandene, in CI nicht blockierende Modernisierungsregeln; neu berührte Allowlist-Regel wurde bereinigt

Closes Commandershadow9/ZERODOX#1985