### PR TITLE
docs(deploy): CI-Success-Reconciliation vollständig dokumentieren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Fixed — CI-Success Deployment-Reconciliation (2026-08-12, PR #410)
+
+- **Verspätet grüne Main-CI holt ausgebliebene Deployments nach:** Ein
+  erfolgreich abgeschlossenes, erlaubtes `workflow_run` kann jetzt einen
+  begrenzten Reconciliation-Task starten. Vorher blieb ein Commit dauerhaft
+  undeployed, wenn der initiale Push-Handler die CI noch als fehlend oder
+  unvollständig gesehen hatte.
+- **Head-/Live-Abgleich vor jedem Versuch:** Der Bot liest den aktuellen
+  Branch-HEAD über GitHub und `buildSha` aus dem produktiven Health-Endpoint.
+  Ein veraltetes CI-Ereignis wird ignoriert; ein bereits live befindlicher SHA
+  beendet den Task ohne Restart.
+- **Konkurrenz- und Retry-Grenzen:** Pro Repo/Branch/SHA läuft nur ein Task.
+  Aktive Deployments und Reservierungen werden abgewartet, fehlgeschlagene
+  Reservierungen werden freigegeben. Default: 120 s Startverzögerung, 30 s
+  Polling, 30 min Timeout, maximal zwei Nachholversuche.
+- **Fail-closed Workflow-Filter:** Nur `main`-Pushes mit `conclusion=success`
+  und Namen aus `projects.<name>.ci_workflows` dürfen reconciliert werden.
+  Notification-, Nightly-, PR-, Failure- und fremde Workflow-Events bleiben
+  ausgeschlossen.
+- **Produktionsbeleg:** Der ZERODOX-Rollout `f709a34e` wurde nach vollständiger
+  Main-CI automatisch gestartet und endete mit verifiziertem Live-SHA, Health,
+  sieben Functional-Smokes, fünf CSP-Smokes und SHIELD-Smoke erfolgreich.
+- **Tests:** Gezielte GitHub-Integration-Tests decken Scheduling, Stale-SHA,
+  bereits-live, Reservierungen, Retry-Grenzen und Eventfilter ab.
+
 ### Fixed — Operational Follow-ups (2026-06-25)
 
 - **Changelog-DB/API-Tests entblockt**: `ChangelogDB` nutzt wieder stdlib-`sqlite3` hinter async-kompatiblen Methoden. Damit entfaellt der Sandbox-Haenger durch `aiosqlite.connect()`. Die aiohttp-API-Tests laufen socketfrei direkt gegen Handler/Middleware statt ueber `TestServer`.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,16 @@ deployment:
 
 > **Welle 9.10 / ZERODOX #1985 — Wait-for-CI vor Auto-Deploy:** Sobald ein PR auf einen `deploy_branches`-Branch gemergt wird, wartet der Bot vor dem Trigger von `deploy.sh` auf den Abschluss der in `projects.<name>.ci_workflows` konfigurierten Workflows (z.B. `["Web Quality"]`). Bei `failure`/`timeout` wird `deploy.sh` NICHT aufgerufen — stattdessen erscheint ein Alert im projekt-`ci_channel_id` oder `deployment_log`. Taucht innerhalb der Grace-Period kein Workflow auf, darf nur ein über die GitHub-Commit-Dateiliste verifizierter Docs-only-Commit (Top-Level `*.md`, `docs/**`, `.claude/**`) weiterlaufen. Code- und nicht eindeutig klassifizierbare Commits warten das volle Zeitfenster ab und werden danach mit einem „CI fehlt“-Alert fail-closed blockiert. Hard-Timeout 30 min (überschreibbar via `projects.<name>.ci_wait_max_min`). Exponential backoff 60s → 120s → 240s → cap 300s.
 
+> **ZERODOX #2267 / ShadowOps PR #410 — Reconciliation nach grünem CI:**
+> Für Projekte mit `deploy.reconcile_on_ci_success: true` startet ein später
+> eintreffendes erfolgreiches `workflow_run` einen deduplizierten Nachholpfad.
+> Vor jedem Versuch müssen erfolgreicher SHA und aktueller Branch-HEAD exakt
+> übereinstimmen; der Health-Endpoint muss einen abweichenden `buildSha` melden,
+> und es darf kein Deployment aktiv oder reserviert sein. Stale Events und
+> bereits live befindliche SHAs enden ohne Aktion. Default: 120 s Delay, 30 s
+> Poll, 1800 s Timeout und höchstens zwei Versuche. Der Mechanismus wurde mit
+> dem produktiven ZERODOX-Deploy `f709a34e` Ende-zu-Ende belegt.
+
 **AI komplett deaktivieren (Monitoring + Patch Notes ohne KI):**
 - `ai.enabled: false`
 - `ai_learning.enabled: false`

--- a/docs/operations/github-push-notifications.md
+++ b/docs/operations/github-push-notifications.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub Push Notifications Setup Guide
 status: active
-last_reviewed: 2026-04-15
+last_reviewed: 2026-08-12
 owner: CommanderShadow9
 ---
 
@@ -265,9 +265,47 @@ Dann in GitHub: `https://webhook.yourdomain.com/webhook`
   - Beispiel: ZERODOX Patch Notes werden auf dem ZERODOX-Server in `📋patch-notes` (öffentlich) und `🔧dev-updates` (intern) gepostet
 
 ### Auto-Deploy (optional)
-- Setze `github.auto_deploy: false`
+- Setze `github.auto_deploy: true`
 - Pushs zu main/master Branch triggern automatisches Deployment
 - Erfordert `DeploymentManager` Konfiguration
+
+Für CI-gesteuerte Deployments muss das Projekt zusätzlich die erlaubten
+Workflow-Namen und den Reconciliation-Pfad deklarieren:
+
+```yaml
+projects:
+  zerodox:
+    ci_workflows:
+      - Web Quality
+    ci_wait_max_min: 30
+    monitor:
+      url: https://zerodox.de/api/health  # liefert buildSha
+    deploy:
+      reconcile_on_ci_success: true
+      ci_success_reconcile_delay_sec: 120
+      ci_success_reconcile_poll_sec: 30
+      ci_success_reconcile_timeout_sec: 1800
+      ci_success_reconcile_max_attempts: 2
+```
+
+#### Ablauf und Sicherheitsgrenzen
+
+1. Der normale Push-/Merge-Pfad reserviert den Commit und wartet auf alle
+   `ci_workflows`.
+2. Ein späteres erfolgreiches `workflow_run` auf `main` kann genau einen
+   Reconciliation-Task pro Repo/Branch/SHA planen.
+3. GitHub-Branch-HEAD, erfolgreicher Workflow-SHA und produktiver `buildSha`
+   werden vor jedem Versuch neu gelesen.
+4. Ist der SHA veraltet oder bereits live, endet der Task ohne Deploy.
+5. Aktive Deployments und Reservierungen werden abgewartet. Nach Failure oder
+   Exception wird die Reservierung freigegeben, damit ein echter Retry möglich
+   bleibt.
+6. Nach Timeout/Versuchslimit übernimmt der bestehende Build-SHA-Drift-Wächter
+   als Alarm-Backstop; es gibt keinen unbegrenzten Restart-Loop.
+
+Nur erlaubte erfolgreiche `push`-Workflows auf `main` lösen diesen Pfad aus.
+PR-, Nightly-, Notification-, Failure- und unbekannte Workflow-Events bleiben
+fail-closed ausgeschlossen.
 
 ## Nächste Schritte
 

--- a/docs/operations/setup.md
+++ b/docs/operations/setup.md
@@ -1,7 +1,7 @@
 ---
 title: 🚀 ShadowOps Setup Guide v3.1
 status: active
-last_reviewed: 2026-04-15
+last_reviewed: 2026-08-12
 owner: CommanderShadow9
 ---
 
@@ -409,11 +409,17 @@ github:
   enabled: true
   webhook_secret: "YOUR_GENERATED_SECRET_HERE"
   webhook_port: 8080
-  auto_deploy: false
+  auto_deploy: true
   deploy_branches:
     - main
     - master
 ```
+
+Für Projekte, deren CI nach dem Push asynchron fertig wird, konfiguriere
+zusätzlich `projects.<name>.ci_workflows`, einen Health-Endpoint mit `buildSha`
+und `projects.<name>.deploy.reconcile_on_ci_success: true`. Vollständiger
+Vertrag und Retry-Grenzen:
+[`github-push-notifications.md`](github-push-notifications.md#auto-deploy-optional).
 
 ### Step 3: Configure Firewall
 


### PR DESCRIPTION
## Ergebnis

Dokumentiert den mit PR #410 eingeführten Nachholpfad für verspätet grüne Main-CI.

### Enthalten

- Eventfilter und fail-closed Workflow-Allowlist
- Branch-HEAD-/Live-`buildSha`-Abgleich
- Reservierungen, Deduplizierung, Retry-/Timeout-Grenzen
- vollständiges Konfigurationsbeispiel
- produktiver Ende-zu-Ende-Nachweis mit ZERODOX `f709a34e`
- korrigiertes `auto_deploy: true` im Aktivierungsbeispiel

### Verifikation

- `git diff --check` grün
- Frontmatter der geänderten Operations-Dokumente geprüft
- Werte gegen Implementierung und `config.example.yaml` abgeglichen

Keine Runtime-Codeänderung.
