### PR TITLE
feat: Watchdogs ans ZERODOX-Team-Postfach anbinden (Pilot doku-drift) (#1983)

### DIFF
--- a/deploy/POSTFACH_ROUTING.md
+++ b/deploy/POSTFACH_ROUTING.md
@@ -1,0 +1,78 @@
+# Postfach-Routing — welcher Watchdog darf zusätzlich ans ZERODOX-Team-Postfach?
+
+> Zusatz-Dokument zu #1983 (Team-Postfach-Anbindung, Spec
+> `docs/superpowers/specs/2026-07-24-admin-cockpit-finanzen-postfach-design.md`, Stufe E4).
+> Klärt, **warum** ein Watchdog zusätzlich ans Postfach melden darf oder dauerhaft
+> Discord-only bleibt — nicht nur, welche Liste welchen Namen trägt. Discord bleibt in
+> jedem Fall der bestehende Kanal; das Postfach kommt additiv hinzu (siehe
+# lib/postfach-send.sh).
+
+## Das Prinzip (Spec, Abschnitt 3 — "Zwingende Einschränkung zu „Alles ins Postfach"")
+
+> Meldungen, die den **Ausfall von ZERODOX selbst** betreffen, dürfen nicht ausschließlich
+> in ein Postfach laufen, das in ZERODOX gehostet wird — genau im Alarmfall wäre der
+> Empfänger nicht erreichbar. Für diese Klasse (Erreichbarkeits-Wächter,
+> Datenbank-/Speicher-Alarme, externer GitHub-Actions-Wächter) bleibt Discord als bewusst
+> unabhängiger Zweitkanal bestehen. Alles Übrige — Backups, Buchungen, Zahlungen, Akquise,
+> Support, Post, SEO — zieht vollständig um.
+
+Kurz: Das Postfach lebt **in** ZERODOX. Ein Wächter, dessen Meldung lautet "ZERODOX (oder
+eine tragende Säule davon: Datenbank, Speicherplatz, der Bot, der das Postfach befüllt)
+ist gerade nicht ansprechbar", darf sich nicht selbst den einzigen Übertragungsweg
+abschneiden. Ein Wächter, dessen Meldung ein **fachlicher/redaktioneller** Befund ist
+(Doku ist veraltet, ein Score ist gesunken, ein Datensatz ist überfällig) hat dieses
+Problem nicht — ZERODOX war beim Erzeugen der Meldung nachweislich online, sonst gäbe es
+den Befund gar nicht.
+
+**Prüffrage pro Watchdog:** *Kann die Meldung selbst genau dann verloren gehen, wenn sie am
+wichtigsten wäre — weil ZERODOX, seine Datenbank oder der meldende Bot in diesem Moment
+nicht erreichbar sind?* Ja → Discord-only. Nein → postfach-fähig.
+
+## Dauerhaft Discord-only (Erreichbarkeit / DB-Speicher-Alarm / Selbstüberwachung)
+
+| Watchdog | Warum Discord-only |
+|---|---|
+| `zerodox-watchdog` | Meldet, dass zerodox.de nicht antwortet — genau dann wäre ein dort gehostetes Postfach ebenfalls nicht erreichbar. Der Klassiker aus Abschnitt 3. |
+| `memory-watchdog` | RAM-/Swap-Druck auf demselben Server, auf dem auch die ZERODOX-DB und -Web-App laufen — ein Speicher-Alarm im Sinne von Abschnitt 3, Vorstufe zu genau dem Ausfall, den `zerodox-watchdog` erst danach sähe. |
+| `disk-hygiene-watchdog` | Eine volle Platte reißt zuerst die Datenbank mit (Schreibfehler), danach die Web-App — der Datenbank-/Speicher-Alarm aus Abschnitt 3 in Reinform. |
+| `shadowops-watchdog` | Überwacht den ShadowOps-Bot selbst (`:8766/health`) — der Bot ist der Absender, der Postfach-Meldungen überhaupt erst verschickt. Fällt der Absender aus, kann er auch keine Postfach-Meldung über seinen eigenen Ausfall mehr abliefern. |
+| `shadowops-drift-watchdog` | Ergänzt den vorigen um Service-State + Restart-Loop-Erkennung — dieselbe Selbstüberwachungs-Logik, derselbe Grund. |
+| `shadowops-backup-test` (`backup-restore-test.sh`, monatlich) | Prüft die Wiederherstellbarkeit **desselben Systems**, das im Ernstfall auch das Postfach trägt. Eine Aussage über "können wir ZERODOX aus dem Backup retten" gehört in den Kanal, der einen bereits durch ZERODOX kaputten Zustand überlebt. |
+
+Zusätzlich außerhalb dieses Repos, aber derselben Klasse: der externe GitHub-Actions-Cron
+(`external-uptime.yml`, hosted `ubuntu-latest`), der zerodox.de + guildscout.eu von
+**außerhalb** des VPS anpingt — genau der Fall, den kein VPS-interner Wächter (auch kein
+Postfach-Eintrag) abdecken kann, wenn der VPS selbst komplett tot ist. Bleibt beim
+externen Discord-Webhook, nicht Teil dieser Umstellung.
+
+## Postfach-fähig (redaktionell/fachlich, keine Aussage über Erreichbarkeit)
+
+| Watchdog | Kategorie/Befund | Warum unbedenklich |
+|---|---|---|
+| `doku-drift-watchdog` | Doku vs. Realität (Port-Map, MEMORY.md-Länge) | **Pilot, bereits umgesetzt** (dieser PR). Rein redaktionell — ZERODOX lief nachweislich, als der Wächter den Vergleich zog. |
+| `ki-cost-watchdog` | Token-/Kosten-Rollup Claude+Codex, Anomalie-Alarm | Reine Kostenbeobachtung, keine Verfügbarkeitsaussage. |
+| `security-freshness-watchdog` | Alter des letzten `sec_jobs`-Laufs in der security_analyst-DB | Eine **stehende** DB-Zeile fehlt/ist alt — das ist ein fachlicher Rückstand, kein Ausfall von ZERODOX selbst (ZERODOX-Web und die security_analyst-DB sind getrennte Komponenten). |
+| `seo-audit-freshness-watchdog`, `seo-deep-audit-freshness-watchdog`, `seo-output-freshness-watchdog` | Alter des letzten SEO-Audits/-Outputs in der seo_agent-DB | Dieselbe Begründung wie oben: Frische-Prüfung gegen eine Fach-DB, keine Erreichbarkeitsaussage über ZERODOX selbst. |
+| `mayday-sim-build-drift-watchdog` | Build-ID auf maydaysim.de vs. `origin/main` HEAD | Redaktioneller Drift (Deploy hinkt Git hinterher), keine Ausfallmeldung — maydaysim.de antwortet ja, nur mit altem Stand. |
+
+## Noch nicht entschieden — braucht Owner-/Lead-Entscheidung vor Umstellung
+
+Diese Watchdogs prüfen **andere** Projekte oder Komponenten als ZERODOX selbst. Die
+Prüffrage von oben lässt sich für sie beantworten, aber #1983 hat dafür keinen
+Auftrag — sie werden hier nur benannt, damit niemand sie in einer künftigen Welle
+stillschweigend falsch einsortiert:
+
+| Watchdog | Vorläufige Einschätzung nach der Prüffrage | Offene Frage |
+|---|---|---|
+| `zerodox-akquise-ai-watchdog` | Prüft `172.19.0.1:9300/health` — die Akquise-AI-Bridge, eine ZERODOX-Nachbarkomponente im selben Docker-Netz. Nach Wortlaut von Abschnitt 3 ("Ausfall von ZERODOX selbst") knapp außerhalb, da eine eigene Komponente — aber dieselbe VPS/Netz-Korrelation wie bei `zerodox-watchdog` ist plausibel. | Zählt eine Nachbarkomponente im selben Docker-Netz als "ZERODOX selbst"? |
+| `guildscout-watchdog`, `mayday-sim-watchdog`, `mayday-ci-runner-watchdog`, `mayday-scheduler-watchdog` | Reine Erreichbarkeits-Wächter — aber für **andere** Projekte (GuildScout, mayday-sim), nicht ZERODOX. Nach Wortlaut greift die Einschränkung nicht (das ZERODOX-Postfach bliebe ja erreichbar, wenn nur GuildScout/mayday-sim ausfällt). | Gehören Ausfall-Meldungen fremder Projekte überhaupt ins ZERODOX-Postfach, oder ist das Postfach bewusst ZERODOX-Scope? Reine Scope-Frage, keine Erreichbarkeits-Frage. |
+| `ai-agent-framework-watchdog` | Prozess-State von `zerodox-support-agent`/`seo-agent` (ZERODOX-Agents) **und** `guildscout-feedback-agent` (fremdes Projekt) in einem Wächter gemischt. | Müsste ggf. aufgeteilt werden, bevor der ZERODOX-Anteil postfach-fähig würde. |
+| `cmdshadow-design-watchdog` | Prüft `cmdshadow-design-healthcheck.service` — ein eigenständiges Tool-Projekt, keine ZERODOX-Komponente. | Reine Scope-Frage wie bei GuildScout/mayday-sim oben. |
+
+## Referenz
+
+- Sende-Helfer: `scripts/lib/postfach-send.sh`
+- Pilot-Umsetzung: `scripts/doku-drift-watchdog.sh`
+- Vertrag ZERODOX-Seite: `web/src/app/api/internal/notifications/ingest/route.ts`
+- Vollständige Watchdog-Übersicht (Ports/Cycles): `deploy/MONITORING_SETUP.md`,
+  `~/.claude/rules/infrastructure.md` (ZERODOX-Repo, Tabelle "Externes Service-Monitoring")

--- a/deploy/POSTFACH_ROUTING.md
+++ b/deploy/POSTFACH_ROUTING.md
@@ -28,6 +28,37 @@ den Befund gar nicht.
 wichtigsten wäre — weil ZERODOX, seine Datenbank oder der meldende Bot in diesem Moment
 nicht erreichbar sind?* Ja → Discord-only. Nein → postfach-fähig.
 
+## Nur bei Befund ins Postfach — keine Kenntnisnahme ohne Anlass
+
+**Diese Regel gilt für jede künftige Umstellung, nicht nur den Piloten** (Korrektur
+während der Review des Piloten, #1983):
+
+> Wiederkehrende Prüfungen melden **nur bei Befund** ins Postfach. Ein Lauf ohne Befund
+> erzeugt keinen Eintrag.
+>
+> **Ausnahme:** Läufe, deren Erfolg selbst ein Nachweis ist — Sicherungsläufe etwa, wo
+> „Sicherung um 03:00 erfolgreich" eine aufbewahrungswürdige Tatsache ist. Dort ist die
+> Kenntnisnahme gewollt.
+
+**Warum:** Ein Wächter, der täglich läuft und auch bei "alles in Ordnung" einen
+`KENNTNISNAHME`-Eintrag schreibt, erzeugt 365 Zeilen im Jahr, die niemand liest und die
+nichts auslösen. Die Standardansicht des Postfachs filtert auf "offen und ungelesen" —
+eine Kenntnisnahme ist zunächst ebenfalls ungelesen und würde dort erscheinen. Die erste
+Ansicht, die morgens jemand öffnet, wäre dann voll mit "nichts zu tun"-Meldungen: genau
+die zweite Flut, die dieses Vorhaben verhindern soll. Das Postfach zeigt **Arbeitsvorrat**,
+kein Betriebsprotokoll — für "lief durch" gibt es weiterhin Discord und die Log-Dateien.
+
+**Der Unterschied zur Ausnahme:** Bei einem Sicherungslauf ist die **Abwesenheit** der
+Meldung das Alarmsignal (kein Lauf = etwas ist kaputt) — deshalb muss die Anwesenheit
+dokumentiert sein, damit ihr Fehlen überhaupt auffällt. Bei einer Doku-Prüfung, einer
+Frische-Prüfung oder einem Drift-Check interessiert dagegen nur der Befund selbst; ihr
+Ausbleiben ist der Normalfall und braucht keinen Beleg.
+
+**Praktisch:** Der `postfach_post`-Aufruf gehört ausschließlich in den Befund-Zweig
+(`if [ Befund vorhanden ]`), nicht in einen `else`-Zweig für den Normalfall. Der
+Discord-Weg bleibt davon unberührt — er darf weiterhin jeden Lauf melden, dort ist der
+Throttle/Fingerprint-Mechanismus bereits eingespielt.
+
 ## Dauerhaft Discord-only (Erreichbarkeit / DB-Speicher-Alarm / Selbstüberwachung)
 
 | Watchdog | Warum Discord-only |
@@ -49,7 +80,7 @@ externen Discord-Webhook, nicht Teil dieser Umstellung.
 
 | Watchdog | Kategorie/Befund | Warum unbedenklich |
 |---|---|---|
-| `doku-drift-watchdog` | Doku vs. Realität (Port-Map, MEMORY.md-Länge) | **Pilot, bereits umgesetzt** (dieser PR). Rein redaktionell — ZERODOX lief nachweislich, als der Wächter den Vergleich zog. |
+| `doku-drift-watchdog` | Doku vs. Realität (Port-Map, MEMORY.md-Länge) | **Pilot, bereits umgesetzt** (dieser PR). Rein redaktionell — ZERODOX lief nachweislich, als der Wächter den Vergleich zog. Meldet **nur bei Befund** (siehe Abschnitt oben) — ein Lauf ohne Drift erzeugt keinen Postfach-Eintrag. |
 | `ki-cost-watchdog` | Token-/Kosten-Rollup Claude+Codex, Anomalie-Alarm | Reine Kostenbeobachtung, keine Verfügbarkeitsaussage. |
 | `security-freshness-watchdog` | Alter des letzten `sec_jobs`-Laufs in der security_analyst-DB | Eine **stehende** DB-Zeile fehlt/ist alt — das ist ein fachlicher Rückstand, kein Ausfall von ZERODOX selbst (ZERODOX-Web und die security_analyst-DB sind getrennte Komponenten). |
 | `seo-audit-freshness-watchdog`, `seo-deep-audit-freshness-watchdog`, `seo-output-freshness-watchdog` | Alter des letzten SEO-Audits/-Outputs in der seo_agent-DB | Dieselbe Begründung wie oben: Frische-Prüfung gegen eine Fach-DB, keine Erreichbarkeitsaussage über ZERODOX selbst. |

--- a/deploy/POSTFACH_ROUTING.md
+++ b/deploy/POSTFACH_ROUTING.md
@@ -86,19 +86,38 @@ externen Discord-Webhook, nicht Teil dieser Umstellung.
 | `seo-audit-freshness-watchdog`, `seo-deep-audit-freshness-watchdog`, `seo-output-freshness-watchdog` | Alter des letzten SEO-Audits/-Outputs in der seo_agent-DB | Dieselbe Begründung wie oben: Frische-Prüfung gegen eine Fach-DB, keine Erreichbarkeitsaussage über ZERODOX selbst. |
 | `mayday-sim-build-drift-watchdog` | Build-ID auf maydaysim.de vs. `origin/main` HEAD | Redaktioneller Drift (Deploy hinkt Git hinterher), keine Ausfallmeldung — maydaysim.de antwortet ja, nur mit altem Stand. |
 
-## Noch nicht entschieden — braucht Owner-/Lead-Entscheidung vor Umstellung
+## Postfach-fähig, aber erst nach dem Soak des Piloten (Fremdprojekt-Wächter)
 
-Diese Watchdogs prüfen **andere** Projekte oder Komponenten als ZERODOX selbst. Die
-Prüffrage von oben lässt sich für sie beantworten, aber #1983 hat dafür keinen
-Auftrag — sie werden hier nur benannt, damit niemand sie in einer künftigen Welle
-stillschweigend falsch einsortiert:
+Diese Watchdogs prüfen **andere** Projekte oder Komponenten als ZERODOX selbst. Bis zum
+Abschluss der Pilot-Review stand hier "noch nicht entschieden" — die Frage ist jetzt geklärt
+(Team-Lead-Entscheidung nach Review des Piloten, #1983):
 
-| Watchdog | Vorläufige Einschätzung nach der Prüffrage | Offene Frage |
+> **Fremdprojekt-Wächter (GuildScout, MayDay, cmdshadow-design, AI-Agent-Framework, Akquise-AI):**
+> postfach-fähig, aber **erst nach dem Soak des Piloten**. Das Selbstüberwachungs-Paradox greift bei
+> ihnen nicht — sie überwachen andere Systeme, ihre Zustellung hängt nicht am überwachten Objekt.
+> Umstellung als eigener, kleiner Schritt pro Projekt, nicht als Sammelaktion.
+
+**Begründung:** Ein Wächter, der meldet "GuildScout antwortet nicht", ist nicht von ZERODOX'
+Verfügbarkeit betroffen — ZERODOX läuft, das Postfach ist erreichbar, die Meldung kommt an.
+Die Prüffrage von oben beantwortet sich für diese ganze Klasse mit "Nein" (kein
+Discord-only-Zwang). Dazu kommt die ausdrückliche Owner-Vorgabe: ZERODOX soll die zentrale
+Sammelstelle für die Infrastruktur werden, weil dort Oberfläche, Nutzer und Push-System liegen
+— Fremdprojekt-Wächter gehören also grundsätzlich dazu.
+
+**Warum trotzdem nicht in dieser Welle:** #1983 hat bewusst nur den Piloten umgestellt. Erst
+muss sich im Betrieb zeigen, dass die Entdopplung greift und das Postfach nicht flutet — sieben
+weitere Wächter gleichzeitig scharf zu schalten wäre genau die Sammelauslieferung, die dieses
+Konzept vermeiden will. Jede Umstellung erfolgt danach als eigener, kleiner Schritt pro Projekt.
+
+Die Tabelle bleibt als Ausgangspunkt für die jeweilige Einzel-Umstellung erhalten — sie war
+zuvor als offene Erlaubnis-Frage formuliert, ist jetzt als Vorbereitungsnotiz zu lesen:
+
+| Watchdog | Warum postfach-fähig (Prüffrage) | Vorbereitung vor der Einzel-Umstellung |
 |---|---|---|
-| `zerodox-akquise-ai-watchdog` | Prüft `172.19.0.1:9300/health` — die Akquise-AI-Bridge, eine ZERODOX-Nachbarkomponente im selben Docker-Netz. Nach Wortlaut von Abschnitt 3 ("Ausfall von ZERODOX selbst") knapp außerhalb, da eine eigene Komponente — aber dieselbe VPS/Netz-Korrelation wie bei `zerodox-watchdog` ist plausibel. | Zählt eine Nachbarkomponente im selben Docker-Netz als "ZERODOX selbst"? |
-| `guildscout-watchdog`, `mayday-sim-watchdog`, `mayday-ci-runner-watchdog`, `mayday-scheduler-watchdog` | Reine Erreichbarkeits-Wächter — aber für **andere** Projekte (GuildScout, mayday-sim), nicht ZERODOX. Nach Wortlaut greift die Einschränkung nicht (das ZERODOX-Postfach bliebe ja erreichbar, wenn nur GuildScout/mayday-sim ausfällt). | Gehören Ausfall-Meldungen fremder Projekte überhaupt ins ZERODOX-Postfach, oder ist das Postfach bewusst ZERODOX-Scope? Reine Scope-Frage, keine Erreichbarkeits-Frage. |
-| `ai-agent-framework-watchdog` | Prozess-State von `zerodox-support-agent`/`seo-agent` (ZERODOX-Agents) **und** `guildscout-feedback-agent` (fremdes Projekt) in einem Wächter gemischt. | Müsste ggf. aufgeteilt werden, bevor der ZERODOX-Anteil postfach-fähig würde. |
-| `cmdshadow-design-watchdog` | Prüft `cmdshadow-design-healthcheck.service` — ein eigenständiges Tool-Projekt, keine ZERODOX-Komponente. | Reine Scope-Frage wie bei GuildScout/mayday-sim oben. |
+| `zerodox-akquise-ai-watchdog` | Prüft `172.19.0.1:9300/health` — die Akquise-AI-Bridge, eine ZERODOX-Nachbarkomponente im selben Docker-Netz. Fällt sie aus, bleiben ZERODOX-Web, -DB und Postfach trotzdem erreichbar — die Prüffrage greift nicht. | Keine besondere — folgt demselben Muster wie der Pilot. |
+| `guildscout-watchdog`, `mayday-sim-watchdog`, `mayday-ci-runner-watchdog`, `mayday-scheduler-watchdog` | Reine Erreichbarkeits-Wächter für **andere** Projekte (GuildScout, mayday-sim) — das ZERODOX-Postfach bliebe erreichbar, wenn nur GuildScout/mayday-sim ausfällt. | Keine besondere — folgt demselben Muster wie der Pilot. |
+| `ai-agent-framework-watchdog` | Meldet Prozess-State, keine ZERODOX-Verfügbarkeitsaussage. | Prüft **gemischt** `zerodox-support-agent`/`seo-agent` (ZERODOX) **und** `guildscout-feedback-agent` (fremd) — vor der Umstellung klären, ob eine Aufteilung sinnvoll ist, damit ZERODOX- und Fremdprojekt-Anteil getrennt zuordenbar bleiben. |
+| `cmdshadow-design-watchdog` | Prüft `cmdshadow-design-healthcheck.service` — ein eigenständiges Tool-Projekt, keine ZERODOX-Verfügbarkeitsaussage. | Keine besondere — folgt demselben Muster wie der Pilot. |
 
 ## Referenz
 

--- a/scripts/doku-drift-watchdog.sh
+++ b/scripts/doku-drift-watchdog.sh
@@ -37,6 +37,12 @@ if ! declare -f discord_post >/dev/null 2>&1; then
     -H 'Content-Type: application/json' --data "$2" --max-time 10 "$1" 2>/dev/null || echo 000; }
 fi
 
+# Zusätzlich additiv ans ZERODOX-Team-Postfach (#1983) — rein additiv, Discord
+# oben bleibt unverändert der Hauptkanal. Fehlt der Schlüssel oder die Lib,
+# bleibt postfach_post schlicht ungenutzt (kein Fallback nötig, kein Fehler).
+# shellcheck source=lib/postfach-send.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/postfach-send.sh" 2>/dev/null || true
+
 drift_lines=()
 
 # (a) Container-Host-Ports, die in keiner Port-Map-Datei stehen.
@@ -96,6 +102,23 @@ if [ "${#drift_lines[@]}" -gt 0 ]; then
   echo "[doku-drift] ${#drift_lines[@]} Drift(s) erkannt"
 else
   echo "[doku-drift] OK — keine Abweichung"
+fi
+
+# Postfach-Eintrag: ein Eintrag pro Tag (dedupKey rotiert täglich), unabhängig
+# vom Discord-Throttle oben — das Postfach führt den Tages-Status als Verlauf,
+# Discord alarmiert nur bei tatsächlichem (nicht bereits gemeldetem) Drift.
+if declare -f postfach_post >/dev/null 2>&1; then
+  postfach_dedup="shadowops:doku-drift-watchdog:$(date -u +%Y-%m-%d)"
+  if [ "${#drift_lines[@]}" -gt 0 ]; then
+    postfach_body="$(printf '• %s\n' "${drift_lines[@]}")"
+    postfach_post --category=system --type=watchdog.doku-drift.finding \
+      --severity=WARNING --kind=VORGANG --title="Doku-Drift erkannt" \
+      --body="$postfach_body" --dedup-key="$postfach_dedup" || true
+  else
+    postfach_post --category=system --type=watchdog.doku-drift.ok \
+      --severity=INFO --kind=KENNTNISNAHME --title="Doku-Drift-Check: keine Abweichung" \
+      --dedup-key="$postfach_dedup" || true
+  fi
 fi
 
 jq -nc --arg fp "$fp" --arg a "$new_alert_at" --arg c "$now_iso" --argjson n "${#drift_lines[@]}" \

--- a/scripts/doku-drift-watchdog.sh
+++ b/scripts/doku-drift-watchdog.sh
@@ -104,21 +104,18 @@ else
   echo "[doku-drift] OK — keine Abweichung"
 fi
 
-# Postfach-Eintrag: ein Eintrag pro Tag (dedupKey rotiert täglich), unabhängig
-# vom Discord-Throttle oben — das Postfach führt den Tages-Status als Verlauf,
-# Discord alarmiert nur bei tatsächlichem (nicht bereits gemeldetem) Drift.
-if declare -f postfach_post >/dev/null 2>&1; then
+# Postfach-Eintrag: NUR bei Befund (Team-Lead-Korrektur #1983). Ein Lauf ohne
+# Drift erzeugt KEINEN Eintrag — sonst würde die Postfach-Übersicht mit
+# "geprüft, alles ok"-Kenntnisnahmen volllaufen, die niemand abarbeiten muss.
+# Begründung + Ausnahme (Sicherungsläufe) siehe deploy/POSTFACH_ROUTING.md
+# Abschnitt "Nur bei Befund ins Postfach". Discord oben bleibt unverändert —
+# dort ist der Throttle bereits eingespielt und meldet weiterhin jeden Lauf.
+if declare -f postfach_post >/dev/null 2>&1 && [ "${#drift_lines[@]}" -gt 0 ]; then
   postfach_dedup="shadowops:doku-drift-watchdog:$(date -u +%Y-%m-%d)"
-  if [ "${#drift_lines[@]}" -gt 0 ]; then
-    postfach_body="$(printf '• %s\n' "${drift_lines[@]}")"
-    postfach_post --category=system --type=watchdog.doku-drift.finding \
-      --severity=WARNING --kind=VORGANG --title="Doku-Drift erkannt" \
-      --body="$postfach_body" --dedup-key="$postfach_dedup" || true
-  else
-    postfach_post --category=system --type=watchdog.doku-drift.ok \
-      --severity=INFO --kind=KENNTNISNAHME --title="Doku-Drift-Check: keine Abweichung" \
-      --dedup-key="$postfach_dedup" || true
-  fi
+  postfach_body="$(printf '• %s\n' "${drift_lines[@]}")"
+  postfach_post --category=system --type=watchdog.doku-drift.finding \
+    --severity=WARNING --kind=VORGANG --title="Doku-Drift erkannt" \
+    --body="$postfach_body" --dedup-key="$postfach_dedup" || true
 fi
 
 jq -nc --arg fp "$fp" --arg a "$new_alert_at" --arg c "$now_iso" --argjson n "${#drift_lines[@]}" \

--- a/scripts/lib/postfach-send.sh
+++ b/scripts/lib/postfach-send.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# postfach-send.sh — additiver Sender an das ZERODOX Team-Postfach (#1983).
+#
+# WARUM: Watchdogs alarmen bisher ausschließlich per Discord (discord-send.sh).
+# Das Team-Postfach (ZERODOX #1980–#1983) führt redaktionelle/fachliche Meldungen
+# zusätzlich als durchsuchbaren, als-erledigt-markierbaren Datensatz. Discord bleibt
+# für Erreichbarkeits-Wächter der unabhängige Zweitkanal (siehe
+# deploy/POSTFACH_ROUTING.md) — dieser Helfer ist rein ADDITIV und darf den
+# Discord-Pfad niemals ersetzen, verzögern oder zum Abbruch bringen.
+#
+# NUTZUNG (sourcebar):
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/postfach-send.sh"
+#   postfach_post --category=system --type=watchdog.doku-drift.finding \
+#     --severity=WARNING --kind=VORGANG --title="Doku-Drift erkannt" \
+#     --body="…" --dedup-key="shadowops:doku-drift-watchdog:$(date -u +%Y-%m-%d)"
+#   # Returncode: 0 bei Erfolg (HTTP 2xx), sonst 1 — NIE fatal für den Aufrufer.
+#   # Aufrufer mit `set -e` sichern den Call mit `|| true` ab, siehe
+#   # doku-drift-watchdog.sh.
+#
+# VERHALTEN:
+#   - Fehlt NOTIFY_INGEST_KEY (nicht konfiguriert): kein Request, stille Rückkehr
+#     (return 1). Das ist der Normalfall vor dem Operator-Setup, kein Fehler.
+#   - Netzwerkfehler / Nicht-2xx-Antwort: stille Rückkehr (return 1), NIE `exit`.
+#   - Diagnose geht ausschließlich nach stderr — stdout bleibt leer, damit
+#     Aufrufer, die eigene Ausgaben per Command-Substitution einsammeln,
+#     nicht versehentlich den HTTP-Code mit einfangen.
+#
+# Pflichtfelder: --category --type --severity --kind --title --dedup-key
+# Optional:      --body --link
+#
+# Vertrag (ZERODOX-Seite): web/src/app/api/internal/notifications/ingest/route.ts
+#   category: support|customer|billing|system|akquise|recht|sicherheit
+#   severity: INFO|WARNING|CRITICAL        kind: VORGANG|KENNTNISNAHME
+#   source wird hier fest auf SHADOWOPS gesetzt (Spec E4: shadowops-bot + Watchdogs).
+#
+# ENV-Overrides: POSTFACH_INGEST_URL, POSTFACH_SEND_TIMEOUT, NOTIFY_INGEST_KEY
+#   (kein Default für den Key — Operator-Setup in $WEBHOOK_CONFIG erforderlich,
+#   z.B. /home/cmdshadow/.config/shadowops-watchdog.env).
+#
+# Idempotent sourcebar (Guard) — keine Seiteneffekte beim Sourcen.
+
+[ -n "${_POSTFACH_SEND_SH_LOADED:-}" ] && return 0
+_POSTFACH_SEND_SH_LOADED=1
+
+POSTFACH_INGEST_URL="${POSTFACH_INGEST_URL:-https://zerodox.de/api/internal/notifications/ingest}"
+POSTFACH_SEND_TIMEOUT="${POSTFACH_SEND_TIMEOUT:-10}"
+
+# postfach_post --category=… --type=… --severity=… --kind=… --title=…
+#               --dedup-key=… [--body=…] [--link=…]
+# Gibt bei Erfolg (HTTP 2xx) 0 zurück, sonst 1. Schreibt höchstens eine
+# Diagnosezeile nach stderr — bricht NIE das Aufrufer-Skript ab.
+postfach_post() {
+    local category="" type="" severity="" kind="" title="" body="" link="" dedup_key=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --category=*) category="${1#*=}" ;;
+            --type=*) type="${1#*=}" ;;
+            --severity=*) severity="${1#*=}" ;;
+            --kind=*) kind="${1#*=}" ;;
+            --title=*) title="${1#*=}" ;;
+            --body=*) body="${1#*=}" ;;
+            --link=*) link="${1#*=}" ;;
+            --dedup-key=*) dedup_key="${1#*=}" ;;
+            *) echo "[postfach-send] unbekanntes Argument '$1' — ignoriert" >&2 ;;
+        esac
+        shift
+    done
+
+    if [ -z "$category" ] || [ -z "$type" ] || [ -z "$severity" ] || [ -z "$kind" ] \
+        || [ -z "$title" ] || [ -z "$dedup_key" ]; then
+        echo "[postfach-send] Pflichtfeld fehlt (category/type/severity/kind/title/dedup-key) — kein Versand" >&2
+        return 1
+    fi
+
+    local ingest_key="${NOTIFY_INGEST_KEY:-}"
+    if [ -z "$ingest_key" ]; then
+        # Bewusst kein Fehler-Log: additiver Kanal, Discord trägt unverändert weiter.
+        return 1
+    fi
+
+    local payload
+    payload=$(jq -nc \
+        --arg category "$category" --arg type "$type" --arg severity "$severity" \
+        --arg kind "$kind" --arg source "SHADOWOPS" --arg title "$title" \
+        --arg body "$body" --arg link "$link" --arg dedupKey "$dedup_key" \
+        '{category:$category, type:$type, severity:$severity, kind:$kind, source:$source,
+          title:$title, dedupKey:$dedupKey}
+         + (if $body == "" then {} else {body:$body} end)
+         + (if $link == "" then {} else {link:$link} end)' 2>/dev/null) || {
+        echo "[postfach-send] jq konnte Payload nicht bauen — kein Versand" >&2
+        return 1
+    }
+
+    local http
+    http=$(curl -sS -o /dev/null -w '%{http_code}' --max-time "$POSTFACH_SEND_TIMEOUT" \
+        -X POST -H "Content-Type: application/json" -H "X-Notify-Key: $ingest_key" \
+        --data "$payload" "$POSTFACH_INGEST_URL" 2>/dev/null) || http="000"
+
+    case "$http" in
+        2??) return 0 ;;
+        *)
+            echo "[postfach-send] Ingest-Route antwortete mit HTTP '${http}' — Discord-Weg trägt weiter" >&2
+            return 1
+            ;;
+    esac
+}


### PR DESCRIPTION
Zweite Hälfte von ZERODOX #1983. Die ZERODOX-Seite (Eingangsschnittstelle `/api/internal/notifications/ingest`) ist seit heute live und **verifiziert** — ein Aufruf über `notify_admin` landet nachweislich als Zeile in `AdminNotification`.

## Inhalt

| Datei | Zweck |
|---|---|
| `scripts/lib/postfach-send.sh` | Sende-Bibliothek: `postfach_post --category=… --type=… --title=… --dedup-key=…`. Idempotent sourcebar, `source` fest auf `SHADOWOPS` |
| `scripts/doku-drift-watchdog.sh` | Pilot-Anbindung (+20 Zeilen) |
| `deploy/POSTFACH_ROUTING.md` | Klassifikation: welcher Wächter darf ins Postfach, welcher bleibt in Discord |

## Drei bewusste Entscheidungen

**Additiv, kein Ersatz.** Discord bleibt unverändert der Hauptkanal. In dieser Änderung wird **kein** bestehender Meldeweg abgeschaltet.

**Nur bei Befund.** Ein Lauf ohne Drift erzeugt *keinen* Postfach-Eintrag. Sonst liefe die Übersicht mit „geprüft, alles ok"-Kenntnisnahmen voll, die niemand abarbeiten muss — das Postfach ist ein Arbeitsvorrat, kein Protokoll. Discord meldet weiterhin jeden Lauf.

**Fail-safe beim Sourcen.** `source … || true` plus `declare -f postfach_post`-Prüfung vor jedem Aufruf. Fehlt die Bibliothek oder der Schlüssel, läuft der Wächter unverändert weiter — er darf nicht abstürzen, weil ein optionales Ziel unkonfiguriert ist.

## Betreiber-Voraussetzung — bereits erledigt

`NOTIFY_INGEST_KEY` in `~/.config/shadowops-watchdog.env` gesetzt, byteweise identisch zu `ZERODOX/.env`.

⚠️ Das war eine Lücke, die leicht übersehen wird: `postfach-send.sh` kehrt ohne Schlüssel **still** zurück — kein Request, kein Fehler, kein Logeintrag. Ohne diesen Eintrag hätte die Anbindung wie „funktioniert, es passiert nur nichts" ausgesehen.

## Prüfung

```
bash -n           beide Skripte sauber
shellcheck -S error   sauber
jq-Payload isoliert getestet → gültiges JSON
```

Der jq-Ausdruck nutzt `{…} + (if …)` auf **oberster Ebene** (Objekt-Konkatenation) — gültig. Nicht zu verwechseln mit dem Muster in einem Objekt-**Wert**, das heute in ZERODOX `scripts/lib/notify.sh` den Discord-Rückfall lahmgelegt hat (ZERODOX PR #2091). Gezielt gegengeprüft, hier nicht vorhanden.

Closes #1983

🤖 Generated with [Claude Code](https://claude.com/claude-code)