### PR TITLE
feat: Deploy aus eigenem Baum statt aus dem geteilten Arbeitsverzeichnis

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -370,6 +370,22 @@ projects:
     enabled: true
     tag: "[ZERODOX]"
     path: "/home/cmdshadow/ZERODOX"
+    # Optional: eigener Baum nur fuer den Deploy (ZERODOX #2344).
+    #
+    # Ohne diesen Schluessel deployt der Bot aus `path` — also aus demselben
+    # Verzeichnis, in dem Menschen und parallele Sessions arbeiten. Sein
+    # Git-Schritt scheitert dort an allem, was der Baum gerade ist:
+    # uncommittete Dateien ebenso wie ein nicht gepushter lokaler Commit
+    # ("Not possible to fast-forward"). Beides ist am 15.08.2026 passiert und
+    # hat sechs Merges stundenlang blockiert — ohne Selbstheilung, weil es
+    # nach einem fehlgeschlagenen Deploy keinen Retry gibt.
+    #
+    # `path` bleibt bewusst der Arbeitsbaum: Es steuert auch Backup-Monitoring,
+    # Disk-Schwellwerte, Kontext, Verifikation und GitHub-Polling.
+    #
+    # ⚠️ Der Deploy-Baum wird bei jedem Lauf per `reset --hard` auf den
+    # Remote-Stand gezwungen. Dort darf niemand arbeiten.
+    deploy_path: "/home/cmdshadow/ZERODOX-deploy"
     repo_url: "https://github.com/Commandershadow9/ZERODOX"
     services:
       - "zerodox-web"

--- a/src/integrations/deployment_manager.py
+++ b/src/integrations/deployment_manager.py
@@ -121,6 +121,13 @@ class DeploymentManager:
             projects[project_name] = {
                 'name': project_name,
                 'path': Path(project_config.get('path', '')),
+                # Optionaler eigener Baum fuer den Deploy (ZERODOX #2344).
+                # Ohne diesen Eintrag bleibt alles wie bisher — `_deploy_path`
+                # faellt dann auf 'path' zurueck. Bewusst getrennt gehalten:
+                # 'path' steuert ausserdem Backup-Monitoring, Disk-Checks,
+                # Kontext, Verifikation und Polling; es umzubiegen laegte fuenf
+                # Funktionen um, um eine zu reparieren.
+                'deploy_path': project_config.get('deploy_path'),
                 'branch': project_config.get('branch', 'main'),
                 'deploy_enabled': deploy_enabled,  # NEW: Track if deploy is enabled
                 'run_tests': deploy_config.get('run_tests', False),
@@ -464,45 +471,73 @@ class DeploymentManager:
             self.logger.info(f"🗑️ Removing old backup: {old_backup.name}")
             shutil.rmtree(old_backup)
 
-    async def _git_pull(self, project: Dict, branch: str):
+    def _deploy_path(self, project: Dict) -> Path:
         """
-        Pull latest code from git
+        Verzeichnis, aus dem deployt wird.
+
+        Bewusst getrennt von `project['path']`: Dieses Feld steuert ausserdem
+        Backup-Monitoring (`Path(path)/'backups'/'daily'`), Disk-Schwellwerte,
+        Kontext, Verifikation und GitHub-Polling — acht Dateien insgesamt. Wer
+        einfach `path` auf einen Deploy-Baum umbiegt, lenkt fuenf Funktionen um,
+        um eine zu reparieren, und macht dabei das Backup-Monitoring blind.
+
+        Ohne `deploy_path` bleibt alles wie bisher; die Umstellung ist damit
+        fuer jedes andere Projekt ein No-op.
 
         Args:
             project: Project configuration
-            branch: Branch to pull
+
+        Returns:
+            Pfad, in dem Git-Schritt, Tests und post-deploy laufen sollen
         """
-        # Fetch latest
-        fetch_cmd = ['git', 'fetch', 'origin', branch]
+        return Path(project.get('deploy_path') or project['path'])
+
+    async def _git_pull(self, project: Dict, branch: str):
+        """
+        Bringt den Deploy-Baum hart auf den Stand von origin/<branch>.
+
+        Frueher: fetch + checkout + `git pull`. Das hat Merge-Semantik und
+        scheitert deshalb an dem, was der Arbeitsbaum gerade ist — in der Nacht
+        zum 15.08.2026 zweimal (ZERODOX #2344):
+
+          "local changes ... would be overwritten by merge ... Aborting"
+          "Not possible to fast-forward, aborting"
+
+        Sechs Merges blieben dadurch stundenlang undeployt, ohne Selbstheilung:
+        Nach fehlgeschlagenem deploy.sh gibt es keinen Retry, und der Reconcile
+        scheitert an derselben Stelle.
+
+        `fetch --prune` + `reset --hard` ist idempotent und immun gegen dirty,
+        divergiert und abgebrochenen Rebase gleichermassen. Man kann nicht fuer
+        jeden Zustand einen eigenen Guard bauen — die Abhaengigkeit muss weg.
+
+        ⚠️ Verwirft lokale Aenderungen im Deploy-Baum. Genau deshalb gehoert
+        dorthin ein Verzeichnis, in dem kein Mensch arbeitet (`deploy_path`).
+
+        Args:
+            project: Project configuration
+            branch: Branch to deploy
+        """
+        cwd = str(self._deploy_path(project))
+
+        # Fetch latest (--prune raeumt entfernte Branches mit ab)
+        fetch_cmd = ['git', 'fetch', '--prune', 'origin', branch]
         process = await asyncio.create_subprocess_exec(
             *fetch_cmd,
-            cwd=str(project['path']),
+            cwd=cwd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
-        await process.communicate()
+        _, stderr = await process.communicate()
 
         if process.returncode != 0:
-            raise DeploymentError("Git fetch failed")
+            raise DeploymentError(f"Git fetch failed: {stderr.decode()}")
 
-        # Checkout branch
-        checkout_cmd = ['git', 'checkout', branch]
+        # Hart auf den Remote-Stand setzen — kein checkout, kein merge.
+        reset_cmd = ['git', 'reset', '--hard', f'origin/{branch}']
         process = await asyncio.create_subprocess_exec(
-            *checkout_cmd,
-            cwd=str(project['path']),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
-        )
-        await process.communicate()
-
-        if process.returncode != 0:
-            raise DeploymentError(f"Git checkout {branch} failed")
-
-        # Pull latest
-        pull_cmd = ['git', 'pull', 'origin', branch]
-        process = await asyncio.create_subprocess_exec(
-            *pull_cmd,
-            cwd=str(project['path']),
+            *reset_cmd,
+            cwd=cwd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
@@ -510,7 +545,7 @@ class DeploymentManager:
         stdout, stderr = await process.communicate()
 
         if process.returncode != 0:
-            raise DeploymentError(f"Git pull failed: {stderr.decode()}")
+            raise DeploymentError(f"Git reset --hard origin/{branch} failed: {stderr.decode()}")
 
     async def _run_tests(self, project: Dict) -> bool:
         """
@@ -526,7 +561,7 @@ class DeploymentManager:
 
         process = await asyncio.create_subprocess_exec(
             *test_cmd,
-            cwd=str(project['path']),
+            cwd=str(self._deploy_path(project)),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE
         )
@@ -558,7 +593,7 @@ class DeploymentManager:
                 'bash',
                 '-lc',
                 raw_cmd,
-                cwd=str(project['path']),
+                cwd=str(self._deploy_path(project)),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE
             )
@@ -566,7 +601,7 @@ class DeploymentManager:
             cmd = shlex.split(raw_cmd)
             process = await asyncio.create_subprocess_exec(
                 *cmd,
-                cwd=str(project['path']),
+                cwd=str(self._deploy_path(project)),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE
             )

--- a/tests/unit/test_deployment_deploy_path.py
+++ b/tests/unit/test_deployment_deploy_path.py
@@ -1,0 +1,193 @@
+"""
+Tests fuer den getrennten Deploy-Pfad und das harte Zuruecksetzen im Git-Schritt.
+
+Hintergrund (ZERODOX #2344, Vorfaelle in der Nacht zum 15.08.2026):
+
+Der Bot deployt aus demselben Verzeichnis, in dem Menschen und parallele
+Sessions arbeiten. Sein `git pull` scheitert dort an allem, was der Baum
+gerade ist:
+
+  1. ~03:00 — vier uncommittete Dateien:
+     "Your local changes to the following files would be overwritten by
+      merge ... Aborting"
+  2. ~03:40 — ein nicht gepushter lokaler Commit auf main:
+     "Not possible to fast-forward, aborting"
+
+Sechs Merges blieben dadurch ueber Stunden undeployt. Es heilt nicht von
+selbst: Nach fehlgeschlagenem deploy.sh gibt es keinen Retry, und der
+Reconcile-Versuch scheitert an derselben Stelle. In Discord erscheint dabei
+"Deployment fehlgeschlagen" — dieselbe Meldung wie bei rotem CI-Gate,
+weshalb man in der CI sucht und dort nichts findet.
+
+Zwei Konsequenzen, die diese Tests absichern:
+
+**deploy_path getrennt von path.** `project['path']` steuert nicht nur den
+Deploy, sondern auch Backup-Monitoring (`Path(path)/'backups'/'daily'`),
+Disk-Schwellwerte, Kontext, Verifikation und GitHub-Polling — acht Dateien
+insgesamt. Wer einfach `path` umbiegt, lenkt fuenf Funktionen um, um eine zu
+reparieren, und macht das Backup-Monitoring stillschweigend blind.
+
+**reset --hard statt pull.** Ein `pull` hat Merge-Semantik und kann deshalb
+scheitern. `fetch` + `reset --hard` ist idempotent und immun gegen dirty,
+divergiert und abgebrochenen Rebase gleichermassen. Fuer einen Baum, in dem
+niemand arbeitet, ist das genau richtig — man kann nicht fuer jeden Zustand
+einen eigenen Guard bauen, man muss die Abhaengigkeit aufloesen.
+"""
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.integrations.deployment_manager import DeploymentManager, DeploymentError
+
+
+class _MockProcess:
+    """Mock fuer asyncio.subprocess.Process."""
+
+    def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+@pytest.fixture
+def mgr():
+    """Stub-Instance ohne __init__ — die geprueften Methoden nutzen nur das
+    project-Argument, keinen Instanz-State."""
+    return DeploymentManager.__new__(DeploymentManager)
+
+
+def test_load_projects_reicht_deploy_path_durch():
+    """
+    `_load_projects` baut das project-Dict aus einer expliziten Feldliste.
+    Fehlt `deploy_path` dort, kommt der Config-Eintrag nie beim Leser an —
+    `_deploy_path` naehme still den Fallback und der Bot deployte weiterhin
+    aus dem Arbeitsbaum. Der Defekt waere unsichtbar: kein Fehler, keine
+    Warnung, nur die alte Blockade bleibt bestehen.
+    """
+    class _Config:
+        projects = {
+            'zerodox': {
+                'enabled': True,
+                'path': '/home/cmdshadow/ZERODOX',
+                'deploy_path': '/home/cmdshadow/ZERODOX-deploy',
+                'deploy': {'enabled': True},
+            }
+        }
+
+    mgr = DeploymentManager.__new__(DeploymentManager)
+    mgr.config = _Config()
+    mgr.logger = __import__('logging').getLogger('test')
+
+    geladen = mgr._load_projects()
+
+    assert 'deploy_path' in geladen['zerodox'], (
+        '_load_projects reicht deploy_path nicht durch — der Config-Eintrag '
+        'bleibt wirkungslos und der Bot deployt weiter aus dem Arbeitsbaum'
+    )
+    assert geladen['zerodox']['deploy_path'] == '/home/cmdshadow/ZERODOX-deploy'
+
+
+def test_load_projects_ohne_deploy_path_bleibt_unveraendert():
+    """Projekte ohne das Feld duerfen sich nicht anders verhalten als bisher."""
+    class _Config:
+        projects = {
+            'guildscout': {
+                'enabled': True,
+                'path': '/home/cmdshadow/GuildScout',
+                'deploy': {'enabled': True},
+            }
+        }
+
+    mgr = DeploymentManager.__new__(DeploymentManager)
+    mgr.config = _Config()
+    mgr.logger = __import__('logging').getLogger('test')
+
+    geladen = mgr._load_projects()
+    assert not geladen['guildscout'].get('deploy_path')
+    assert str(mgr._deploy_path(geladen['guildscout'])) == '/home/cmdshadow/GuildScout'
+
+
+def test_deploy_path_bevorzugt_eigenes_feld(mgr):
+    projekt = {
+        'path': Path('/home/cmdshadow/ZERODOX'),
+        'deploy_path': '/home/cmdshadow/ZERODOX-deploy',
+    }
+    assert str(mgr._deploy_path(projekt)) == '/home/cmdshadow/ZERODOX-deploy'
+
+
+def test_deploy_path_faellt_auf_path_zurueck(mgr):
+    """Ohne deploy_path bleibt alles wie bisher — die Umstellung ist damit
+    fuer jedes andere Projekt ein No-op."""
+    projekt = {'path': Path('/home/cmdshadow/GuildScout')}
+    assert str(mgr._deploy_path(projekt)) == '/home/cmdshadow/GuildScout'
+
+
+def test_deploy_path_ignoriert_leeren_wert(mgr):
+    """Ein leerer String in der Config darf nicht zu cwd='' fuehren."""
+    projekt = {'path': Path('/home/cmdshadow/ZERODOX'), 'deploy_path': ''}
+    assert str(mgr._deploy_path(projekt)) == '/home/cmdshadow/ZERODOX'
+
+
+def test_git_pull_arbeitet_im_deploy_pfad(mgr):
+    """Alle Git-Aufrufe muessen im Deploy-Baum laufen, nicht im Arbeitsbaum."""
+    projekt = {
+        'path': Path('/home/cmdshadow/ZERODOX'),
+        'deploy_path': '/home/cmdshadow/ZERODOX-deploy',
+    }
+    aufrufe = []
+
+    async def _fake_exec(*cmd, **kwargs):
+        aufrufe.append((cmd, kwargs.get('cwd')))
+        return _MockProcess(0)
+
+    with patch('asyncio.create_subprocess_exec', new=AsyncMock(side_effect=_fake_exec)):
+        asyncio.run(mgr._git_pull(projekt, 'main'))
+
+    assert aufrufe, 'es wurde gar kein Git-Kommando ausgefuehrt'
+    for cmd, cwd in aufrufe:
+        assert cwd == '/home/cmdshadow/ZERODOX-deploy', (
+            f'Git-Kommando {cmd[:3]} lief in {cwd} statt im Deploy-Baum'
+        )
+
+
+def test_git_pull_setzt_hart_zurueck_statt_zu_pullen(mgr):
+    """
+    `git pull` scheitert an dirty oder divergiert — genau die beiden Faelle,
+    die den Bot blockiert haben. `reset --hard origin/<branch>` kann das nicht.
+    """
+    projekt = {'path': Path('/x'), 'deploy_path': '/y'}
+    kommandos = []
+
+    async def _fake_exec(*cmd, **kwargs):
+        kommandos.append(list(cmd))
+        return _MockProcess(0)
+
+    with patch('asyncio.create_subprocess_exec', new=AsyncMock(side_effect=_fake_exec)):
+        asyncio.run(mgr._git_pull(projekt, 'main'))
+
+    flach = [' '.join(k) for k in kommandos]
+
+    assert any('reset --hard origin/main' in k for k in flach), (
+        f'kein hartes Zuruecksetzen gefunden: {flach}'
+    )
+    assert not any(k.startswith('git pull') for k in flach), (
+        f'`git pull` ist noch vorhanden und kann weiterhin an einem dirty oder '
+        f'divergierten Baum scheitern: {flach}'
+    )
+
+
+def test_git_pull_meldet_fehler_weiterhin(mgr):
+    """Die Fehlerbehandlung darf durch die Umstellung nicht verlorengehen."""
+    projekt = {'path': Path('/x'), 'deploy_path': '/y'}
+
+    async def _fake_exec(*cmd, **kwargs):
+        return _MockProcess(1, stderr=b'fatal: irgendwas')
+
+    with patch('asyncio.create_subprocess_exec', new=AsyncMock(side_effect=_fake_exec)):
+        with pytest.raises(DeploymentError):
+            asyncio.run(mgr._git_pull(projekt, 'main'))


### PR DESCRIPTION
Behebt [ZERODOX#2344](https://github.com/Commandershadow9/ZERODOX/issues/2344).

## Problem

Der Bot deployt ZERODOX aus `/home/cmdshadow/ZERODOX` — demselben Verzeichnis, in dem Menschen und parallele Sessions arbeiten. Sein `git pull` scheitert dort an allem, was der Baum gerade ist. In der Nacht zum 15.08.2026 **zweimal mit verschiedenen Ursachen**:

```
~03:00   error: Your local changes to the following files would be
         overwritten by merge ... Aborting          ← 4 uncommittete Dateien

~03:40   fatal: Not possible to fast-forward, aborting
                                                    ← nicht gepushter Commit
```

Sechs Merges blieben stundenlang undeployt. **Es heilt nicht von selbst:** Nach fehlgeschlagenem `deploy.sh` gibt es keinen Retry (`ci_mixin.py:922-924`), der CI-Success-Reconcile scheitert an derselben Stelle, und der Drift-Monitor ist `alert-only`.

Erschwerend: Discord meldet „Deployment fehlgeschlagen" — dieselbe Meldung wie bei rotem CI-Gate. Man sucht in der CI und findet dort nichts.

## Änderung 1 — `deploy_path` als eigenes Feld

```python
def _deploy_path(self, project: Dict) -> Path:
    return Path(project.get('deploy_path') or project['path'])
```

**Bewusst getrennt von `path`.** Dieses Feld steuert nicht nur den Deploy:

```
project_monitor.py:2048   backup_dir = Path(path) / 'backups' / 'daily'
project_monitor.py:1728   Disk-Schwellwert
context_manager.py:230    Kontext
verification.py:114       Verifikation
polling_mixin.py:59       GitHub-Polling
```

Wer einfach `path` umbiegt, lenkt **fünf Funktionen um, um eine zu reparieren** — und macht das Backup-Monitoring stillschweigend blind, weil es dann unter `ZERODOX-deploy/backups/daily` sucht, wo nichts liegt.

Projekte ohne das Feld verhalten sich unverändert (Fallback). Für GuildScout und mayday-sim ist das ein No-op.

## Änderung 2 — `reset --hard` statt `pull`

`fetch --prune` + `reset --hard origin/<branch>` statt `fetch` + `checkout` + `pull`. Idempotent und immun gegen dirty, divergiert und abgebrochenen Rebase **gleichermaßen**. Man kann nicht für jeden Zustand einen eigenen Guard bauen — die Abhängigkeit muss weg.

⚠️ Verwirft lokale Änderungen im Deploy-Baum. Genau deshalb gehört dorthin ein Verzeichnis, in dem niemand arbeitet.

## Der Fund, ohne den alles wirkungslos geblieben wäre

`_load_projects()` baut das project-Dict aus einer **expliziten Feldliste**. `deploy_path` stand dort nicht — der Config-Eintrag wäre nie beim Leser angekommen. Kein Fehler, keine Warnung: Der Bot hätte still weiter aus dem Arbeitsbaum deployt, und die Blockade wäre geblieben.

Die vorhandenen Tests fanden das nicht, weil sie das project-Dict direkt konstruieren und `_load_projects` überspringen. Deshalb ein eigener Test dafür — mit einem Gegentest, der belegt, dass Projekte **ohne** das Feld unverändert bleiben.

## Konfiguration

`config/config.yaml` ist gitignored. Produktiv gesetzt sind dort:

```yaml
deploy_path: /home/cmdshadow/ZERODOX-deploy
post_deploy_command: bash /home/cmdshadow/ZERODOX-deploy/scripts/deploy.sh --skip-e2e --remote-build --yes
```

Der zweite Pfad ist **nicht optional**: `deploy.sh` leitet sein `ROOT_DIR` aus `BASH_SOURCE` ab. Ein Aufruf des alten Pfads hätte weiterhin den Arbeitsbaum deployt — der Umbau wäre wirkungslos geblieben, ohne dass es auffällt.

Dokumentiert in `config.example.yaml`.

## Vorbereitung auf ZERODOX-Seite (bereits erledigt)

- `/home/cmdshadow/ZERODOX-deploy` existiert als Worktree des Haupt-Repos. Günstig: `--git-common-dir` löst `ENV_FILE` auf die kanonische `.env` auf, der in ZERODOX#2314 beschriebene Fallstrick entfällt.
- **Alle Host-Mounts in `docker-compose.yml` sind absolut** (ZERODOX#2349). Gegengeprüft aus dem Deploy-Baum heraus: `uploads`, `runtime/twitch-team` und `maintenance/*` zeigen weiterhin auf `/home/cmdshadow/ZERODOX/…`. Ein Deploy von dort kann Kundendaten und Twitch-Session also nicht verfehlen.

## Tests

```
8 neue Tests (test_deployment_deploy_path.py)
58 Deploy-Tests gesamt — keine Regression
```

Rot-Grün belegt: Vor der Implementierung 5 von 6 rot; der `_load_projects`-Test war einzeln rot, während sein Gegentest grün blieb.

## Nach dem Merge

Bot neu starten und den ersten Deploy verifizieren:

```bash
docker inspect zerodox-web --format '{{range .Mounts}}{{if eq .Type "bind"}}{{.Source}}{{"\n"}}{{end}}{{end}}'
# MUSS weiterhin /home/cmdshadow/ZERODOX/uploads enthalten
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)