### PR TITLE
Runner-VM-Disk überwachen — die Lücke, durch die die CI aller Projekte stillstand

### DIFF
--- a/deploy/runner-vm-disk-watchdog.service
+++ b/deploy/runner-vm-disk-watchdog.service
@@ -1,0 +1,43 @@
+[Unit]
+# Zweite Luecke aus ZERODOX #2148: Die Retention auf der Runner-VM laeuft
+# (Cron 04:37, /usr/local/bin/zerodox-build-cache-prune), aber ihre Fruehwarnung
+# schreibt nur in ein lokales Log auf der VM — dort liest sie niemand.
+#
+# Am 2026-08-05 lief / auf 10.8.0.10 auf 100 %. Alle 8 ZERODOX-Runner und die
+# mayday-sim-Runner fielen bei GitHub auf "offline", die CI aller Projekte stand
+# ueber eine Stunde. `systemctl` meldete die Dienste dabei als "active running" —
+# der Prozess-Status war also wertlos, die Disk war das Signal.
+#
+# Der disk-hygiene-watchdog auf dem Hauptserver deckt diese VM nicht ab; er misst
+# nur lokale Mountpoints. Dieser Watchdog schliesst genau diese Luecke ueber den
+# ohnehin vorhandenen Health-Endpunkt.
+Description=Runner-VM Disk Watchdog — Alarm bevor die CI stillsteht (ZERODOX #2148)
+Documentation=https://github.com/Commandershadow9/ZERODOX/issues/2148
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/home/cmdshadow/.config/shadowops-watchdog.env
+Environment=WATCHDOG_SERVICE_NAME=runner-vm-disk
+Environment=WATCHDOG_HEALTH_URL=http://10.8.0.10:9100/health
+Environment=WATCHDOG_MODE=http
+Environment=WATCHDOG_REQUIRE_BOT_READY=0
+# Schwelle 85 %: Die Retention haelt die VM normal bei 56-71 %. 85 % laesst
+# genug Vorlauf, um zu reagieren, bevor Runner ausfallen — und liegt weit genug
+# ueber dem Normalband, dass kein Rauschen entsteht.
+# Anfuehrungszeichen sind PFLICHT: systemd bricht `Environment=KEY=wert mit
+# leerzeichen` am Leerzeichen um. Ohne sie kam nur `.components.disk.used_percent`
+# an, jq lieferte die Zahl statt eines Wahrheitswerts, und der Watchdog wertete
+# das als ungueltigen Filter — ein Fehlalarm bei voellig gesunder VM (08.08.2026).
+Environment="WATCHDOG_HEALTH_JQ_FILTER=.components.disk.used_percent < 85"
+Environment=WATCHDOG_STATE_FILE=/home/cmdshadow/shadowops-bot/data/watchdog_state_runner-vm-disk.json
+ExecStart=/home/cmdshadow/shadowops-bot/scripts/service-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=runner-vm-disk-watchdog
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target

--- a/deploy/runner-vm-disk-watchdog.timer
+++ b/deploy/runner-vm-disk-watchdog.timer
@@ -1,0 +1,15 @@
+[Unit]
+# 30 Minuten statt 5: Eine Platte laeuft nicht in Minuten voll, und der Cache
+# waechst pro CI-Lauf. Haeufigeres Fragen brachte nur Last ohne frueheres Wissen.
+Description=Timer: Runner-VM Disk-Check alle 30 Min (ZERODOX #2148)
+
+[Timer]
+OnBootSec=9min
+OnUnitActiveSec=30min
+RandomizedDelaySec=90s
+AccuracySec=1min
+Persistent=false
+Unit=runner-vm-disk-watchdog.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Schließt Punkt 2 von [ZERODOX #2148](https://github.com/Commandershadow9/ZERODOX/issues/2148).

## Was fehlte

Die Retention auf der Runner-VM läuft seit dem Vorfall (Cron 04:37, Log belegt vier saubere Läufe — am 06.08. vier Verzeichnisse entfernt, am 08.08. zwei, Disk stabil 56–71 %). Ihre **Frühwarnung schreibt aber nur in ein lokales Log auf der VM**, das niemand liest. Der `disk-hygiene-watchdog` auf dem Hauptserver misst ausschließlich lokale Mountpoints.

Damit war der Zustand, der am 05.08. die CI aller Projekte über eine Stunde lahmlegte, weiterhin unbeobachtet.

## Lösung ohne neues Skript

`:9100/health` liefert die Disk bereits mit (`.components.disk.used_percent`), und `service-watchdog.sh` kann per `WATCHDOG_HEALTH_JQ_FILTER` einen jq-Ausdruck auswerten — dasselbe Verfahren wie beim `mayday-ci-runner-watchdog`. Es braucht also nur eine Unit.

Schwelle **85 %**, Intervall **30 min**. Begründung im Unit-Kommentar: Die Retention hält die VM bei 56–71 %, 85 % lässt Vorlauf und erzeugt kein Rauschen; eine Platte läuft nicht in Minuten voll.

## Die Falle, die beim Bauen zuschlug

`Environment=KEY=wert mit leerzeichen` bricht in systemd **ohne Anführungszeichen** am Leerzeichen um. Vom Filter kam nur `.components.disk.used_percent` an, jq lieferte `63.3` statt eines Wahrheitswerts, der Watchdog wertete das folgerichtig als ungültigen Filter — und alarmierte bei kerngesunder VM.

Mein Vortest lief über `env VAR='…'` in bash. Dort sind Leerzeichen unproblematisch: Ich hatte den **falschen Pfad** geprüft. Der Fehlalarm ist im Kanal richtiggestellt.

## Geprüft — beide Richtungen über den systemd-Pfad

| Prüfung | Ergebnis |
|---|---|
| Filter kommt vollständig an | `WATCHDOG_HEALTH_JQ_FILTER=.components.disk.used_percent < 85` ✅ |
| gesunde VM (63,3 %) | `OK — healthy`, State `up`, 0 Fehlschläge |
| **Gegenprobe** Schwelle 10 % via Drop-In | `down (jq_filter_false)` — die Bedingung löst nachweislich aus |
| Drop-In entfernt, Normalzustand | Filter wieder `< 85` |

Die Gegenprobe lief bewusst über ein systemd-Drop-In mit totem Webhook, nicht über bash — sonst hätte sie denselben blinden Fleck gehabt wie der ursprüngliche Vortest.

Die Units liegen in `deploy/` und werden über `sync-watchdog-units.sh` als Symlink gespiegelt (IaC nach #294), nicht als reguläre Datei im user-Verzeichnis — sonst wären sie Orphans außerhalb der Verwaltung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)