### PR TITLE
Watchdog: Inode-Erschöpfung und /tmp sichtbar machen

### DIFF
--- a/scripts/disk-hygiene-watchdog.sh
+++ b/scripts/disk-hygiene-watchdog.sh
@@ -19,6 +19,11 @@ set -euo pipefail
 WARN_PCT="${DISK_WARN_PCT:-85}"
 CRIT_PCT="${DISK_CRIT_PCT:-90}"
 MOUNT="${DISK_MOUNT:-/}"
+# Zusaetzlich beobachtete Einhaengepunkte, durch Leerzeichen getrennt.
+# /tmp ist eine tmpfs und liegt damit im RAM — volllaufen kostet hier zweierlei:
+# Platz UND Arbeitsspeicher. Fuer diese Punkte wird AUSSCHLIESSLICH gewarnt, nie
+# automatisch geloescht: Was dort liegt, gehoert fremden Prozessen.
+EXTRA_MOUNTS="${DISK_EXTRA_MOUNTS:-/tmp}"
 JOURNAL_CAP="${JOURNAL_CAP:-500M}"
 ALERT_THROTTLE_S="${ALERT_THROTTLE_S:-3600}"
 STATE_FILE="${STATE_FILE:-/home/cmdshadow/shadowops-bot/data/watchdog_state_disk-hygiene.json}"
@@ -42,7 +47,16 @@ fi
 
 now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 now_ts=$(date +%s)
-disk_pct() { df --output=pcent "$MOUNT" | tail -1 | tr -dc '0-9'; }
+disk_pct() { df --output=pcent "${1:-$MOUNT}" | tail -1 | tr -dc '0-9'; }
+
+# Inode-Erschoepfung ist an `df -h` NICHT zu erkennen. Am 08.08.2026 stand /tmp
+# bei 100 % Inodes (3.755 von 1.048.576 frei) und meldete gleichzeitig 6,8 GB
+# freien Platz. Jeder Vorgang, der viele kleine Dateien anlegt — ein git-Worktree,
+# ein npm-Install, ein Build — scheiterte mit „No space left on device", waehrend
+# dieser Watchdog „OK — Disk 42 %" meldete. Bytes und Inodes sind zwei getrennte
+# Vorraete: Wer nur einen misst, sieht die Haelfte und haelt sie fuer das Ganze.
+inode_pct() { df --output=ipcent "${1:-$MOUNT}" 2>/dev/null | tail -1 | tr -dc '0-9'; }
+
 pct_before=$(disk_pct)
 
 last_alert_at=""
@@ -91,9 +105,40 @@ else
   pct_after="$pct_before"
 fi
 
+# Zusatzbefunde: Inodes auf dem Hauptmount, Bytes UND Inodes auf den
+# Zusatz-Mounts. Bewusst NACH dem Auto-Prune — ein Docker-Prune gibt auch Inodes
+# frei, es waere unehrlich, den Zustand davor zu melden.
+#
+# Alle Vergleiche stehen in `if`-Bloecken statt als `[ … ] && …`: Unter
+# `set -e` ist eine falsche Testbedingung als letzter Befehl ein Skript-Abbruch —
+# der Watchdog wuerde stumm enden, statt zu alarmieren.
+extra_findings=""
+add_finding() {
+  if [ -n "$extra_findings" ]; then extra_findings="${extra_findings}"$'\n'"$1"; else extra_findings="$1"; fi
+}
+
+ipct_main=$(inode_pct "$MOUNT" || echo "")
+if [ -n "$ipct_main" ] && [ "$ipct_main" -ge "$CRIT_PCT" ]; then
+  add_finding "${MOUNT} — Inodes ${ipct_main}% (Schwelle ${CRIT_PCT}%)"
+fi
+
+ipct_tmp=""
+for m in $EXTRA_MOUNTS; do
+  if [ ! -d "$m" ]; then continue; fi
+  m_bytes=$(disk_pct "$m" || echo "")
+  m_inodes=$(inode_pct "$m" || echo "")
+  if [ "$m" = "/tmp" ]; then ipct_tmp="$m_inodes"; fi
+  if [ -n "$m_bytes" ] && [ "$m_bytes" -ge "$CRIT_PCT" ]; then
+    add_finding "${m} — belegt ${m_bytes}% (Schwelle ${CRIT_PCT}%)"
+  fi
+  if [ -n "$m_inodes" ] && [ "$m_inodes" -ge "$CRIT_PCT" ]; then
+    add_finding "${m} — Inodes ${m_inodes}% (Schwelle ${CRIT_PCT}%), Platz sagt ${m_bytes:-?}%"
+  fi
+done
+
 # Stufe 2: Alarm nur wenn nach Prune weiterhin kritisch (throttled)
 should_alert=0
-if [ "$pct_after" -ge "$CRIT_PCT" ]; then
+if [ "$pct_after" -ge "$CRIT_PCT" ] || [ -n "$extra_findings" ]; then
   if [ -n "$last_alert_at" ]; then
     elapsed=$(( now_ts - $(date -d "$last_alert_at" +%s 2>/dev/null || echo 0) ))
     [ "$elapsed" -ge "$ALERT_THROTTLE_S" ] && should_alert=1
@@ -106,14 +151,32 @@ new_alert_at="$last_alert_at"
 if [ "$should_alert" -eq 1 ]; then
   # || true: du liefert non-zero (Permission-Fehler + SIGPIPE durch head) — unter
   # set -e+pipefail würde das sonst das Script killen BEVOR der Alarm gesendet wird.
-  top=$(du -xh "$MOUNT" 2>/dev/null | sort -rh | head -6 | awk '{printf "%s  %s\n",$1,$2}' || true)
+  # Top-Verbraucher dort zeigen, wo es brennt: Bei einem reinen Zusatzbefund ist
+  # eine Liste der groessten Ordner unter / nutzlos — der Platz fehlt woanders.
+  top_mount="$MOUNT"
+  if [ "$pct_after" -lt "$CRIT_PCT" ] && [ -n "$extra_findings" ]; then
+    top_mount=$(printf '%s\n' "$extra_findings" | head -1 | awk '{print $1}')
+    if [ ! -d "$top_mount" ]; then top_mount="$MOUNT"; fi
+  fi
+  top=$(du -xh "$top_mount" 2>/dev/null | sort -rh | head -6 | awk '{printf "%s  %s\n",$1,$2}' || true)
+
+  if [ "$pct_after" -ge "$CRIT_PCT" ]; then
+    alert_title="🔴 Disk weiterhin kritisch nach Auto-Prune"
+    alert_desc="Manueller Eingriff noetig — Auto-Bereinigung hat nicht gereicht."
+  else
+    # Auto-Prune hilft hier nicht: Er raeumt Docker-Cache und journald, nicht /tmp.
+    alert_title="🔴 Speicher-Engpass ausserhalb des Auto-Prune"
+    alert_desc="Manueller Eingriff noetig. Der Auto-Prune raeumt nur Docker-Cache und journald — dieser Befund liegt ausserhalb seiner Reichweite."
+  fi
+
   fields=$(jq -nc --arg p "${pct_after}% (Schwelle ${CRIT_PCT}%)" --arg pr "$freed_note" \
-    --arg top "$top" \
+    --arg top "$top" --arg tm "$top_mount" \
+    --arg extra "${extra_findings:-—}" \
     '[{name:"Disk nach Auto-Prune",value:$p,inline:false},
       {name:"Auto-Aktion",value:$pr,inline:false},
-      {name:"Top-Verbraucher",value:("```\n"+$top+"```"),inline:false}]')
-  if send_alert 15158332 "🔴 Disk weiterhin kritisch nach Auto-Prune" \
-    "Manueller Eingriff noetig — Auto-Bereinigung hat nicht gereicht." "$fields"; then
+      {name:"Weitere Befunde",value:("```\n"+$extra+"```"),inline:false},
+      {name:("Top-Verbraucher in "+$tm),value:("```\n"+$top+"```"),inline:false}]')
+  if send_alert 15158332 "$alert_title" "$alert_desc" "$fields"; then
     new_alert_at="$now_iso"
   else
     echo "[disk-hygiene] ERROR: Webhook fehlgeschlagen" >&2
@@ -124,7 +187,14 @@ elif [ "$pct_before" -ge "$WARN_PCT" ] && [ "$pct_after" -lt "$CRIT_PCT" ]; then
 fi
 
 jq -nc --arg a "$new_alert_at" --arg c "$now_iso" --argjson pb "$pct_before" --argjson pa "$pct_after" \
-  '{last_alert_at:$a,last_checked_at:$c,pct_before:$pb,pct_after:$pa}' > "$STATE_FILE"
+  --argjson im "${ipct_main:-null}" --argjson it "${ipct_tmp:-null}" \
+  '{last_alert_at:$a,last_checked_at:$c,pct_before:$pb,pct_after:$pa,
+    inode_pct_main:$im,inode_pct_tmp:$it}' > "$STATE_FILE"
 
-[ "$pct_after" -lt "$WARN_PCT" ] && echo "[disk-hygiene] OK — Disk ${pct_after}%"
+# Die Zeile nennt Inodes ausdruecklich mit. „OK — Disk 42 %" allein hat am
+# 08.08.2026 einen Mount bei 100 % Inodes ueberdeckt: Sie war wahr und trotzdem
+# irrefuehrend, weil sie den zweiten Vorrat verschwieg.
+if [ "$pct_after" -lt "$WARN_PCT" ] && [ -z "$extra_findings" ]; then
+  echo "[disk-hygiene] OK — Disk ${pct_after}%, Inodes ${MOUNT} ${ipct_main:-?}%, /tmp ${ipct_tmp:-n/a}%"
+fi
 exit 0


### PR DESCRIPTION
## Was war

Am 08.08.2026 schlug ein `git worktree add` mit **„No space left on device"** fehl — bei 6,8 GB freiem Platz. Es fehlten keine Bytes, sondern **Inodes**: `/tmp` stand bei **100 %** (3.755 von 1.048.576 frei).

Der `disk-hygiene-watchdog` meldete zur selben Stunde:

```
Aug 08 12:51:37 disk-hygiene-watchdog[111215]: [disk-hygiene] OK — Disk 42%
```

Die Meldung war wahr und trotzdem irreführend.

## Zwei getrennte Lücken

1. **Bytes ≠ Inodes.** Das Skript prüfte nur `df --output=pcent`. Ein Dateisystem kann bei 31 % Belegung praktisch unbenutzbar sein, wenn die Inodes aufgebraucht sind — betroffen ist genau das, was hier ständig läuft: Worktrees, `npm install`, Builds.
2. **`MOUNT` war fest `/`.** `/tmp` ist eine eigene tmpfs und lief voll, ohne dass sich auf `/` etwas rührte. Weil tmpfs im RAM liegt, kostete das zusätzlich **15 GB Arbeitsspeicher** — der Swap stand bei 97 %. Der `memory-watchdog` hat das korrekt alarmiert (`last_state: "alarm"`, 10:18 UTC), konnte die Ursache aber nicht benennen.

## Was sich ändert

- `inode_pct()` neben `disk_pct()`; `disk_pct()` nimmt jetzt einen Mount als Argument (rückwärtskompatibel, Default bleibt `$MOUNT`).
- `DISK_EXTRA_MOUNTS` (Default `/tmp`) — Bytes **und** Inodes.
- Die OK-Zeile nennt beide Vorräte: `OK — Disk 42%, Inodes / 19%, /tmp 66%`.
- Der Alarmtext unterscheidet, ob der Auto-Prune überhaupt greifen kann. Bei einem `/tmp`-Befund ist „Auto-Bereinigung hat nicht gereicht" falsch — er räumt Docker-Cache und journald, an `/tmp` kommt er nie.
- Top-Verbraucher werden für den betroffenen Mount gezeigt, nicht stur für `/`.
- State-File führt `inode_pct_main` und `inode_pct_tmp` mit.

## Bewusst nicht

**Kein Auto-Löschen in `/tmp`.** Was dort liegt, gehört fremden Prozessen; das Skript hält seine Zusage, ausschließlich Docker-Cache und journald anzufassen. Zusatz-Mounts lösen nur einen Alarm aus.

## Geprüft

| Prüfung | Ergebnis |
|---|---|
| `bash -n` | ok |
| shellcheck -S warning | nur bestehendes SC1090 (Z. 32), keine neue Warnung |
| Normallauf, echte Schwellen | `OK — Disk 42%, Inodes / 19%, /tmp 66%`, exit 0 |
| **Gegenprobe** `DISK_CRIT_PCT=60` | Alarm-Pfad nachweislich betreten (kein OK-Text, Webhook-Versuch) |

Die Gegenprobe ist der Punkt: Ohne sie wäre nur belegt, dass das Skript weiterhin „OK" sagen kann — nicht, dass die neue Bedingung überhaupt auslösen *kann*.

Alle neuen Vergleiche stehen in `if`-Blöcken statt als `[ … ] && …`. Unter `set -euo pipefail` ist eine falsche Testbedingung als letzter Befehl ein Abbruch — der Watchdog würde stumm enden, statt zu alarmieren.

⚠️ **Die Datei ist bereits wirksam.** Der Timer führt sie direkt aus `~/shadowops-bot/scripts/` aus, also aus dem Arbeitsverzeichnis — die Änderung wirkt unabhängig von diesem Merge. Der PR versioniert sie, damit ein `git pull` sie nicht zurückdreht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)