### PR TITLE
fix(deploy): reconcile successful ZERODOX main CI

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -374,6 +374,17 @@ projects:
     services:
       - "zerodox-web"
     critical: true
+    ci_workflows:
+      - "Web Quality"
+    deploy:
+      # ZERODOX#2267: Ein erfolgreicher push-CI-Lauf auf main gleicht nach
+      # 120 s den produktiven buildSha mit dem aktuellen Branch-HEAD ab und
+      # holt einen zuvor wegen roter/pending CI abgebrochenen Deploy nach.
+      reconcile_on_ci_success: true
+      ci_success_reconcile_delay_sec: 120
+      ci_success_reconcile_poll_sec: 30
+      ci_success_reconcile_timeout_sec: 1800
+      ci_success_reconcile_max_attempts: 2
     monitor:
       enabled: true
       checks:

--- a/src/integrations/github_integration/ci_mixin.py
+++ b/src/integrations/github_integration/ci_mixin.py
@@ -48,6 +48,196 @@ def _paths_are_docs_only(paths: list[str]) -> bool:
 
 class CIMixin:
 
+    def _schedule_ci_success_reconcile(
+        self,
+        repo_name: str,
+        branch: str,
+        successful_sha: str,
+        repo_full_name: str,
+        project_config: Dict,
+    ) -> bool:
+        """Startet genau einen Reconcile pro Repo/Branch/SHA im Hintergrund."""
+        if not successful_sha or not repo_full_name:
+            self.logger.warning(
+                "⚠️ CI-Reconcile uebersprungen: repo_full_name oder head_sha fehlt "
+                f"({repo_name}/{branch})."
+            )
+            return False
+
+        key = f"{self._normalize_repo_name(repo_name)}:{branch}:{successful_sha}"
+        existing = self._ci_reconcile_tasks.get(key)
+        if existing and not existing.done():
+            self.logger.info(
+                f"ℹ️ CI-Reconcile {repo_name}@{successful_sha[:7]} laeuft bereits."
+            )
+            return False
+
+        task = asyncio.create_task(
+            self._reconcile_ci_success_deployment(
+                repo_name=repo_name,
+                branch=branch,
+                successful_sha=successful_sha,
+                repo_full_name=repo_full_name,
+                project_config=project_config,
+            )
+        )
+        self._ci_reconcile_tasks[key] = task
+
+        def _cleanup(finished: asyncio.Task) -> None:
+            if self._ci_reconcile_tasks.get(key) is finished:
+                self._ci_reconcile_tasks.pop(key, None)
+
+        task.add_done_callback(_cleanup)
+        return True
+
+    async def _fetch_branch_head_sha(
+        self,
+        repo_full_name: str,
+        branch: str,
+    ) -> Optional[str]:
+        """Liest den aktuellen Branch-HEAD ueber GitHub, ohne den Deploy-Tree anzufassen."""
+        if not repo_full_name or not branch:
+            return None
+        headers = {"Accept": "application/vnd.github+json"}
+        token = self._get_github_token()
+        if token:
+            headers["Authorization"] = f"token {token}"
+        url = f"https://api.github.com/repos/{repo_full_name}/commits/{branch}"
+        try:
+            async with aiohttp.ClientSession(headers=headers) as session:
+                async with session.get(url, timeout=20) as resp:
+                    if resp.status != 200:
+                        self.logger.warning(
+                            f"⚠️ Branch-HEAD fuer {repo_full_name}/{branch} nicht lesbar "
+                            f"(HTTP {resp.status})."
+                        )
+                        return None
+                    payload = await resp.json()
+                    sha = str(payload.get('sha') or '')
+                    return sha or None
+        except Exception as e:
+            self.logger.warning(
+                f"⚠️ Branch-HEAD fuer {repo_full_name}/{branch} nicht lesbar: {e}"
+            )
+            return None
+
+    async def _fetch_live_build_sha(self, health_url: str) -> Optional[str]:
+        """Liest buildSha aus dem produktiven Health-Endpoint (fail-open)."""
+        if not health_url:
+            return None
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(health_url, timeout=15) as resp:
+                    if resp.status != 200:
+                        self.logger.warning(
+                            f"⚠️ CI-Reconcile: Health-Endpoint HTTP {resp.status}."
+                        )
+                        return None
+                    payload = await resp.json()
+                    sha = str(payload.get('buildSha') or '')
+                    if not sha or sha == 'unknown':
+                        return None
+                    return sha
+        except Exception as e:
+            self.logger.warning(f"⚠️ CI-Reconcile: buildSha nicht lesbar: {e}")
+            return None
+
+    def _deployment_is_active(self, repo_name: str) -> bool:
+        manager = self.deployment_manager
+        if not manager:
+            return False
+        active = getattr(manager, 'active_deployments', {}) or {}
+        normalized = repo_name.lower().replace('-', '_')
+        return any(
+            bool(value)
+            for key, value in active.items()
+            if key.lower() == repo_name.lower() or key.lower().replace('-', '_') == normalized
+        )
+
+    async def _reconcile_ci_success_deployment(
+        self,
+        repo_name: str,
+        branch: str,
+        successful_sha: str,
+        repo_full_name: str,
+        project_config: Dict,
+    ) -> None:
+        """Deployt einen gruenen main-HEAD nach, falls Produktion hinterherlaeuft.
+
+        Der Reconcile wartet zunaechst auf den normalen PR-/Push-Deploy. Bleibt
+        live danach hinter dem weiterhin aktuellen, gruenen Branch-HEAD, wird
+        maximal zweimal ueber die normale CI-/Deploy-Pipeline nachgezogen.
+        """
+        deploy_config = project_config.get('deploy') or {}
+        delay_sec = max(0, int(deploy_config.get('ci_success_reconcile_delay_sec', 120)))
+        poll_sec = max(1, int(deploy_config.get('ci_success_reconcile_poll_sec', 30)))
+        timeout_sec = max(poll_sec, int(deploy_config.get('ci_success_reconcile_timeout_sec', 1800)))
+        max_attempts = max(1, int(deploy_config.get('ci_success_reconcile_max_attempts', 2)))
+        health_url = (project_config.get('monitor') or {}).get('url') or ''
+        deadline = time.monotonic() + timeout_sec
+        attempts = 0
+
+        if delay_sec:
+            await asyncio.sleep(delay_sec)
+
+        while time.monotonic() < deadline:
+            branch_sha = await self._fetch_branch_head_sha(repo_full_name, branch)
+            if not branch_sha:
+                await asyncio.sleep(poll_sec)
+                continue
+            if branch_sha != successful_sha:
+                self.logger.info(
+                    f"ℹ️ CI-Reconcile {repo_name}@{successful_sha[:7]} veraltet: "
+                    f"{branch} steht bereits auf {branch_sha[:7]}. Der neuere CI-Lauf ist zustaendig."
+                )
+                return
+
+            live_sha = await self._fetch_live_build_sha(health_url)
+            if not live_sha:
+                await asyncio.sleep(poll_sec)
+                continue
+            if live_sha == branch_sha:
+                self.logger.info(
+                    f"✅ CI-Reconcile: {repo_name} live bereits aktuell ({live_sha[:7]})."
+                )
+                return
+
+            if self._deployment_is_active(repo_name):
+                await asyncio.sleep(poll_sec)
+                continue
+
+            if not self._reserve_deploy(repo_name, branch_sha):
+                # Der normale PR-/Push-Trigger wartet oder deployt noch. Sobald
+                # er scheitert, gibt _trigger_deployment die Reservierung frei.
+                await asyncio.sleep(poll_sec)
+                continue
+
+            attempts += 1
+            self.logger.warning(
+                f"🔁 CI-Reconcile: live {live_sha[:7]} != {branch} {branch_sha[:7]} "
+                f"nach gruener CI — Nachhol-Deploy {attempts}/{max_attempts}."
+            )
+            await self._trigger_deployment(
+                repo_name=repo_name,
+                branch=branch,
+                commit_sha=branch_sha[:7],
+                repo_full_name=repo_full_name,
+                full_sha=branch_sha,
+            )
+            # Der Reconcile selbst dedupliziert Tasks. Fuer einen zweiten,
+            # tatsaechlich noetigen Versuch muss die generische 1h-Reservierung
+            # nach Abschluss dieses Versuchs wieder frei sein; vor dem naechsten
+            # Deploy werden Branch-HEAD und live buildSha erneut geprueft.
+            self._release_deploy(repo_name, branch_sha)
+            if attempts >= max_attempts:
+                break
+            await asyncio.sleep(poll_sec)
+
+        self.logger.warning(
+            f"⚠️ CI-Reconcile fuer {repo_name}@{successful_sha[:7]} ohne Gleichstand beendet; "
+            "der buildSha-Drift-Waechter bleibt als Alarm-Backstop aktiv."
+        )
+
     async def _send_or_update_ci_message(
         self,
         channel: discord.abc.Messageable,
@@ -675,6 +865,7 @@ class CIMixin:
                         workflow_names=workflow_names,
                         max_wait_min=max_wait_min,
                     )
+                    self._release_deploy(repo_name, full_sha)
                     return
                 if outcome in {"timeout", "missing"}:
                     await self._send_ci_wait_alert(
@@ -686,6 +877,7 @@ class CIMixin:
                         workflow_names=workflow_names,
                         max_wait_min=max_wait_min,
                     )
+                    self._release_deploy(repo_name, full_sha)
                     return
                 # success/docs_only/no_workflows → weiter unten deployen. Bei docs_only
                 # beendet deploy.sh selbst ohne Runtime-Aenderung (identische Allowlist).
@@ -729,8 +921,10 @@ class CIMixin:
                     )
             else:
                 self.logger.warning(f"⚠️ Deployment fehlgeschlagen: {repo_name}")
+                self._release_deploy(repo_name, full_sha or '')
 
         except Exception as e:
+            self._release_deploy(repo_name, full_sha or '')
             self.logger.error(f"❌ Deployment Fehler: {e}", exc_info=True)
 
     async def _repoll_after_deploy(

--- a/src/integrations/github_integration/core.py
+++ b/src/integrations/github_integration/core.py
@@ -186,6 +186,10 @@ class GitHubIntegration(JulesWorkflowMixin,
         self.local_polling_task = None
         self._inflight_commits: Dict[str, float] = self._load_inflight_state()
         self._ci_polling_tasks: Dict[str, asyncio.Task] = {}
+        # ZERODOX#2267: Ein erfolgreicher main-CI-Lauf startet einen verzögerten
+        # Reconcile. Pro Repo/Branch/SHA darf nur einer gleichzeitig laufen,
+        # auch wenn GitHub denselben workflow_run per Webhook und Poll liefert.
+        self._ci_reconcile_tasks: Dict[str, asyncio.Task] = {}
         # #478: Hintergrund-Tasks fuer Auto-Deploy. Der Webhook-Handler darf nicht
         # synchron auf den (minutenlangen) Deploy warten — sonst 504 (GitHub-Timeout).
         self._deploy_tasks: set = set()

--- a/src/integrations/github_integration/event_handlers_mixin.py
+++ b/src/integrations/github_integration/event_handlers_mixin.py
@@ -325,6 +325,30 @@ class EventHandlersMixin:
                     )
                     return
 
+            # ZERODOX#2267: Der urspruengliche PR-/Push-Trigger kann bereits
+            # aufgegeben haben, wenn ein CI-Lauf cancelled/rot war und ein
+            # spaeterer Re-Run gruen wird. Das erfolgreiche main-workflow_run
+            # ist deshalb ein zweiter, zustandsloser Weg zum Deploy. Der
+            # eigentliche Reconcile laeuft im Hintergrund, verifiziert vorher
+            # Branch-HEAD und live buildSha und dedupliziert Doppel-Events.
+            if (
+                self.auto_deploy_enabled
+                and is_completed
+                and str(conclusion).lower() == 'success'
+                and branch in self.deploy_branches
+                and event_name == 'push'
+                and bool((project_config.get('deploy') or {}).get('reconcile_on_ci_success', False))
+            ):
+                full_sha = workflow.get('head_sha') or payload.get('sha') or ''
+                repo_full_name = repo.get('full_name') or ''
+                self._schedule_ci_success_reconcile(
+                    repo_name=repo_name,
+                    branch=branch,
+                    successful_sha=full_sha,
+                    repo_full_name=repo_full_name,
+                    project_config=project_config,
+                )
+
             allow_jobs_fetch = jobs_url and (is_completed or status in ('in_progress', 'queued'))
             if allow_jobs_fetch:
                 jobs_response = await self._fetch_workflow_jobs(jobs_url)

--- a/src/integrations/github_integration/state_mixin.py
+++ b/src/integrations/github_integration/state_mixin.py
@@ -151,3 +151,16 @@ class StateMixin:
             return False
         self._reserved_deploy_shas[key] = now
         return True
+
+    def _release_deploy(self, repo_name: str, full_sha: str) -> None:
+        """Gibt eine fehlgeschlagene Deploy-Reservierung fuer einen Retry frei.
+
+        Erfolgreiche Deploys behalten ihre TTL-Reservierung als Schutz gegen
+        doppelte GitHub-Events. Nur Fehler-/Abbruchpfade rufen diese Methode auf,
+        damit ein spaeter gruen werdender workflow_run denselben SHA erneut
+        anstossen kann (ZERODOX#2267).
+        """
+        if not full_sha or not hasattr(self, '_reserved_deploy_shas'):
+            return
+        key = (self._normalize_repo_name(repo_name), full_sha)
+        self._reserved_deploy_shas.pop(key, None)

--- a/tests/unit/test_github_integration.py
+++ b/tests/unit/test_github_integration.py
@@ -1120,6 +1120,175 @@ class TestReleaseHandling:
         integration._send_release_notification.assert_called_once()
 
 
+class TestCiSuccessDeployReconcile:
+    """ZERODOX#2267: Gruene main-CI holt einen ausgefallenen Deploy nach."""
+
+    @staticmethod
+    def _project_config():
+        return {
+            'ci_workflows': ['Web Quality'],
+            'deploy': {
+                'reconcile_on_ci_success': True,
+                'ci_success_reconcile_delay_sec': 0,
+                'ci_success_reconcile_poll_sec': 1,
+                'ci_success_reconcile_timeout_sec': 10,
+                'ci_success_reconcile_max_attempts': 1,
+            },
+            'monitor': {'url': 'https://zerodox.de/api/health'},
+        }
+
+    @pytest.mark.asyncio
+    async def test_successful_main_workflow_schedules_reconcile(
+        self, mock_bot, enabled_config,
+    ):
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration.config.projects = {'zerodox': self._project_config()}
+        integration._schedule_ci_success_reconcile = Mock(return_value=True)
+        mock_bot.get_channel.return_value = None
+
+        await integration.handle_workflow_run_event({
+            'action': 'completed',
+            'repository': {
+                'name': 'ZERODOX',
+                'full_name': 'Commandershadow9/ZERODOX',
+                'html_url': 'https://github.com/Commandershadow9/ZERODOX',
+            },
+            'workflow_run': {
+                'id': 123,
+                'name': 'Web Quality',
+                'path': '.github/workflows/web-quality.yml',
+                'status': 'completed',
+                'conclusion': 'success',
+                'head_branch': 'main',
+                'head_sha': 'a' * 40,
+                'event': 'push',
+            },
+        })
+
+        integration._schedule_ci_success_reconcile.assert_called_once_with(
+            repo_name='ZERODOX',
+            branch='main',
+            successful_sha='a' * 40,
+            repo_full_name='Commandershadow9/ZERODOX',
+            project_config=integration.config.projects['zerodox'],
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('branch', 'conclusion', 'event_name'),
+        [
+            ('feature/test', 'success', 'push'),
+            ('main', 'failure', 'push'),
+            ('main', 'success', 'pull_request'),
+        ],
+    )
+    async def test_non_green_main_push_does_not_schedule(
+        self, mock_bot, enabled_config, branch, conclusion, event_name,
+    ):
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration.config.projects = {'zerodox': self._project_config()}
+        integration._schedule_ci_success_reconcile = Mock(return_value=True)
+        mock_bot.get_channel.return_value = None
+
+        await integration.handle_workflow_run_event({
+            'action': 'completed',
+            'repository': {
+                'name': 'ZERODOX',
+                'full_name': 'Commandershadow9/ZERODOX',
+            },
+            'workflow_run': {
+                'id': 124,
+                'name': 'Web Quality',
+                'path': '.github/workflows/web-quality.yml',
+                'status': 'completed',
+                'conclusion': conclusion,
+                'head_branch': branch,
+                'head_sha': 'b' * 40,
+                'event': event_name,
+            },
+        })
+
+        integration._schedule_ci_success_reconcile.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reconcile_deploys_when_live_is_behind(
+        self, mock_bot, enabled_config,
+    ):
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        project_config = self._project_config()
+        integration.config.projects = {'zerodox': project_config}
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.active_deployments = {'zerodox': False}
+        integration._fetch_branch_head_sha = AsyncMock(return_value='c' * 40)
+        integration._fetch_live_build_sha = AsyncMock(return_value='d' * 40)
+        integration._trigger_deployment = AsyncMock()
+        integration._reserve_deploy = Mock(return_value=True)
+        integration._release_deploy = Mock()
+
+        await integration._reconcile_ci_success_deployment(
+            repo_name='ZERODOX',
+            branch='main',
+            successful_sha='c' * 40,
+            repo_full_name='Commandershadow9/ZERODOX',
+            project_config=project_config,
+        )
+
+        integration._trigger_deployment.assert_awaited_once_with(
+            repo_name='ZERODOX',
+            branch='main',
+            commit_sha='c' * 7,
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='c' * 40,
+        )
+        integration._release_deploy.assert_called_once_with('ZERODOX', 'c' * 40)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_ignores_obsolete_successful_sha(
+        self, mock_bot, enabled_config,
+    ):
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        project_config = self._project_config()
+        integration.config.projects = {'zerodox': project_config}
+        integration.deployment_manager = MagicMock()
+        integration._fetch_branch_head_sha = AsyncMock(return_value='e' * 40)
+        integration._fetch_live_build_sha = AsyncMock()
+        integration._trigger_deployment = AsyncMock()
+
+        await integration._reconcile_ci_success_deployment(
+            repo_name='ZERODOX',
+            branch='main',
+            successful_sha='f' * 40,
+            repo_full_name='Commandershadow9/ZERODOX',
+            project_config=project_config,
+        )
+
+        integration._fetch_live_build_sha.assert_not_awaited()
+        integration._trigger_deployment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_ci_releases_sha_for_later_success(
+        self, mock_bot, enabled_config,
+    ):
+        integration = GitHubIntegration(mock_bot, enabled_config)
+        integration.config.projects = {'zerodox': self._project_config()}
+        integration.deployment_manager = MagicMock()
+        integration.deployment_manager.deploy_project = AsyncMock()
+        integration._wait_for_ci_completion = AsyncMock(return_value='failure')
+        integration._send_ci_wait_alert = AsyncMock()
+        integration._release_deploy = Mock()
+
+        await integration._trigger_deployment(
+            repo_name='ZERODOX',
+            branch='main',
+            commit_sha='1' * 7,
+            repo_full_name='Commandershadow9/ZERODOX',
+            full_sha='1' * 40,
+        )
+
+        integration._release_deploy.assert_called_once_with('ZERODOX', '1' * 40)
+        integration.deployment_manager.deploy_project.assert_not_awaited()
+
+
 class TestNotificationsProjectLookup:
     """Regressionstests fuer dash/underscore-Projektnamen in Notifications."""
 


### PR DESCRIPTION
## Ergebnis

Ein erfolgreicher `Web Quality`-Lauf auf `main` gleicht nun verzögert den aktuellen Branch-HEAD mit dem produktiven `buildSha` ab. Bleibt Produktion nach roter/cancelled/pending CI zurück, wird der Deploy idempotent über dieselbe gehärtete CI-/Deploy-Pipeline nachgeholt.

- Opt-in pro Projekt via `deploy.reconcile_on_ci_success`
- nur `workflow_run: completed/success`, Event `push`, Deploy-Branch
- veraltete Workflow-SHAs werden ignoriert
- laufende Deploys und bestehende SHA-Reservierungen werden abgewartet
- Fehlerpfade geben die Reservierung für einen späteren grünen Lauf frei
- maximal zwei Nachholversuche; vorhandener buildSha-Drift-Wächter bleibt Backstop

## Verifikation

- `tests/unit/test_github_integration.py`: 56/56 grün
- gezielte Reconcile-/Failure-Tests: 10/10 grün
- `py_compile` grün
- `git diff --check` grün

Bezug: https://github.com/Commandershadow9/ZERODOX/issues/2267